### PR TITLE
Fix for very wide images displaying incorrectly

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -82,6 +82,8 @@
 		}
 		.course-image img {
 			width: 100%;
+			height: 100%;
+			object-fit: cover;
 			position: absolute;
 			top: 0;
 			left: 0;

--- a/demo/all-courses.json
+++ b/demo/all-courses.json
@@ -168,7 +168,7 @@
           "rel": [
             "course-image"
           ],
-          "href": "http://lorempixel.com/100/100/"
+          "href": "http://lorempixel.com/500/100/"
         }
       ],
       "actions": [
@@ -255,7 +255,7 @@
           "rel": [
             "course-image"
           ],
-          "href": "http://lorempixel.com/400/200/"
+          "href": "http://lorempixel.com/100/500/"
         }
       ],
       "actions": [


### PR DESCRIPTION
Since it was being displayed with width: 100%, space (and therefore the grey background) was showing up above/below the image.