### PR TITLE
Fix Webkit image aliasing during transform

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -62,6 +62,11 @@
 		.course-image-container {
 			position: relative;
 			padding-top: 43%;
+			transition: filter 0.25s, -webkit-filter 0.25s;
+		}
+		.course-image-container.hover {
+			-webkit-filter: saturate(1.15);
+			filter: saturate(1.15);
 		}
 		.course-image {
 			position: absolute;
@@ -85,9 +90,10 @@
 			margin: auto;
 			transition: filter 0.25s, -webkit-filter 0.25s, transform 0.5s ease-in-out;
 		}
-		.course-image img.hover {
-			filter: contrast(1.15) saturate(1.15);
-			-webkit-filter: contrast(1.15) saturate(1.15);
+		.course-image-container.hover > .course-image img {
+			/* Ensure only one filter per layer to avoid aliasing bug in Webkit during transforms */
+			-webkit-filter: contrast(1.15);
+			filter: contrast(1.15);
 			transform: scale(1.1);
 		}
 		.course-text {

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -194,7 +194,7 @@
 			_setCourseTileHovered: function(isHovered) {
 				this.toggleClass('hover', isHovered, this.$$('.tile-container'));
 				this.toggleClass('hover', isHovered, this.$$('.hover-menu'));
-				this.toggleClass('hover', isHovered, this.$$('.course-image img'));
+				this.toggleClass('hover', isHovered, this.$$('.course-image-container'));
 			},
 			_onTouchMenuOpen: function() {
 				var courseTile = this.$$('.tile-container');


### PR DESCRIPTION
Fixes an issue in Webkit browsers where applying multiple filters in the same property and applying a transform causes aliasing/stepping, by distributing filters to parent elements so that each element has at most one filter applied.