### PR TITLE
Update d2l-ajax-ui

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "polymer": "Polymer/polymer#^1.4.0",
     "iron-ajax": "PolymerElements/iron-ajax#^1.2.0",
-    "d2l-ajax": "Brightspace/d2l-ajax-ui#^1.1.0",
+    "d2l-ajax": "Brightspace/d2l-ajax-ui#^1.1.1",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-icon": "PolymerElements/iron-icon#^1.0.8",

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -155,6 +155,13 @@ describe('<d2l-course-tile>', function() {
 				'/organizations/1?embedDepth=1',
 				[200, {}, JSON.stringify(organization)]);
 
+			server.respondWith(
+				'GET',
+				'/d2l/lp/auth/xsrf-tokens',
+				[200, {}, JSON.stringify({
+					referrerToken: 'foo'
+				})]);
+
 			widget.$.organizationRequest.addEventListener('response', function() {
 				// Ensure organization has been received before doing tests
 				done();


### PR DESCRIPTION
This version includes the XSRF header on same-domain requests that aren't GET or HEAD, which is apparently a requirement of the LMS API routes. (We're using PUT to change the pin state, so this was a problem if not using canonical namespaces.)