### PR TITLE
fixes #55: using fork of app-localize-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "iron-icon": "PolymerElements/iron-icon#^1.0.8",
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
-    "app-localize-behavior": "PolymerElements/app-localize-behavior#^0.9.0",
+    "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.0.0",
     "d2l-icons": "^2.1.0",
     "d2l-offscreen": "^2.0.0",


### PR DESCRIPTION
@ryantmer: So the JavaScript error in IE10 (#55) ended up being contained to `app-localize-behavior`. I've created a defect for them and a pull request, but in the meantime I've forked and started pointing navigation at the fork. You'll have to do the same (this PR) since we share that dependency Bower-styles.