### PR TITLE
Refactor d2l-all-courses to not contain a d2l-simple-overlay

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -3,7 +3,6 @@
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-all-courses-styles.html">
-<link rel="import" href="d2l-simple-overlay.html">
 <link rel="import" href="d2l-course-tile.html">
 <link rel="import" href="d2l-course-tile-region-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -21,41 +20,34 @@
 			on-response="allEnrollmentsOnResponse">
 		</d2l-ajax>
 
-		<d2l-simple-overlay
-			id='all-courses-overlay'
-			title="{{localize('allCourses')}}"
-			locale="[[locale]]"
-			with-backdrop>
-
-			<div class="dialog-content">
-				<h3 class="d2l-heading-3">{{localize('pinnedCourses')}}</h3>
-				<d2l-alert visible="{{!_hasPinnedCourses}}">
-					{{localize('noPinnedCoursesMessage')}}
-				</d2l-alert>
-				<div class="my-courses-container" role="region">
-					<template is="dom-repeat" items="[[pinnedCoursesEntities]]">
-						<d2l-course-tile
-							enrollment="[[item]]"
-							hover-enabled="[[_hoverInteractionEnabled]]"
-							touch-enabled="[[_touchInteractionEnabled]]"
-							animate-insertion="[[removeCourseFromTransitionList(item.properties.id)]]">
-						</d2l-course-tile>
-					</template>
-				</div>
-
-				<h3 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h3>
-				<div class="my-courses-container" role="region">
-					<template is="dom-repeat" items="[[unpinnedCoursesEntities]]">
-						<d2l-course-tile
-							enrollment="[[item]]"
-							hover-enabled="[[_hoverInteractionEnabled]]"
-							touch-enabled="[[_touchInteractionEnabled]]"
-							animate-insertion="[[removeCourseFromTransitionList(item.properties.id)]]">
-						</d2l-course-tile>
-					</template>
-				</div>
+		<div class="dialog-content">
+			<h3 class="d2l-heading-3">{{localize('pinnedCourses')}}</h3>
+			<d2l-alert visible="{{!_hasPinnedCourses}}">
+				{{localize('noPinnedCoursesMessage')}}
+			</d2l-alert>
+			<div class="my-courses-container" role="region">
+				<template is="dom-repeat" items="[[pinnedCoursesEntities]]">
+					<d2l-course-tile
+						enrollment="[[item]]"
+						hover-enabled="[[_hoverInteractionEnabled]]"
+						touch-enabled="[[_touchInteractionEnabled]]"
+						animate-insertion="[[removeCourseFromTransitionList(item.properties.id)]]">
+					</d2l-course-tile>
+				</template>
 			</div>
-		</d2l-simple-overlay>
+
+			<h3 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h3>
+			<div class="my-courses-container" role="region">
+				<template is="dom-repeat" items="[[unpinnedCoursesEntities]]">
+					<d2l-course-tile
+						enrollment="[[item]]"
+						hover-enabled="[[_hoverInteractionEnabled]]"
+						touch-enabled="[[_touchInteractionEnabled]]"
+						animate-insertion="[[removeCourseFromTransitionList(item.properties.id)]]">
+					</d2l-course-tile>
+				</template>
+			</div>
+		</div>
 	</template>
 
 	<script>
@@ -72,9 +64,6 @@
 				Polymer.D2L.MyCourses.InteractionDetectionBehavior,
 				Polymer.D2L.MyCourses.CourseManagementBehavior
 			],
-			ready: function() {
-				this.$$('d2l-simple-overlay').focusableNodesOverride = this.focusableNodesOverride;
-			},
 			allEnrollmentsOnResponse: function(response) {
 				if (response.detail.status === 200) {
 					this.setAllCoursesFromSirenResponse(response.detail.xhr.response);
@@ -83,33 +72,16 @@
 					this._rescaleCourseTileRegions(this._getOverlayWidth());
 				}
 			},
-			open: function() {
-				if (this.fetchEnrollments) {
-					this.$.allEnrollmentsRequest.generateRequest();
-				}
-				this.$$('d2l-simple-overlay').open();
-				this._rescaleCourseTileRegions(this._getOverlayWidth());
+			refresh: function() {
+				this.$.allEnrollmentsRequest.generateRequest();
 			},
 			_getOverlayWidth: function() {
-				return this._getAvailableWidth(this.$$('d2l-simple-overlay'));
+				return this._getAvailableWidth(this.$$('.dialog-content'));
 			},
 			get courseTileItemCount() {
 				var itemCount = Math.max(this.pinnedCoursesEntities.length, this.unpinnedCoursesEntities.length);
 
 				return itemCount;
-			},
-			focusableNodesOverride: function() {
-				var courseTileFocusables = [];
-
-				this.getContentChildren().forEach(function(contentChild) {
-					var courseTiles = Polymer.dom(contentChild).querySelectorAll('d2l-course-tile');
-
-					[].forEach.call(courseTiles, function(courseTile) {
-						Array.prototype.push.apply(courseTileFocusables, Polymer.dom(courseTile.root).querySelectorAll('a'));
-					});
-				});
-
-				return courseTileFocusables;
 			},
 			fetchEnrollments: true
 		});

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -72,6 +72,15 @@
 					this._rescaleCourseTileRegions(this._getOverlayWidth());
 				}
 			},
+			focusableNodesOverride: function() {
+				var courseTileFocusables = [];
+
+				Polymer.dom(this.root).querySelectorAll('d2l-course-tile').forEach(function(courseTile) {
+					Array.prototype.push.apply(courseTileFocusables, Polymer.dom(courseTile.root).querySelectorAll('a'));
+				});
+
+				return courseTileFocusables;
+			},
 			refresh: function() {
 				this.$.allEnrollmentsRequest.generateRequest();
 			},

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -99,25 +99,15 @@
 			],
 			ready: function() {
 				this._alertMessage = this.localize('noPinnedCoursesMessage');
-				this.$$('d2l-simple-overlay').focusableNodesOverride = this.focusableNodesOverride;
+
+				var overlay = this.$$('d2l-simple-overlay');
+				var allCourses = this.$$('d2l-all-courses');
+				overlay.focusableNodesOverride = allCourses.focusableNodesOverride.bind(allCourses);
 			},
 			attached: function() {
 				if (!this.delayLoad) {
 					this.$.pinnedCoursesRequest.generateRequest();
 				}
-			},
-			focusableNodesOverride: function() {
-				var courseTileFocusables = [];
-
-				this.getContentChildren().forEach(function(contentChild) {
-					var courseTiles = Polymer.dom(contentChild).querySelectorAll('d2l-course-tile');
-
-					[].forEach.call(courseTiles, function(courseTile) {
-						Array.prototype.push.apply(courseTileFocusables, Polymer.dom(courseTile.root).querySelectorAll('a'));
-					});
-				});
-
-				return courseTileFocusables;
 			},
 			onPinnedCoursesResponse: function(response) {
 				if (response.detail.status === 200) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -5,6 +5,7 @@
 <link rel="import" href="d2l-my-courses-styles.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-course-tile.html">
+<link rel="import" href="d2l-simple-overlay.html">
 <link rel="import" href="d2l-all-courses.html">
 <link rel="import" href="d2l-course-tile-region-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -55,12 +56,20 @@
 			{{localize('viewAllCourses')}}
 		</button>
 
-		<d2l-all-courses
-			enrollments-url="[[enrollmentsUrl]]"
-			pinned-courses-entities="{{pinnedCoursesEntities}}"
-			unpinned-courses-entities="{{unpinnedCoursesEntities}}"
-			locale="[[locale]]">
-		</d2l-all-courses>
+		<d2l-simple-overlay
+			id="all-courses"
+			title="{{localize('allCourses')}}"
+			locale="[[locale]]"
+			with-backdrop>
+
+			<d2l-all-courses
+				enrollments-url="[[enrollmentsUrl]]"
+				pinned-courses-entities="{{pinnedCoursesEntities}}"
+				unpinned-courses-entities="{{unpinnedCoursesEntities}}"
+				locale="[[locale]]">
+			</d2l-all-courses>
+		</d2l-simple-overlay>
+
 	</template>
 
 	<script>
@@ -90,11 +99,25 @@
 			],
 			ready: function() {
 				this._alertMessage = this.localize('noPinnedCoursesMessage');
+				this.$$('d2l-simple-overlay').focusableNodesOverride = this.focusableNodesOverride;
 			},
 			attached: function() {
 				if (!this.delayLoad) {
 					this.$.pinnedCoursesRequest.generateRequest();
 				}
+			},
+			focusableNodesOverride: function() {
+				var courseTileFocusables = [];
+
+				this.getContentChildren().forEach(function(contentChild) {
+					var courseTiles = Polymer.dom(contentChild).querySelectorAll('d2l-course-tile');
+
+					[].forEach.call(courseTiles, function(courseTile) {
+						Array.prototype.push.apply(courseTileFocusables, Polymer.dom(courseTile.root).querySelectorAll('a'));
+					});
+				});
+
+				return courseTileFocusables;
 			},
 			onPinnedCoursesResponse: function(response) {
 				if (response.detail.status === 200) {
@@ -127,7 +150,8 @@
 			openAllCoursesView: function(e) {
 				e.preventDefault();
 				e.stopPropagation();
-				this.$$('d2l-all-courses').open();
+				this.$$('d2l-simple-overlay').open();
+				this.$$('d2l-all-courses').refresh();
 			},
 			_getPinnedCoursesUrl: function(enrollmentsUrl) {
 				return enrollmentsUrl + '?filter=pinned';

--- a/demo/d2l-all-courses-demo.html
+++ b/demo/d2l-all-courses-demo.html
@@ -19,14 +19,6 @@
 	<body unresolved class="d2l-typography">
 		<main class="d2l-max-width">
 			<h1>d2l-all-courses demo</h1>
-			<script>
-				function openOverlay() {
-					var overlay = document.getElementById('all-courses');
-					overlay.open();
-				}
-			</script>
-			<button onclick="openOverlay()">Open All Courses view</button>
-
 			<d2l-all-courses
 				id="all-courses"
 				enrollments-url="all-courses.json"


### PR DESCRIPTION
This simplifies things a bit, as it presents d2l-all-courses as just a modified d2l-my-courses, which it kinda is. This should also enable removal of d2l-all-courses in the future if that's something we decide to do.