### PR TITLE
Fix: 4 courses should be 1 row, not 2

### DIFF
--- a/d2l-course-tile-region-behavior.html
+++ b/d2l-course-tile-region-behavior.html
@@ -30,7 +30,7 @@
 						numCols = 3;
 					}
 				} else {
-					if (itemCount === 1 || itemCount === 2 || itemCount === 4) {
+					if (itemCount === 1 || itemCount === 2) {
 						numCols = 2;
 					} else if (itemCount === 3 || itemCount === 5 || itemCount === 6) {
 						numCols = 3;

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -316,7 +316,7 @@ describe('smoke test', function() {
 				}, {
 					width: 992,
 					itemCount: 4,
-					expectedColumns: 2
+					expectedColumns: 4
 				}, {
 					width: 992,
 					itemCount: 5,


### PR DESCRIPTION
Designs specify that having 4 courses should show up as 1 row of 4 courses, not 2 rows of 2 (the latter resulting in very large course tiles)