### PR TITLE
Simplify d2l-alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ text.
 
 Properties:
 
-- `visible`: Defines whether alert is visible. Can be a truthy value, or a
-function that returns a truthy value.
+- `visible` _Boolean_: Defines whether alert is visible.
 
 ### d2l-simple-overlay
 

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -5,7 +5,7 @@
 	<template>
 		<style include="d2l-alert-styles"></style>
 
-		<div class="message-wrapper" hidden$="{{_hideAlert}}">
+		<div class="message-wrapper" hidden="{{!visible}}">
 			<div class="message-highlight"></div>
 			<content></content>
 		</div>
@@ -17,18 +17,9 @@
 			is: 'd2l-alert',
 			properties: {
 				visible: {
-					type: Object,
-					value: function() {
-						return false;
-					}
-				},
-				_hideAlert: {
 					type: Boolean,
-					computed: '_checkAlertIsHidden(visible)'
+					value: false
 				}
-			},
-			_checkAlertIsHidden: function(isVisible) {
-				return !isVisible;
 			}
 		});
 	</script>

--- a/demo/d2l-alert-demo.html
+++ b/demo/d2l-alert-demo.html
@@ -19,7 +19,19 @@
 	<body unresolved class="d2l-typography">
 		<main class="d2l-max-width">
 			<h1>d2l-alert demo</h1>
-			<d2l-alert visible="true">This is a d2l-alert. It displays informational text.</d2l-alert>
+			<script>
+				function changeVisibility() {
+					var alert = document.getElementById('alert');
+
+					if (alert.hasAttribute('visible')) {
+						alert.removeAttribute('visible');
+					} else {
+						alert.setAttribute('visible', '');
+					}
+				}
+			</script>
+			<button onclick="changeVisibility()">Show/Hide Alert</button>
+			<d2l-alert id="alert" visible>This is a d2l-alert. It displays informational text.</d2l-alert>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
(I'll rebase this once #69 is merged, and it'll remove like 90% of this diff)

Just realized that d2l-alert was about 2x more complicated than it needs to be. Which, considering how un-complicated it is, meant it really wasn't that complicated. But, meh, might as well do the simpler way.