### PR TITLE
Added additional course tile transition on touch menu open

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ Properties:
 - `actionDescription` _String_: used for A11Y offscreen description
 - `backgroundImage` _String_: an icon to use for the menu item
 - `text` _String_: Text to display on menu item
-- `selectionHandler` _String_: Callback for when menu item is selected
+- `selectionEvent` _String_: Name of event that will be fired when menu item selected
+- `hoverEvent` _String_: Name of event that will be fired when menu item is hovered
 
 ## `user-info-api` Integration
 
@@ -99,26 +100,24 @@ will be changed in the future.
 
 Testing from within LMS:
 
-1) Checkout brightspace/d2l-my-courses-ui and brightspace/brightspace-integration
+1. Checkout brightspace/d2l-my-courses-ui and brightspace/brightspace-integration
 
-2) In brightspace-integration project, ensure you're in the correct branch (c12i12)
+2. In brightspace-integration project, ensure you're in the correct branch (c12i12)
 
-3) In d2l-my-courses-ui directory, run
-
-```shell
-bower link
-```
+3. In d2l-my-courses-ui directory, run
+	```shell
+	bower link
+	```
 to allow it to be linked from brightspace-integration
 
-4) In brightspace-integration directory, run
-
-```shell
-bower link d2l-my-courses-ui
-```
+4. In brightspace-integration directory, run
+	```shell
+	bower link d2l-my-courses-ui
+	```
 to link to the local d2l-my-courses-ui project
 
-5) Build and run brightspace-integration (will have to be rebuilt on any changes to d2l-my-courses-ui)
---*Note: If on Windows, you must remove the tmp directory manually prior to building, if it exists.
+5. Build and run brightspace-integration (will have to be rebuilt on any changes to d2l-my-courses-ui)
+ * Note: If on Windows, you must remove the tmp directory manually prior to building, if it exists.
 
 ## Unit Tests
 

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -12,6 +12,8 @@
 			-webkit-backface-visibility: hidden;
 			-moz-backface-visibility: hidden;
 			backface-visibility: hidden;
+			--scale-fade-max-scale: 1.5;
+			--scale-fade-min-scale: 1.05;
 		}
 
 		.tile-container {
@@ -24,24 +26,30 @@
 			-moz-backface-visibility: hidden;
 			backface-visibility: hidden;
 		}
-		.tile-container.unpin-hovered {
-			 transition: 0.25s ease-in-out;
-			 transform: scale(1.05);
-			 box-shadow: 3px 2px 10px rgba(0, 0, 0, 0.3);
-			 z-index: 100;
-			 background-color: var(--d2l-color-white);
+		.tile-container.hover {
+			transition: 0.25s ease-in-out;
+			z-index: 100;
+			background-color: var(--d2l-color-white);
+		}
+		.tile-container.touch-menu-open {
+			transform: scale(1.05);
+			box-shadow: 2px 1px 10px rgba(0, 0, 0, 0.3);
+		}
+		.tile-container.touch-menu-open.unpin-hovered {
+			transform: scale(1.1);
+			box-shadow: 2px 1px 10px rgba(0, 0, 0, 0.3);
+		}
+		.tile-container.unpin-hovered:not(.touch-menu-open) {
+			transform: scale(1.05);
+			box-shadow: 3px 2px 10px rgba(0, 0, 0, 0.3);
 		}
 		.tile-container.animate-insertion {
 			animation: 0.6s forwards scale-and-fade-in;
-			z-index: 100;
 			pointer-events: none;
-			background-color: var(--d2l-color-white);
 		}
 		.tile-container.unpin {
 			animation: 0.7s forwards scale-and-fade-out;
-			z-index: 100;
 			pointer-events: none;
-			background-color: var(--d2l-color-white);
 		}
 
 		a, a:hover, a:visited {
@@ -160,7 +168,7 @@
 
 		@keyframes scale-and-fade-in {
 			from {
-				transform: scale(1.5) translateZ(0);
+				transform: scale(var(--scale-fade-max-scale)) translateZ(0);
 				box-shadow: 10px 6px 20px rgba(0, 0, 0, 0.3);
 				opacity: 0.0;
 			}
@@ -172,12 +180,12 @@
 		}
 		@keyframes scale-and-fade-out {
 			from {
-				transform: scale(1.05) translateZ(0);
+				transform: scale(var(--scale-fade-min-scale)) translateZ(0);
 				box-shadow: 3px 2px 10px rgba(0, 0, 0, 0.3);
 				opacity: 1;
 			}
 			to {
-				transform: scale(1.5) translateZ(0);
+				transform: scale(var(--scale-fade-max-scale)) translateZ(0);
 				box-shadow: 10px 6px 20px rgba(0, 0, 0, 0.3);
 				opacity: 0;
 			}

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -36,7 +36,7 @@
 
 			<div class="hover-menu no-tap-interaction">
 				<button class="menu-item no-tap-interaction"
-					on-click="pinClickHandler"
+					on-click="hoverPinClickHandler"
 					on-focus="hoverPinMenuItem"
 					on-blur="unhoverPinMenuItem"
 					on-mouseover="hoverPinMenuItem"
@@ -111,7 +111,9 @@
 			],
 			listeners: {
 				'touch-pin-hover': '_onUnpinHover',
-				'touch-pin-select': 'pinClickHandler',
+				'touch-pin-select': '_onTouchPinSelect',
+				'touch-menu-open': '_onTouchMenuOpen',
+				'touch-menu-close': '_onTouchMenuClose',
 				'animationend': '_onAnimationComplete'
 			},
 			created: function() {
@@ -137,12 +139,16 @@
 				error.stopPropagation();
 				this._pinned = this._enrollmentEntity.getSubEntitiesByRel('preferences')[0].properties.hasOwnProperty('pinDate');
 			},
-			pinClickHandler: function(e) {
+			hoverPinClickHandler: function(e) {
 				// Prevent the click from triggering navigation to the course
-				if (e) {
-					e.preventDefault();
-				}
+				e.preventDefault();
 
+				this._pinClickHandler(false);
+			},
+			_onTouchPinSelect: function() {
+				this._pinClickHandler(true);
+			},
+			_pinClickHandler: function(isTouch) {
 				this._pinned = !this._pinned;
 
 				var updatePreferences = this.$$('d2l-ajax');
@@ -164,28 +170,41 @@
 				this.pinAnimationInProgress = true;
 				var tileContainer = this.$$('.tile-container');
 				this.toggleClass('unpin-hovered', false, tileContainer);
+
+				if (isTouch) {
+					this.customStyle['--scale-fade-min-scale'] = '1.1';
+					this.updateStyles();
+				}
+
 				this.toggleClass('unpin', true, tileContainer);
 
 				this.pendingPinAction = this._pinned;
 			},
 			hoverCourseTile: function() {
 				if (this.hoverEnabled) {
-					var hoverMenu = this.$$('.hover-menu');
-					Polymer.dom(hoverMenu).classList.add('hover');
-
-					var courseImage = this.$$('.course-image img');
-					Polymer.dom(courseImage).classList.add('hover');
+					this._setCourseTileHovered(true);
 				}
 			},
 			unhoverCourseTile: function(force) {
 				if ((force === true || Polymer.dom(this.root).querySelectorAll(':hover').length === 0) &&
 					!this.pinAnimationInProgress) {
-					var hoverMenu = this.$$('.hover-menu');
-					Polymer.dom(hoverMenu).classList.remove('hover');
-
-					var courseImage = this.$$('.course-image img');
-					Polymer.dom(courseImage).classList.remove('hover');
+					this._setCourseTileHovered(false);
 				}
+			},
+			_setCourseTileHovered: function(isHovered) {
+				this.toggleClass('hover', isHovered, this.$$('.tile-container'));
+				this.toggleClass('hover', isHovered, this.$$('.hover-menu'));
+				this.toggleClass('hover', isHovered, this.$$('.course-image img'));
+			},
+			_onTouchMenuOpen: function() {
+				var courseTile = this.$$('.tile-container');
+				this.toggleClass('touch-menu-open', true, courseTile);
+				this.toggleClass('hover', true, courseTile);
+			},
+			_onTouchMenuClose: function() {
+				var courseTile = this.$$('.tile-container');
+				this.toggleClass('touch-menu-open', false, courseTile);
+				this.toggleClass('hover', false, courseTile);
 			},
 			hoverPinMenuItem: function() {
 				this._onUnpinHover({detail: {hoverState: true}});

--- a/d2l-touch-menu.html
+++ b/d2l-touch-menu.html
@@ -183,6 +183,9 @@
 					this._enableClicksTimerID = setTimeout(this._enableClicks.bind(this), 100);
 				}
 
+				var menuEvent = 'touch-menu-' + (openMenu ? 'open' : 'close');
+				this.fire(menuEvent);
+
 				this._menuItems.forEach(function(menuItem) {
 					menuItem.visible = openMenu;
 				}.bind(this));

--- a/demo/d2l-touch-menu-demo.html
+++ b/demo/d2l-touch-menu-demo.html
@@ -23,7 +23,11 @@
 			<h1>d2l-touch-menu demo</h1>
 			<script>
 				function xHovered(e) {
-					document.getElementById('alert-text').className = e.detail.hoverState ? 'hovered' : '';
+					if(e.detail.hoverState === true) {
+						document.getElementById('alert-text').classList.add('hover');
+					} else {
+						document.getElementById('alert-text').classList.remove('hover');
+					}
 				}
 
 				function xSelected() {
@@ -33,6 +37,14 @@
 					setTimeout(function() {
 						this.className = '';
 					}.bind(alertText), 1000);
+				}
+
+				function menuOpened(e) {
+					document.getElementById('alert-text').classList.add('menu-open');
+				}
+
+				function menuClosed(e) {
+					document.getElementById('alert-text').classList.remove('menu-open');
 				}
 			</script>
 			<style>
@@ -52,7 +64,10 @@
 				#alert-text:before {
 					content: 'Long press me!';
 				}
-				#alert-text.hovered:before {
+				#alert-text.menu-open:before {
+					content: 'Hover over the X!'
+				}
+				#alert-text.menu-open.hover:before {
 					content: 'Release to select!';
 				}
 				#alert-text.selected:before {
@@ -75,6 +90,8 @@
 			<script>
 				document.getElementById('menu-parent').addEventListener('my-hover-event', xHovered);
 				document.getElementById('menu-parent').addEventListener('my-selection-event', xSelected);
+				document.getElementById('menu-parent').addEventListener('touch-menu-open', menuOpened);
+				document.getElementById('menu-parent').addEventListener('touch-menu-close', menuClosed);
 			</script>
 		</main>
 	</body>

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -128,7 +128,7 @@ describe('<d2l-course-tile>', function() {
 					done();
 				});
 
-			courseTile.pinClickHandler(event);
+			courseTile.hoverPinClickHandler(event);
 		});
 
 		it('should update the local pinned state with the received pin state', function(done) {
@@ -138,7 +138,7 @@ describe('<d2l-course-tile>', function() {
 				[200, {}, JSON.stringify(enrollment.entities[0])]);
 
 			expect(courseTile._pinned).to.be.true;
-			courseTile.pinClickHandler(event);
+			courseTile.hoverPinClickHandler(event);
 			expect(courseTile._pinned).to.be.false;
 
 			setTimeout(function() {
@@ -155,7 +155,7 @@ describe('<d2l-course-tile>', function() {
 				[204, {}, '']);
 
 			expect(courseTile._pinned).to.be.true;
-			courseTile.pinClickHandler(event);
+			courseTile.hoverPinClickHandler(event);
 			expect(courseTile._pinned).to.be.false;
 
 			setTimeout(function() {
@@ -171,7 +171,7 @@ describe('<d2l-course-tile>', function() {
 				[404, {}, '']);
 
 			expect(courseTile._pinned).to.be.true;
-			courseTile.pinClickHandler(event);
+			courseTile.hoverPinClickHandler(event);
 			expect(courseTile._pinned).to.be.false;
 
 			setTimeout(function() {


### PR DESCRIPTION
Adds an additional transition on opening a long-press menu on a course tile, and aligns transition/animation properties to match designs. Also some minor refactoring and updating of docs/demo.