### PR TITLE
Fix issue in IE where widget would not load

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.2.0",
-    "d2l-ajax": "Brightspace/d2l-ajax-ui#^1.0.1",
+    "d2l-ajax": "Brightspace/d2l-ajax-ui#^1.0.3",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-icon": "PolymerElements/iron-icon#^1.0.8",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -14,9 +14,10 @@
 
 		<d2l-ajax
 			id="allEnrollmentsRequest"
-			on-response="allEnrollmentsOnResponse"
 			url="[[enrollmentsUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'>
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-response="allEnrollmentsOnResponse"
+			last-response="{{allEnrollmentsResponse}}">
 		</d2l-ajax>
 
 		<d2l-simple-overlay
@@ -57,6 +58,9 @@
 					type: Array,
 					readOnly: true
 				},
+				allEnrollmentsResponse: {
+					type: Object
+				},
 				enrollmentsUrl: {
 					type: String
 				},
@@ -77,7 +81,7 @@
 			},
 			allEnrollmentsOnResponse: function (response) {
 				if (response.detail.status === 200) {
-					this._setAllEnrollmentsEntities(response.detail.xhr.response.entities);
+					this._setAllEnrollmentsEntities(this.allEnrollmentsResponse.entities);
 					this._filterUnpinnedCourses(this.pinnedCoursesEntities, this.allEnrollmentsEntities);
 					this._rescaleCourseTileRegions(this._getOverlayWidth());
 				}

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -13,10 +13,11 @@
 		<d2l-ajax
 			id="enrollmentsRequest"
 			auto
-			on-response="enrollmentsOnResponse"
 			url="[[pinnedCoursesUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			last-response="{{enrollmentsResponse}}"></d2l-ajax>
+			on-response="enrollmentsOnResponse"
+			last-response="{{enrollmentsResponse}}">
+		</d2l-ajax>
 
 		<div class="my-courses-container">
 			<template is="dom-repeat" items="[[enrollmentsResponse.entities]]">
@@ -38,8 +39,7 @@
 			is: 'd2l-my-courses',
 			properties: {
 				enrollmentsResponse: {
-					type: Object,
-					readOnly: true
+					type: Object
 				},
 				enrollmentsUrl: {
 					type: String
@@ -65,11 +65,8 @@
 			detached: function () {
 				window.removeEventListener('resize', this.windowResizeHandler);
 			},
-			enrollmentsOnResponse: function (response) {
-				if (response.detail.status === 200) {
-					this._setEnrollmentsResponse(response.detail.xhr.response);
-					this._rescaleCourseTileRegions();
-				}
+			enrollmentsOnResponse: function () {
+				this._rescaleCourseTileRegions();
 			},
 			openAllCoursesView: function () {
 				this.$$('d2l-all-courses').open();

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -150,8 +150,8 @@ describe('smoke test', function() {
 			ajaxElement.authToken = 'PlaceholderToken';
 			ajaxElement.generateRequest();
 
-			ajaxElement.addEventListener('response', function (response) {
-				expect(Array.isArray(response.detail.xhr.response.entities)).to.be.true;
+			ajaxElement.addEventListener('response', function () {
+				expect(Array.isArray(ajaxElement.lastResponse.entities)).to.be.true;
 				done();
 			});
 		});

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -71,14 +71,6 @@ describe('smoke test', function() {
 				done();
 			});
 		});
-
-		it('should have a read-only response object', function() {
-			widget._setEnrollmentsResponse('foo');
-
-			widget.enrollmentsResponse = 'bar';
-
-			expect(widget.enrollmentsResponse).to.equal('foo');
-		});
 	});
 
 	describe('layout', function () {


### PR DESCRIPTION
Use iron-ajax `lastResponse` instead of `xhr.response` because lastResponse will be properly parsed according to `handleAs`.

Also needed to bump the `d2l-ajax` version to get a required bug fix.