### PR TITLE
Update d2l-siren-parser-ui and remove static rels

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
-    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.0.0",
+    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-icons": "^2.1.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-colors": "^2.0.0",

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -191,7 +191,7 @@
 				// The enrollment is updated (i.e. this handler is called) upon a pin/unpin response as well, but
 				// there's no need to update the organization in that case
 				if (!this._organization) {
-					var organizationLink = enrollment.getLinkByRel('https://api.brightspace.com/rels/organization');
+					var organizationLink = enrollment.getLinkByRel(/\/organization$/);
 					this._organizationUrl = organizationLink.href + '?embedDepth=1';
 					this.$.organizationRequest.generateRequest();
 				}
@@ -209,7 +209,7 @@
 					}
 
 					this._organization = organization;
-					this._organizationHomepageUrl = organization.getLinkByRel('https://api.brightspace.com/rels/organization-homepage').href;
+					this._organizationHomepageUrl = organization.getLinkByRel(/\/organization-homepage$/).href;
 				}
 			},
 			onEnrollmentPinResponse: function(response) {


### PR DESCRIPTION
Changing the canonical namespace of an LMS can result in the rel changing (if it's a non-IANA, FQDN rel). To deal with this, I added the ability to use regexes when using the various helper methods.