### PR TITLE
Remove Fetch Enrollments button from demo

### DIFF
--- a/demo/d2l-my-courses-demo.html
+++ b/demo/d2l-my-courses-demo.html
@@ -19,16 +19,7 @@
 	<body unresolved class="d2l-typography">
 		<main class="d2l-max-width">
 			<h1>d2l-my-courses demo</h1>
-			<script>
-				function fetchEnrollments() {
-					var widget = document.getElementById('my-courses');
-					// Skip loading enrollments root until the explicit enrollmentsUrl override is removed from the widget
-					widget._enrollmentsSearchUrl = 'enrollmentsSearchResponse.json';
-					widget.$.enrollmentsSearchRequest.generateRequest();
-				}
-			</script>
-			<button onclick="fetchEnrollments()" style="margin-bottom: 20px;">Fetch Enrollments</button>
-			<d2l-my-courses id="my-courses" enrollments-url="enrollments.json" delay-load></d2l-my-courses>
+			<d2l-my-courses id="my-courses" enrollments-url="enrollmentsRootResponse.json"></d2l-my-courses>
 		</main>
 	</body>
 </html>


### PR DESCRIPTION
There's no longer an override, so we can do the whole root -> search -> results call chain, rather than having to skip the root call.

Missed this in #82.