### PR TITLE
Update d2l-loading-spinner

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,7 +42,7 @@
     "d2l-colors": "^2.0.0",
     "d2l-typography": "^4.0.0",
     "d2l-link": "^3.0.0",
-    "d2l-loading-spinner": "^3.0.1"
+    "d2l-loading-spinner": "^4.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-my-courses-styles.html
+++ b/d2l-my-courses-styles.html
@@ -8,7 +8,6 @@
 		<style>
 		:host {
 			display: block;
-			--d2l-loading-spinner-size: 100px;
 		}
 		@media not all and (hover: hover) {
 			:host {
@@ -35,6 +34,10 @@
 		}
 		d2l-alert {
 			margin-bottom: 30px;
+		}
+		d2l-loading-spinner {
+			display: block;
+			margin: auto;
 		}
 		</style>
 	</template>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -34,7 +34,7 @@
 			on-response="_onEnrollmentsSearchResponse">
 		</d2l-ajax>
 
-		<d2l-loading-spinner></d2l-loading-spinner>
+		<d2l-loading-spinner size="100"></d2l-loading-spinner>
 
 		<div class="my-courses-content d2l-hidden">
 			<d2l-alert visible="[[!_hasPinnedEnrollments]]">


### PR DESCRIPTION
BSI is using v4, might as well be consistent. Now supports "size" attribute, and requires some CSS to centre it.