### PR TITLE
Add interaction interface detection and only enable one of hover/touc…

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -7,6 +7,7 @@
 <link rel="import" href="d2l-course-tile.html">
 <link rel="import" href="d2l-course-tile-region-behavior.html">
 <link rel="import" href="localize-behavior.html">
+<link rel="import" href="d2l-interaction-detection-behavior.html">
 
 <dom-module id="d2l-all-courses" class="vui-typography">
 	<template>
@@ -33,14 +34,20 @@
 				</d2l-alert>
 				<div class="my-courses-container" role="region">
 					<template is="dom-repeat" filter="isActive" items="[[pinnedCoursesEntities]]">
-						<d2l-course-tile enrollment="[[item]]"></d2l-course-tile>
+						<d2l-course-tile
+							enrollment="[[item]]"
+							hover-enabled="[[_hoverInteractionEnabled]]"
+							touch-enabled="[[_touchInteractionEnabled]]"></d2l-course-tile>
 					</template>
 				</div>
 
 				<h3 class="header">{{localize('unpinnedCourses')}}</h3>
 				<div class="my-courses-container" role="region">
 					<template is="dom-repeat" items="[[unpinnedCoursesEntities]]">
-						<d2l-course-tile enrollment="[[item]]"></d2l-course-tile>
+						<d2l-course-tile
+							enrollment="[[item]]"
+							hover-enabled="[[_hoverInteractionEnabled]]"
+							touch-enabled="[[_touchInteractionEnabled]]"></d2l-course-tile>
 					</template>
 				</div>
 			</div>
@@ -82,7 +89,8 @@
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileRegionBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior
+				Polymer.D2L.MyCourses.LocalizeBehavior,
+				Polymer.D2L.MyCourses.InteractionDetectionBehavior
 			],
 			ready : function() {
 				this.$$('d2l-simple-overlay').focusableNodesOverride = this.focusableNodesOverride;

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -104,13 +104,26 @@
 			vertical-align: middle;
 		}
 		.no-tap-interaction {
-			-webkit-user-select: none;
 			-webkit-touch-callout: none;
 			-webkit-tap-highlight-color: rgba(0,0,0,0);
 			-moz-tap-highlight-color: rgba(0,0,0,0);
 			tap-highlight-color: rgba(0,0,0,0);
 			touch-action: pan-x pan-y;
 		}
+
+		@media not all and (hover: hover) {
+			a, .hover-menu, .menu-item {
+				-webkit-user-select: none;
+			}
+
+			:focus .course-text {
+				text-decoration: none;
+			}
+
+			.hover-menu {
+				display: none;
+			}
+ 		}
 		</style>
 	</template>
 </dom-module>

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -50,7 +50,7 @@
 			</div>
 		</div>
 
-		<d2l-touch-menu>
+		<d2l-touch-menu enabled="[[touchEnabled]]">
 			<d2l-touch-menu-item
 				text="{{localize('pin')}}"
 				background-image="d2l-tier1:pin-filled"
@@ -67,6 +67,14 @@
 				enrollment: {
 					type: Object,
 					observer: '_enrollmentChanged'
+				},
+				hoverEnabled: {
+					type: Boolean,
+					value: true
+				},
+				touchEnabled: {
+					type: Boolean,
+					value: true
 				},
 				_enrollmentEntity: {
 					type: Object,
@@ -137,11 +145,13 @@
 				});
 			},
 			hoverCourseTile: function() {
-				var hoverMenu = this.$$('.hover-menu');
-				Polymer.dom(hoverMenu).classList.add('hover');
+				if (this.hoverEnabled) {
+					var hoverMenu = this.$$('.hover-menu');
+					Polymer.dom(hoverMenu).classList.add('hover');
 
-				var courseImage = this.$$('.course-image img');
-				Polymer.dom(courseImage).classList.add('hover');
+					var courseImage = this.$$('.course-image img');
+					Polymer.dom(courseImage).classList.add('hover');
+				}
 			},
 			unhoverCourseTile: function(force) {
 				if (force === true || Polymer.dom(this.root).querySelectorAll(':hover').length === 0) {

--- a/d2l-interaction-detection-behavior.html
+++ b/d2l-interaction-detection-behavior.html
@@ -1,0 +1,34 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+	(function() {
+		'use strict';
+
+		Polymer.D2L = Polymer.D2L || {};
+		Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+
+		Polymer.D2L.MyCourses.InteractionDetectionBehavior = {
+			properties: {
+				_hoverInteractionEnabled: {
+					type: Boolean,
+					value: true
+				},
+				_touchInteractionEnabled: {
+					type: Boolean,
+					value: false
+				}
+			},
+			ready: function() {
+				if (window.matchMedia) {
+					var touchQuery = window.matchMedia('not all and (hover: hover)');
+					touchQuery.addListener(this._touchQueryListener.bind(this));
+					this._touchQueryListener(touchQuery);
+				}
+			},
+			_touchQueryListener: function(query) {
+				this._touchInteractionEnabled = query.matches && ('ontouchstart' in window);
+				this._hoverInteractionEnabled = !this._touchInteractionEnabled;
+			}
+		};
+	})();
+</script>

--- a/d2l-my-courses-styles.html
+++ b/d2l-my-courses-styles.html
@@ -16,6 +16,13 @@
 			color: var(--vui-color-ferrite);
 		}
 
+		@media not all and (hover: hover) {
+			:host {
+				-webkit-user-select: none;
+				user-select: none;
+			}
+ 		}
+
 		:focus {
 			text-decoration: underline;
 		}

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -8,6 +8,7 @@
 <link rel="import" href="d2l-all-courses.html">
 <link rel="import" href="d2l-course-tile-region-behavior.html">
 <link rel="import" href="localize-behavior.html">
+<link rel="import" href="d2l-interaction-detection-behavior.html">
 
 <dom-module id="d2l-my-courses">
 	<template>
@@ -39,7 +40,11 @@
 
 		<div class="my-courses-container">
 			<template is="dom-repeat" filter="isActive" items="[[_pinnedCoursesResponse.entities]]">
-				<d2l-course-tile enrollment="[[item]]"></d2l-course-tile>
+				<d2l-course-tile
+					enrollment="[[item]]"
+					hover-enabled="[[_hoverInteractionEnabled]]"
+					touch-enabled="[[_touchInteractionEnabled]]">
+				</d2l-course-tile>
 			</template>
 		</div>
 
@@ -100,7 +105,8 @@
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileRegionBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior
+				Polymer.D2L.MyCourses.LocalizeBehavior,
+				Polymer.D2L.MyCourses.InteractionDetectionBehavior
 			],
 			listeners: {
 				'course-pinned': '_onCoursePinned',

--- a/d2l-touch-menu-item-styles.html
+++ b/d2l-touch-menu-item-styles.html
@@ -70,8 +70,8 @@
 			position: relative;
 			box-shadow: 0px 1px 1px 0px rgba(86,89,92,0.20);
 			display: flex;
-			-webkit-transition: 0.3s ease-in-out;
-			transition: 0.3s ease-in-out;
+			-webkit-transition: background-color 0.3s ease-in-out;
+			transition: background-color 0.3s ease-in-out;
 		}
 
 		.longpress-menu-item-text {

--- a/d2l-touch-menu.html
+++ b/d2l-touch-menu.html
@@ -14,6 +14,9 @@
 		Polymer({
 			is: 'd2l-touch-menu',
 			properties: {
+				enabled: {
+					type: Boolean
+				},
 				_touchTarget: {
 					type: Object,
 					observer: '_touchTargetChanged'
@@ -29,7 +32,11 @@
 					type: Boolean,
 					observer: '_onMenuOpenChanged'
 				},
-				_timerID: {
+				_openMenuTimerID: {
+					type: Number,
+					value: null
+				},
+				_enableClicksTimerID: {
 					type: Number,
 					value: null
 				},
@@ -47,10 +54,10 @@
 					}, {
 						event: 'touchmove',
 						handler: 'touchmoveHandler'
+					}, {
+						event: 'click',
+						handler: 'clickHandler'
 					}]
-				},
-				_touchStartEventData: {
-					type: Object
 				},
 				_host: {
 					type: Object
@@ -66,6 +73,9 @@
 				},
 				_initialized: {
 					type: Boolean
+				},
+				_cancelClicks: {
+					type: Boolean
 				}
 			},
 			listeners: {
@@ -76,7 +86,7 @@
 				this._menuItems = [].slice.call(Polymer.dom(this).querySelectorAll('d2l-touch-menu-item'));
 			},
 			attached: function() {
-				if (!this._initialized) {
+				if (this.enabled && !this._initialized) {
 					// Only run once, as attaching to body will cause this to be called again
 					this._initialized = true;
 					this._owner = this.parentNode;
@@ -95,18 +105,10 @@
 			touchstartHandler: function(e) {
 				e.stopPropagation();
 
-				// Capture data about original touch in case we need to generate a click later on
-				this._touchStartEventData = {
-					originalTarget: Polymer.dom(e).path[0],
-					timeStamp: e.timeStamp
-				};
-
 				// Only show the menu if it's tap+hold
-				this._timerID = setTimeout(this.openMenu.bind(this, e), this._longPressDuration);
+				this._openMenuTimerID = setTimeout(this.openMenu.bind(this, e), this._longPressDuration);
 			},
 			touchmoveHandler: function(e) {
-				this._touchStartEventData = null;
-
 				if (this._menuOpen) {
 					var touchPoint = {
 						x: e.changedTouches[0].clientX,
@@ -127,7 +129,7 @@
 						menuItem.hoverState = menuItem.pointInTouchRegion(touchPoint);
 					}.bind(this));
 				} else {
-					this._cancelMenu();
+					clearTimeout(this._openMenuTimerID);
 				}
 			},
 			touchendHandler: function(e) {
@@ -142,30 +144,14 @@
 					}
 				}.bind(this));
 
-				// If this would have otherwise been a tap event, bubble up click event from original touch target
-				if (this._touchStartEventData !== null) {
-					if (e.timeStamp - this._touchStartEventData.timeStamp < 250) {
-						var newEvent = new MouseEvent('click', {
-							'bubbles': true,
-							'cancelable': true
-						});
-
-						this._touchStartEventData.originalTarget.dispatchEvent(newEvent);
-					}
-				}
-
 				this.touchcancelHandler(e);
 			},
 			touchcancelHandler: function() {
-				this._touchStartEventData = null;
-
-				this._cancelMenu();
+				clearTimeout(this._openMenuTimerID);
 
 				this._menuOpen = false;
 			},
 			openMenu: function(touchstartEvent) {
-				this._touchStartEventData = null;
-
 				this.listen(this._touchTarget, 'touchend', 'touchendHandler');
 
 				var touchData = {
@@ -251,18 +237,30 @@
 			contextMenuHandler: function(e) {
 				e.preventDefault();
 			},
-			_cancelMenu: function() {
-				if (this._timerID) {
-					clearTimeout(this._timerID);
-				}
-				this._timerID = null;
-			},
 			_onMenuOpenChanged: function(openMenu) {
 				this._menu.style.visibility = openMenu ? 'visible' : 'hidden';
+
+				if (openMenu) {
+					this._cancelClicks = true;
+				} else {
+					// iOS will send delayed click on long press completion, so we need to slightly delay re-enabling clicks
+					this._enableClicksTimerID = setTimeout(this._enableClicks.bind(this), 100);
+				}
 
 				this._menuItems.forEach(function(menuItem) {
 					menuItem.visible = openMenu;
 				}.bind(this));
+			},
+			clickHandler: function(e) {
+				if (this._cancelClicks) {
+					e.preventDefault();
+					this._enableClicks();
+				}
+			},
+			_enableClicks: function() {
+				this._cancelClicks = false;
+				clearTimeout(this._enableClicksTimerID);
+				this._enableClicksTimerID = null;
 			}
 		});
 	</script>


### PR DESCRIPTION
- Will now detect (to a reasonable degree) whether hover and/or touch interfaces are supported, enabling only the detected interface, defaulting to both enabled if it can't be reasonably determined. This will need improvement in the future, but works reasonably well for now. Allows for more normal interaction on desktop (context menu, selection, etc)

- Rather than simulating click events on short touches, allow platform's click event to run if long-press menu wasn't opened. Also adds click prevention for a short time after closing to catch delayed click events on iOS.

- Corrected a transition that should have only applied to background-colour on touch menu items, but also delayed the menu item from being hidden.

- Disable pointer events on hover button in non-hover interface, so that it doesn't swallow click events on touch devices.