### PR TITLE
Remove explicit enrollmentsUrl override

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -129,8 +129,6 @@
 			},
 			attached: function() {
 				if (!this.delayLoad) {
-					// TODO: Remove this override once the LMS is updated
-					this.enrollmentsUrl = '/d2l/api/hm/enrollments';
 					this.$.enrollmentsRootRequest.generateRequest();
 				}
 			},


### PR DESCRIPTION
The LMS is now setting this properly, so it can be removed from here.