### PR TITLE
Pin Firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - 4
 sudo: false
 addons:
-  firefox: latest
+  firefox: "46.0"
 before_script:
 - npm run test:lint:js
 - npm run test:lint:html

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -1,7 +1,10 @@
 {
   "plugins": {
     "local": {
-      "browsers": ["firefox"]
+      "browsers": [{
+        "browserName": "firefox",
+        "version": "46"
+      }]
     },
     "sauce": {
       "disabled": true,


### PR DESCRIPTION
FF47 is not compatible with Selenium 2.53.0, which is what wct-local is using. Pinning the version for now, until wct-local updates to a newer version of Selenium.