### PR TITLE
Fix course image scaling

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -23,11 +23,11 @@
 			left: 0;
 			right: 0;
 			bottom: 0;
-			background-size: cover;
-			background-position: center;
 			border-top-left-radius: 10px;
 			border-top-right-radius: 10px;
 			background: #B9C2D0;
+			background-position: center;
+			background-size: cover;
 		}
 		.course-text {
 			width: 100%;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -67,7 +67,7 @@
 		getCourseImageUrl: function (links) {
 			for (var i = 0; i < links.length; ++i) {
 				if (links[i].rel.indexOf('course-image') > -1) {
-					return links[i].href;
+					return links[i].href + '?width=768&height=1';
 				}
 			}
 		},

--- a/demo/my-courses.json
+++ b/demo/my-courses.json
@@ -155,7 +155,7 @@
           "rel": [
             "course-image"
           ],
-          "href": "http://lorempixel.com/400/200/"
+          "href": "http://lorempixel.com/100/100/"
         }
       ],
       "actions": [


### PR DESCRIPTION
Two problems addressed here:

1. Due to the ordering of CSS, if a small image was uploaded to Nitro, the course tile image was not being stretched to fill the course tile
2. If a larger image is uploaded, Nitro was giving us back a smaller (640x480) image. Fix this by specifying that we want a 768px wide (our max course tile width) image, which we can then shrink as required.