### PR TITLE
US72668 - Cleanup styles

### DIFF
--- a/d2l-alert-styles.html
+++ b/d2l-alert-styles.html
@@ -1,14 +1,14 @@
 <link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../vui-typography/small-text.html">
 
 <dom-module id="d2l-alert-styles">
 	<template>
 		<style include="vui-colors"></style>
+		<style include="vui-small-text"></style>
 		<style>
 		:host {
-			@apply(--vui-font);
+			@apply(--vui-small-text);
 			display: block;
-			font-family: 'Lato-Regular', sans-serif;
-			font-size: 0.7em;
 		}
 		.message-wrapper {
 			position: relative;

--- a/d2l-alert-styles.html
+++ b/d2l-alert-styles.html
@@ -1,9 +1,7 @@
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="../vui-colors/colors.html">
 
 <dom-module id="d2l-alert-styles">
 	<template>
-		<style include="vui-typography"></style>
 		<style include="vui-colors"></style>
 		<style>
 		:host {

--- a/d2l-all-courses-styles.html
+++ b/d2l-all-courses-styles.html
@@ -1,9 +1,7 @@
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="d2l-course-tile-region-styles.html">
 
 <dom-module id="d2l-all-courses-styles">
 	<template>
-		<style include="vui-typography"></style>
 		<style include="d2l-course-tile-region-styles"></style>
 		<style>
 		:host {

--- a/d2l-all-courses-styles.html
+++ b/d2l-all-courses-styles.html
@@ -5,18 +5,14 @@
 		<style include="d2l-course-tile-region-styles"></style>
 		<style>
 		:host {
-			@apply(--vui-font);
 			display: block;
-			font-family: 'Lato-Regular', sans-serif;
-			letter-spacing: 1px;
-			color: var(--vui-color-ferrite);
 		}
-
-		h3.header {
-			@apply(--vui-heading-3);
+		h3 {
+			/* overrides to vui-heading-3 */
 			margin: 10px 0;
+			font-size: 20px;
+			/* end overrides */
 		}
-
 		d2l-alert {
 			margin-bottom: 20px;
 		}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-simple-overlay.html">
 <link rel="import" href="d2l-course-tile.html">
@@ -9,7 +8,7 @@
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-interaction-detection-behavior.html">
 
-<dom-module id="d2l-all-courses" class="vui-typography">
+<dom-module id="d2l-all-courses">
 	<template>
 		<style include="d2l-all-courses-styles"></style>
 
@@ -28,7 +27,7 @@
 			with-backdrop>
 
 			<div class="dialog-content">
-				<h3 class="header">{{localize('pinnedCourses')}}</h3>
+				<h3 class="vui-heading-3">{{localize('pinnedCourses')}}</h3>
 				<d2l-alert visible="{{_hasPinnedCourses}}">
 					{{localize('noPinnedCoursesMessage')}}
 				</d2l-alert>
@@ -41,7 +40,7 @@
 					</template>
 				</div>
 
-				<h3 class="header">{{localize('unpinnedCourses')}}</h3>
+				<h3 class="vui-heading-3">{{localize('unpinnedCourses')}}</h3>
 				<div class="my-courses-container" role="region">
 					<template is="dom-repeat" items="[[unpinnedCoursesEntities]]">
 						<d2l-course-tile

--- a/d2l-course-tile-region-styles.html
+++ b/d2l-course-tile-region-styles.html
@@ -1,8 +1,5 @@
-<link rel="import" href="../vui-typography/typography.html">
-
 <dom-module id="d2l-course-tile-region-styles">
 	<template>
-		<style include="vui-typography"></style>
 		<style>
 		:host {
 			@apply(--vui-font);

--- a/d2l-course-tile-region-styles.html
+++ b/d2l-course-tile-region-styles.html
@@ -2,11 +2,7 @@
 	<template>
 		<style>
 		:host {
-			@apply(--vui-font);
 			display: block;
-			font-family: 'Lato-Regular', sans-serif;
-			letter-spacing: 1px;
-			color: var(--vui-color-ferrite);
 		}
 
 		.my-courses-container {

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -1,15 +1,15 @@
 <link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../vui-typography/small-text.html">
 
 <dom-module id="d2l-course-tile-styles">
 	<template>
 		<style include="vui-colors"></style>
+		<style include="vui-small-text"></style>
 		<style>
 		:host {
 			display: block;
-			@apply(--vui-font);
 			-webkit-backface-visibility: hidden;
 		}
-
 		.tile-container {
 			position: relative;
 		}
@@ -32,7 +32,7 @@
 			bottom: 0;
 			border-top-left-radius: 10px;
 			border-top-right-radius: 10px;
-			background: #B9C2D0;
+			background: var(--vui-color-pressicus);
 			overflow: hidden;
 			z-index: 0;
 		}
@@ -52,13 +52,15 @@
 			transform: scale(1.1);
 		}
 		.course-text {
-			@apply(--vui-heading-4);
 			width: 100%;
 			max-height: 75px;
 			overflow: hidden;
 			position: relative;
 			margin-top: 0.4em;
 			margin-bottom: 1.9em;
+			/* overrides to vui-heading-4 */
+			font-weight: 400;
+			/* end overrides */
 			/* ellipses for long text */
 			display: -webkit-box;
 			-webkit-line-clamp: 2;
@@ -98,8 +100,11 @@
 			background: rgba(0,0,0,0.7);
 		}
 		.menu-text {
+			@apply(--vui-small-text);
+			/* overrides to vui-small-text */
 			font-size: 14px;
-			vertical-align: middle;
+			color: rgba(255,255,255,1);
+			/* end overrides */
 		}
 		.no-tap-interaction {
 			-webkit-touch-callout: none;

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -1,9 +1,7 @@
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="../vui-colors/colors.html">
 
 <dom-module id="d2l-course-tile-styles">
 	<template>
-		<style include="vui-typography"></style>
 		<style include="vui-colors"></style>
 		<style>
 		:host {

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -31,7 +31,7 @@
 						<img aria-hidden="true" />
 					</div>
 				</div>
-				<div class="course-text">{{_enrollmentEntity.properties.name}}</div>
+				<div class="course-text vui-heading-4">{{_enrollmentEntity.properties.name}}</div>
 			</a>
 
 			<div class="hover-menu no-tap-interaction">

--- a/d2l-my-courses-styles.html
+++ b/d2l-my-courses-styles.html
@@ -1,10 +1,8 @@
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="../vui-colors/colors.html">
 <link rel="import" href="d2l-course-tile-region-styles.html">
 
 <dom-module id="d2l-my-courses-styles">
 	<template>
-		<style include="vui-typography"></style>
 		<style include="vui-colors"></style>
 		<style include="d2l-course-tile-region-styles"></style>
 		<style>

--- a/d2l-my-courses-styles.html
+++ b/d2l-my-courses-styles.html
@@ -1,57 +1,42 @@
 <link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../vui-typography/small-text.html">
 <link rel="import" href="d2l-course-tile-region-styles.html">
 
 <dom-module id="d2l-my-courses-styles">
 	<template>
 		<style include="vui-colors"></style>
+		<style include="vui-small-text"></style>
 		<style include="d2l-course-tile-region-styles"></style>
 		<style>
 		:host {
-			@apply(--vui-font);
 			display: block;
-			font-family: 'Lato-Regular', sans-serif;
-			letter-spacing: 1px;
-			color: var(--vui-color-ferrite);
 		}
-
+		:focus {
+			text-decoration: underline;
+		}
 		@media not all and (hover: hover) {
 			:host {
 				-webkit-user-select: none;
 				user-select: none;
 			}
  		}
-
-		:focus {
-			text-decoration: underline;
-		}
-
 		.all-courses-button {
+			@apply(--vui-small-text);
+			/* overrides to vui-small-text */
 			color: var(--vui-color-celestine);
-			font-family: inherit;
-			font-size: 0.7rem;
-			font-weight: 700;
-			line-height: 1rem;
+			margin: 0;
 			margin-top: -10px;
+			font-weight: 700;
+			/* end overrides */
 			display: block;
 			background: none;
 			border: none;
 			padding: 0;
 			cursor: pointer;
 			position: relative;
-			z-index: 1;
 		}
-
 		.all-courses-button:hover {
 			text-decoration: underline;
-		}
-
-		.header {
-			font-family: 'Lato';
-			font-size: 1em;
-			letter-spacing: 0.035em;
-			color: var(--vui-color-celestine);
-			padding-top: 5px;
-			display: block;
 		}
 		d2l-alert {
 			margin-bottom: 30px;

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -18,7 +18,7 @@
 			user-select: none;
 			-webkit-user-select: none;
 			-moz-user-select: none;
-			ms-user-select: none;
+			-ms-user-select: none;
 		}
 
 		.close-button {
@@ -80,8 +80,12 @@
 		}
 
 		h2 {
-			@apply(--vui-heading-4);
+			/* overrides to vui-heading-2 */
+			font-weight: 400;
 			font-size: 30px;
+			margin-top: 30px;
+			margin-bottom: 30px;
+			/* end overrides */
 		}
 		</style>
 	</template>

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -11,14 +11,14 @@
 <link rel="import" href="icons.html">
 <link rel="import" href="localize-behavior.html">
 
-<dom-module id='d2l-simple-overlay'>
+<dom-module id="d2l-simple-overlay">
 	<style include="d2l-simple-overlay-styles"></style>
 	<template>
 		<div class="max-width">
 			<button class="close-button pull-right" on-tap="handleClose" alt$="{{localize('closeSimpleOverlayAltText')}}">
 				<iron-icon icon="actions:close"></iron-icon>
 			</button>
-			<h2>{{title}}</h2>
+			<h2 class="vui-heading-2">{{title}}</h2>
 		</div>
 		<div class="scrollable">
 			<div class="max-width">

--- a/d2l-touch-menu-item-styles.html
+++ b/d2l-touch-menu-item-styles.html
@@ -1,9 +1,10 @@
-<link rel="import" href="../vui-typography/typography.html">
 <link rel="import" href="../vui-colors/colors.html">
+<link rel="import" href="../vui-typography/small-text.html">
 
 <dom-module id="d2l-touch-menu-item-styles">
 	<template>
 		<style include="vui-colors"></style>
+		<style include="vui-small-text"></style>
 		<style>
 		:host {
 			z-index: 1000;
@@ -75,17 +76,18 @@
 		}
 
 		.longpress-menu-item-text {
-			@apply(--vui-font);
+			@apply(--vui-small-text);
+			/* vui-small-text overrides */
+			color: var(--vui-color-white);
+			/* end overrides */
 			background-color: var(--vui-color-pressicus);
 			border-radius: 0.25em;
 			box-sizing: border-box;
-			color: var(--vui-color-white);
 			display: inline-block;
 			width: 80%;
 			left: 10%;
 			right: 90%;
 			top: -45%;
-			font-size: 0.23em;
 			padding-top: 0.1em;
 			padding-bottom: 0.1em;
 			opacity: 0;

--- a/demo/index.html
+++ b/demo/index.html
@@ -13,8 +13,10 @@
 	    </script>
 		<link rel="stylesheet" href="demo.css">
 		<link rel="import" href="../d2l-my-courses.html">
+		<link rel="import" href="../../vui-typography/typography.html">
+		<style is="custom-style" include="vui-typography"></style>
 	</head>
-	<body unresolved>
+	<body unresolved class="vui-typography">
 		<main class="d2l-max-width">
 			<d2l-my-courses enrollments-url="my-courses.json"></d2l-my-courses>
 		</main>


### PR DESCRIPTION
Reasonings and stuff:

- We shouldn't be importing `vui-typography`; the LMS is importing this already
- We _should_ explicitly import `vui-small-text`, as it's not as-guaranteed to be present
- `vui-typography` has moved away from variables to just classes; so, use classes rather than `@apply` rules (except for small text)
- Use Daylight styles as much as possible, and only override where we explicitly want to

TODO

- [x] Review explicit overrides with @thehappypixel 

Fixes #16