### PR TITLE
Explicitly call out behavior name

### DIFF
--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -10,7 +10,7 @@
 		/*
 		* Behavior for elements that require localization, based on `app-localize-behavior`
 		*
-		* @polymerBehavior
+		* @polymerBehavior Polymer.D2L.MyCourses.LocalizeBehavior
 		*/
 		Polymer.D2L.MyCourses.LocalizeBehaviorImpl = {
 			properties: {


### PR DESCRIPTION
This appears to be a sort-of-bug, or at least an oversight, in Hydrolysis which results in some warnings about not finding the behaviour for behaviours that extend other behaviours. This can be avoided (and it's strictly more proper anyway) by explicitly labelling the behavior.