### PR TITLE
Use d2l-offscreen web component for offscreen text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,8 @@
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^0.9.0",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.0.0",
     "vui-link": "^2.1.0",
-    "d2l-icons": "^2.0.2"
+    "d2l-icons": "^2.0.2",
+    "d2l-offscreen": "^2.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../vui-link/link.html">
 <link rel="import" href="d2l-my-courses-styles.html">
@@ -43,7 +44,7 @@
 			</template>
 		</div>
 
-		<div class="d2l-offscreen" aria-live="polite">{{ariaMessage}}</div>
+		<d2l-offscreen aria-live="polite">{{ariaMessage}}</d2l-offscreen>
 
 		<button class="all-courses-button"
 			hidden$="{{!_hasCourses}}"

--- a/d2l-touch-menu-item.html
+++ b/d2l-touch-menu-item.html
@@ -1,7 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="d2l-touch-menu-item-styles.html">
 <link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
+<link rel="import" href="d2l-touch-menu-item-styles.html">
 
 <dom-module id="d2l-touch-menu-item">
 	<template>
@@ -15,7 +16,7 @@
 			</div>
 		</div>
 
-		<div class="d2l-offscreen" aria-live="polite">{{ariaMessage}}</div>
+		<d2l-offscreen aria-live="polite">{{ariaMessage}}</d2l-offscreen>
 	</template>
 	<script>
 		Polymer({

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -11,12 +11,3 @@ main {
 	overflow: hidden;
 	position: fixed;
 }
-
-.d2l-offscreen {
-	word-wrap: normal !important;
-	position: absolute !important;
-	left: -10000px;
-	overflow: hidden;
-	width: 1px;
-	height: 1px;
-}


### PR DESCRIPTION
New WC that is intended to have the proper formatting/styles for offscreen components. We were previously relying on shady DOM leakage for this to work, but this method will now work with both shady and shadow DOM.