### PR TITLE
Fix hidden on d2l-alert

### DIFF
--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -63,7 +63,15 @@
 				*/
 				visible: {
 					type: Boolean,
-					value: false
+					value: false,
+					observer: '_visibleChanged'
+				}
+			},
+			_visibleChanged: function(visible) {
+				if (visible) {
+					this.style.display = 'block';
+				} else {
+					this.style.display = 'none';
 				}
 			}
 		});

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -14,7 +14,6 @@
 		<style>
 			:host {
 				@apply(--d2l-small-text);
-				display: block;
 			}
 			.message-wrapper {
 				position: relative;
@@ -63,15 +62,7 @@
 				*/
 				visible: {
 					type: Boolean,
-					value: false,
-					observer: '_visibleChanged'
-				}
-			},
-			_visibleChanged: function(visible) {
-				if (visible) {
-					this.style.display = 'block';
-				} else {
-					this.style.display = 'none';
+					value: false
 				}
 			}
 		});


### PR DESCRIPTION
Turns out that elements that have hidden=false are still kinda-displayed, in that they still take up space for their padding/margin. Use display:none to overcome this (still going to keep hidden=true/false, since it's a more semantic meaning).