### PR TITLE
Use ImageUrl from enrollments response for course image

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -27,6 +27,7 @@
 			background-position: center;
 			border-top-left-radius: 10px;
 			border-top-right-radius: 10px;
+			background: #B9C2D0;
 		}
 		.course-text {
 			width: 100%;

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -34,8 +34,6 @@
 				var courseImage = this.$$('.course-image');
 				if (newValue) {
 					Polymer.dom(courseImage).setAttribute('style', 'background-image: url(' + newValue + ');');
-				} else {
-					Polymer.dom(courseImage).setAttribute('style', 'background: #E57231');
 				}
 			}
 		});

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -26,28 +26,17 @@
 					type: String
 				},
 				imageSrc: {
-					type: String
-				},
-				imageCategories: {
-					type: Array,
-					readOnly: true,
-					value: function () {
-						return [
-							'abstract', 'animals', 'business', 'city', 'food', 'people', 'nature', 'sports', 'transport'
-						];
-					}
+					type: String,
+					observer: '_imageSrcChanged'
 				}
 			},
-			ready: function () {
-				var courseImage = this.$$('.course-image'),
-					courseImageSrc = this.imageSrc || this._getRandomImageUrl();
-
-				Polymer.dom(courseImage).setAttribute('style', 'background-image: url(' + courseImageSrc + ');');
-			},
-			_getRandomImageUrl: function () {
-				var index = Math.floor((Math.random() * 10) + 1); // 1 - 10 inclusive
-				var category = this.imageCategories[Math.floor((Math.random() * this.imageCategories.length))];
-				return 'http://lorempixel.com/640/480/' + category + '/' + index;
+			_imageSrcChanged: function (newValue) {
+				var courseImage = this.$$('.course-image');
+				if (newValue) {
+					Polymer.dom(courseImage).setAttribute('style', 'background-image: url(' + newValue + ');');
+				} else {
+					Polymer.dom(courseImage).setAttribute('style', 'background: #E57231');
+				}
 			}
 		});
 	</script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -16,10 +16,13 @@
 			last-response="{{enrollmentsResponse}}"></d2l-ajax>
 
 		<div class="my-courses-container">
-			<template is="dom-repeat" items="[[enrollmentsResponse.entities]]">
+			<template
+				is="dom-repeat"
+				items="[[enrollmentsResponse.entities]]">
 				<d2l-course-tile
 					target="/d2l/home/[[item.properties.id]]"
-					name="[[item.properties.name]]"></d2l-course-tile>
+					name="[[item.properties.name]]"
+					image-src="{{getCourseImageUrl(item.links)}}"></d2l-course-tile>
 			</template>
 		</div>
 
@@ -59,6 +62,18 @@
 			if (response.detail.status === 200) {
 				this._setupColumns(response.detail.xhr.response.entities.length);
 				this._setEnrollmentsResponse(response.detail.xhr.response);
+			}
+		},
+		getCourseImageUrl: function (links) {
+			var courseImageLink = links.find(function(item) {
+				return item.rel.indexOf('course-image') > -1;
+			});
+
+			if (courseImageLink) {
+				return courseImageLink.href;
+			} else {
+				// If no course image, let course-tile know (so it can use a placeholder)
+				return false
 			}
 		},
 		_getPinnedCoursesUrl: function (enrollmentsUrl) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -65,12 +65,10 @@
 			}
 		},
 		getCourseImageUrl: function (links) {
-			var courseImageLink = links.find(function(item) {
-				return item.rel.indexOf('course-image') > -1;
-			});
-
-			if (courseImageLink) {
-				return courseImageLink.href;
+			for (var i = 0; i < links.length; ++i) {
+				if (links[i].rel.indexOf('course-image') > -1) {
+					return links[i].href;
+				}
 			}
 		},
 		_getPinnedCoursesUrl: function (enrollmentsUrl) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -71,9 +71,6 @@
 
 			if (courseImageLink) {
 				return courseImageLink.href;
-			} else {
-				// If no course image, let course-tile know (so it can use a placeholder)
-				return false
 			}
 		},
 		_getPinnedCoursesUrl: function (enrollmentsUrl) {

--- a/demo/my-courses.json
+++ b/demo/my-courses.json
@@ -150,6 +150,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123059"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -225,6 +231,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123060"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -300,6 +312,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123061"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -375,6 +393,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123062"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -450,6 +474,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123063"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -525,6 +555,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123064"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -600,6 +636,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123065"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -675,6 +717,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123066"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [
@@ -750,6 +798,12 @@
             "self"
           ],
           "href": "http://localhost:3000/enrollments/123067"
+        },
+        {
+          "rel": [
+            "course-image"
+          ],
+          "href": "http://lorempixel.com/400/200/"
         }
       ],
       "actions": [

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -12,7 +12,11 @@ describe('smoke test', function() {
 					properties: {
 						name: 'Test Name',
 						id: 'TestName'
-					}
+					},
+					links: [{
+						rel: ['course-image'],
+						href: 'http://example.com'
+					}]
 				}]
 			}
 		};


### PR DESCRIPTION
~~This is fine for demo purposes, but we will have to address how we should behave if the desired image does not exist.~~ As per @thehappypixel's design, a course without an image will show a Pressicus grey background instead (for this thin slice, at least).

~~Since the `course-image` comes back as a Siren link, so I'm passing the whole `links` of the enrollment into the course tile... might be nice to just pass the `course-image`'s href?~~ Just the href is now being passed to the course tile.