### PR TITLE
Change animation for desktop overlay open/close

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.2.0",
-    "d2l-ajax": "Brightspace/d2l-ajax-ui#1.0.1",
+    "d2l-ajax": "Brightspace/d2l-ajax-ui#^1.0.1",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-icon": "PolymerElements/iron-icon#^1.0.8",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -88,13 +88,16 @@
 				if (response.detail.status === 200) {
 					this._setAllEnrollmentsEntities(response.detail.xhr.response.entities);
 					this._filterUnpinnedCourses(this.pinnedCoursesEntities, this.allEnrollmentsEntities);
-					this._rescaleCourseTileRegions();
+					this._rescaleCourseTileRegions(this._getMyWidth());
 				}
 			},
 			open: function() {
-					this._rescaleCourseTileRegions();
-					this.$.allEnrollmentsRequest.generateRequest();
-					this.$$('d2l-simple-overlay').open();
+				this._rescaleCourseTileRegions(this._getMyWidth());
+				this.$.allEnrollmentsRequest.generateRequest();
+				this.$$('d2l-simple-overlay').open();
+			},
+			_getMyWidth: function () {
+				return this._getAvailableWidth(this.root.host);
 			},
 			_filterUnpinnedCourses: function(pinnedCoursesEntities, allCoursesEntities) {
 				if(pinnedCoursesEntities && allCoursesEntities) {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -88,16 +88,16 @@
 				if (response.detail.status === 200) {
 					this._setAllEnrollmentsEntities(response.detail.xhr.response.entities);
 					this._filterUnpinnedCourses(this.pinnedCoursesEntities, this.allEnrollmentsEntities);
-					this._rescaleCourseTileRegions(this._getMyWidth());
+					this._rescaleCourseTileRegions(this._getOverlayWidth());
 				}
 			},
 			open: function() {
-				this._rescaleCourseTileRegions(this._getMyWidth());
 				this.$.allEnrollmentsRequest.generateRequest();
 				this.$$('d2l-simple-overlay').open();
+				this._rescaleCourseTileRegions(this._getOverlayWidth());
 			},
-			_getMyWidth: function () {
-				return this._getAvailableWidth(this.root.host);
+			_getOverlayWidth: function () {
+				return this._getAvailableWidth(this.$$('d2l-simple-overlay'));
 			},
 			_filterUnpinnedCourses: function(pinnedCoursesEntities, allCoursesEntities) {
 				if(pinnedCoursesEntities && allCoursesEntities) {

--- a/d2l-course-tile-region-behavior.html
+++ b/d2l-course-tile-region-behavior.html
@@ -25,10 +25,10 @@
 			get courseTileItemCount() {
 				throw "Must implement courseTileItemCount in behavior consumer";
 			},
-			_rescaleCourseTileRegions: function() {
+			_rescaleCourseTileRegions: function(forcedWidth) {
 				var itemCount = this.courseTileItemCount;
 
-				this._setupColumns(itemCount);
+				this._setupColumns(itemCount, forcedWidth);
 			},
 			_calcNumColumns: function (width, itemCount) {
 				var numCols = 1;
@@ -55,7 +55,7 @@
 
 				return numCols;
 			},
-			_setupColumns: function (itemCount) {
+			_setupColumns: function (itemCount, forcedWidth) {
 				var containers = Polymer.dom(this.root).querySelectorAll('.my-courses-container');
 				var colClasses = ['columns-2', 'columns-3', 'columns-4'];
 				var currentColClass = function (domNode) {
@@ -69,7 +69,7 @@
 					}
 
 				containers.forEach(function(container) {
-					var width = this._getAvailableWidth(container);
+					var width = forcedWidth || this._getAvailableWidth(container);
 					var numCols = this._calcNumColumns(width, itemCount);
 					var domNode = Polymer.dom(container);
 					var oldClassName = currentColClass(domNode);

--- a/d2l-course-tile-region-styles.html
+++ b/d2l-course-tile-region-styles.html
@@ -13,6 +13,7 @@
 		}
 
 		.my-courses-container {
+			width: 100%;
 			display: flex;
 			flex-wrap: wrap;
 			flex-direction: row;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -73,8 +73,8 @@
 			},
 			enrollmentsOnResponse: function (response) {
 				if (response.detail.status === 200) {
-					this._setupColumns(response.detail.xhr.response.entities.length);
 					this._setEnrollmentsResponse(response.detail.xhr.response);
+					this._rescaleCourseTileRegions();
 				}
 			},
 			openAllCoursesView: function () {

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -2,9 +2,10 @@
 <link rel="import" href="../iron-overlay-behavior/iron-overlay-behavior.html">
 <link rel="import" href="../neon-animation/neon-animation-runner-behavior.html">
 <link rel="import" href="../neon-animation/animations/slide-from-bottom-animation.html">
-<link rel="import" href="../neon-animation/animations/slide-from-top-animation.html">
 <link rel="import" href="../neon-animation/animations/slide-down-animation.html">
-<link rel="import" href="../neon-animation/animations/slide-up-animation.html">
+<link rel="import" href="../neon-animation/animations/transform-animation.html">
+<link rel="import" href="../neon-animation/animations/fade-in-animation.html">
+<link rel="import" href="../neon-animation/animations/fade-out-animation.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="d2l-simple-overlay-styles.html">
 <link rel="import" href="icons.html">
@@ -43,22 +44,32 @@
 			animationConfig: {
 				value: function() {
 					return {
-						'fromBottom': {
+						'mobileOpen': {
 							name: 'slide-from-bottom-animation',
 							node: this
 						},
-						'fromTop': {
-							name: 'slide-from-top-animation',
-							node: this
-						},
-						'down': {
+						'mobileClose': {
 							name: 'slide-down-animation',
 							node: this
 						},
-						'up': {
-							name: 'slide-up-animation',
+						'desktopOpen': [{
+							name: 'transform-animation',
+							transformFrom: 'scale(.95) translateY(-100px)',
+							transformTo: 'scale(1) translateY(0)',
 							node: this
-						}
+						}, {
+							name: 'fade-in-animation',
+							node: this
+						}],
+						'desktopClose': [{
+							name: 'transform-animation',
+							transformFrom: 'scale(1) translateY(0)',
+							transformTo: 'scale(.95) translateY(-100px)',
+							node: this
+						}, {
+							name: 'fade-out-animation',
+							node: this
+						}]
 					};
 				}
 			},
@@ -95,18 +106,18 @@
 			Polymer.dom(this.root).querySelector('.scrollable').scrollTop = 0;
 
 			if (this._isMobile()) {
-				this.playAnimation('fromBottom');
+				this.playAnimation('mobileOpen');
 			} else {
-				this.playAnimation('fromTop');
+				this.playAnimation('desktopOpen');
 			}
 		},
 		_renderClosed: function () {
 			this.cancelAnimation();
 
 			if (this._isMobile()) {
-				this.playAnimation('down');
+				this.playAnimation('mobileClose');
 			} else {
-				this.playAnimation('up');
+				this.playAnimation('desktopClose');
 			}
 		},
 		_onNeonAnimationFinish: function () {


### PR DESCRIPTION
- Use scale, translateY, and fade instead of slide from top
- Introduce `forceWidth` param to responsive container calculations so that we can use a width from a specific container. This was needed because the scale transform affects the width.

Also updated the `d2l-ajax` reference since it was accidentally pinned to v1.0.1