### PR TITLE
upgrading to offscreen 2.1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.0.0",
     "d2l-icons": "^2.1.0",
-    "d2l-offscreen": "^2.0.0",
+    "d2l-offscreen": "^2.1.0",
     "d2l-colors": "^2.0.0",
     "d2l-typography": "^4.0.0",
     "d2l-link": "^3.0.0"


### PR DESCRIPTION
Need to bump this as another thing in BSI needs a new feature in `2.1.0`. @ryantmer, @apalaniuk is it cool if I do a release of `my-courses` after this change is in and update BSI?