### PR TITLE
US72258 Recent courses UI

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -37,7 +37,7 @@
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
-    "d2l-icons": "^2.1.0",
+    "d2l-icons": "^2.4.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-colors": "^2.0.0",
     "d2l-typography": "^4.0.0",

--- a/d2l-course-list-item.html
+++ b/d2l-course-list-item.html
@@ -73,7 +73,7 @@ See the course tile docs for an important note about and enrollment vs an organi
 				* Course list item enrollment
 				*
 				* When the enrollment is set, the list item will automatically fetch information about the
-				* organization the enrollment is is.
+				* organization the enrollment is related to.
 				*
 				* @type {Entity}
 				*/

--- a/d2l-course-list-item.html
+++ b/d2l-course-list-item.html
@@ -56,12 +56,8 @@ See the course tile docs for an important note about and enrollment vs an organi
 			<div class="course-image">
 				<img aria-hidden="true" />
 			</div>
-			<div>
-				{{_organization.properties.name}}
-			</div>
-			<div class="course-code">
-				{{_organization.properties.code}}
-			</div>
+			<div class="course-text">{{_organization.properties.name}}</div>
+			<div class="course-code">{{_organization.properties.code}}</div>
 		</a>
 
 	</template>

--- a/d2l-course-list-item.html
+++ b/d2l-course-list-item.html
@@ -12,12 +12,21 @@ See the course tile docs for an important note about and enrollment vs an organi
 	<style>
 		:host {
 			display: block;
-			padding-bottom: 10px;
+			overflow: auto;
+			margin-bottom: 10px;
 			clear: both;
 		}
+		a {
+			text-decoration: none;
+			font-weight: 400;
+			color: var(--d2l-color-ferrite);
+		}
+		.course-code {
+			font-weight: 300;
+		}
 		.course-image {
-			height: 43px;
-			width: 100px;
+			height: 64.5px;
+			width: 150px;
 			border-top-left-radius: 10px;
 			border-top-right-radius: 10px;
 			background: var(--d2l-color-pressicus);
@@ -31,9 +40,6 @@ See the course tile docs for an important note about and enrollment vs an organi
 			height: 100%;
 			object-fit: cover;
 			margin: auto;
-		}
-		.course-text {
-			line-height: 43px;
 		}
 	</style>
 
@@ -50,8 +56,11 @@ See the course tile docs for an important note about and enrollment vs an organi
 			<div class="course-image">
 				<img aria-hidden="true" />
 			</div>
-			<div class="course-text d2l-heading-4">
+			<div>
 				{{_organization.properties.name}}
+			</div>
+			<div class="course-code">
+				{{_organization.properties.code}}
 			</div>
 		</a>
 

--- a/d2l-course-list-item.html
+++ b/d2l-course-list-item.html
@@ -1,0 +1,71 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
+
+<!--
+`<d2l-course-list-item>` is a single entry in a `<d2l-course-list>`.
+
+This is really just a simple list element - similar to a course tile, but in a more traditional list view.
+See the course tile docs for an important note about and enrollment vs an organization.
+-->
+<dom-module id="d2l-course-list-item">
+	<template>
+
+		<d2l-ajax
+			id="organizationRequest"
+			url="[[_organizationUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onOrganizationResponse">
+		</d2l-ajax>
+
+		<a href="[[_organizationHomepageUrl]]">
+			{{_organization.properties.name}}
+		</a>
+
+	</template>
+
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-course-list-item',
+
+			properties: {
+				/*
+				* Course list item enrollment
+				*
+				* When the enrollment is set, the list item will automatically fetch information about the
+				* organization the enrollment is is.
+				*
+				* @type {Entity}
+				*/
+				enrollment: {
+					type: Object,
+					observer: '_enrollmentChanged'
+				},
+				/*
+				* The URL to fetch the `_organization` Entity from (determined from the `enrollment`'s Links)
+				* @type {String}
+				*/
+				_organizationUrl: {
+					type: String
+				}
+			},
+			_enrollmentChanged: function(enrollment) {
+				var organizationLink = enrollment.getLinkByRel(/\/organization$/);
+				this._organizationUrl = organizationLink.href + '?embedDepth=1';
+				this.$.organizationRequest.generateRequest();
+			},
+			_onOrganizationResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var organization = parser.parse(response.detail.xhr.response);
+
+					this._organization = organization;
+					this._organizationHomepageUrl = organization.getLinkByRel(/\/organization-homepage$/).href;
+				}
+
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-course-list-item.html
+++ b/d2l-course-list-item.html
@@ -9,6 +9,34 @@ This is really just a simple list element - similar to a course tile, but in a m
 See the course tile docs for an important note about and enrollment vs an organization.
 -->
 <dom-module id="d2l-course-list-item">
+	<style>
+		:host {
+			display: block;
+			padding-bottom: 10px;
+			clear: both;
+		}
+		.course-image {
+			height: 43px;
+			width: 100px;
+			border-top-left-radius: 10px;
+			border-top-right-radius: 10px;
+			background: var(--d2l-color-pressicus);
+			overflow: hidden;
+			z-index: 0;
+			float: left;
+			margin-right: 10px;
+		}
+		.course-image img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+			margin: auto;
+		}
+		.course-text {
+			line-height: 43px;
+		}
+	</style>
+
 	<template>
 
 		<d2l-ajax
@@ -18,8 +46,13 @@ See the course tile docs for an important note about and enrollment vs an organi
 			on-iron-ajax-response="_onOrganizationResponse">
 		</d2l-ajax>
 
-		<a href="[[_organizationHomepageUrl]]">
-			{{_organization.properties.name}}
+		<a href$="[[_organizationHomepageUrl]]">
+			<div class="course-image">
+				<img aria-hidden="true" />
+			</div>
+			<div class="course-text d2l-heading-4">
+				{{_organization.properties.name}}
+			</div>
 		</a>
 
 	</template>
@@ -44,6 +77,20 @@ See the course tile docs for an important note about and enrollment vs an organi
 					observer: '_enrollmentChanged'
 				},
 				/*
+				* The organization that the `enrollment` relates to
+				* @type {Entity}
+				*/
+				_organization: {
+					type: Object
+				},
+				/*
+				* URL of the `organization` homepage
+				* @type {String}
+				*/
+				_organizationHomepageUrl: {
+					type: String
+				},
+				/*
 				* The URL to fetch the `_organization` Entity from (determined from the `enrollment`'s Links)
 				* @type {String}
 				*/
@@ -60,6 +107,13 @@ See the course tile docs for an important note about and enrollment vs an organi
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var organization = parser.parse(response.detail.xhr.response);
+
+					var courseImageEntity = organization.getSubEntityByClass('course-image');
+					if (courseImageEntity) {
+						var courseImageLink = courseImageEntity.getLinkByRel('alternate');
+						var courseImage = this.$$('.course-image img');
+						Polymer.dom(courseImage).setAttribute('src', courseImageLink.href);
+					}
 
 					this._organization = organization;
 					this._organizationHomepageUrl = organization.getLinkByRel(/\/organization-homepage$/).href;

--- a/d2l-course-list.html
+++ b/d2l-course-list.html
@@ -7,6 +7,13 @@
 `<d2l-course-list>` creates a list of `<d2l-course-list-item`> elements.
 -->
 <dom-module id="d2l-course-list">
+	<style>
+		ul {
+			list-style-type: none;
+			padding-left: 0;
+		}
+	</style>
+
 	<template>
 		<d2l-ajax
 			id="enrollmentsRequest"

--- a/d2l-course-list.html
+++ b/d2l-course-list.html
@@ -1,0 +1,70 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="d2l-course-list-item.html">
+
+<!--
+`<d2l-course-list>` creates a list of `<d2l-course-list-item`> elements.
+-->
+<dom-module id="d2l-course-list">
+	<template>
+		<d2l-ajax
+			id="enrollmentsRequest"
+			url="[[enrollmentsUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onEnrollmentsResponse">
+		</d2l-ajax>
+
+		<ul>
+			<template is="dom-repeat" items="[[_enrollments]]">
+				<li>
+					<d2l-course-list-item
+						enrollment="[[item]]">
+					</d2l-course-list-item>
+				</li>
+			</template>
+		</ul>
+	</template>
+
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-course-list',
+
+			properties: {
+				/*
+				* URL that is called to fetch the enrollments to list
+				* @type {String}
+				*/
+				enrollmentsUrl: {
+					type: String,
+					observer: '_enrollmentsUrlChanged'
+				},
+				/*
+				* Set of enrollment entities for which to display course-list-items
+				* @type {Array<Entity>}
+				*/
+				_enrollments: {
+					type: Array,
+					notify: true,
+					value: function() {
+						return [];
+					}
+				}
+			},
+			_enrollmentsUrlChanged: function() {
+				this.$.enrollmentsRequest.generateRequest();
+			},
+			_onEnrollmentsResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var enrollments = parser.parse(response.detail.xhr.response);
+
+					this._enrollments = enrollments.entities;
+				}
+			}
+		});
+	</script>
+
+</dom-module>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -56,7 +56,7 @@
 				overflow: auto;
 			}
 			.button-bar .view-button {
-				margin-right: 10px;
+				margin-right: 25px;
 				float: left;
 				display: block;
 				position: relative;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -50,8 +50,35 @@
 			.hidden {
 				display: none;
 			}
+			.button-bar {
+				margin-bottom: 10px;
+				display: block;
+				overflow: auto;
+			}
+			.button-bar .view-button {
+				margin-right: 10px;
+				float: left;
+				display: block;
+				position: relative;
+			}
+			.view-button {
+				@apply(--d2l-small-text);
+				/* overrides to d2l-small-text */
+				font-size: 1rem;
+				color: var(--d2l-color-galena);
+				/* end overrides */
+				background: none;
+				border: none;
+				padding: 0;
+				cursor: pointer;
+			}
+			.view-button-selected {
+				font-weight: 700;
+				color: var(--d2l-color-ferrite);
+			}
 			d2l-alert {
-				margin-bottom: 30px;
+				padding-bottom: 30px;
+				clear: both;
 			}
 			d2l-loading-spinner {
 				display: block;
@@ -76,6 +103,25 @@
 		<d2l-loading-spinner size="100"></d2l-loading-spinner>
 
 		<div class="my-courses-content hidden">
+			<div class="button-bar">
+				<button
+					id="recentViewButton"
+					class="view-button view-button-selected"
+					on-tap="_selectRecentView">
+					Last Accessed
+				</button>
+				<button
+					id="tileViewButton"
+					class="view-button"
+					on-tap="_selectTileView">
+					My Courses
+				</button>
+			</div>
+
+			<d2l-course-list
+				enrollments-url="[[_recentEnrollmentsSearchUrl]]">
+			</d2l-course-list>
+
 			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
 				{{_alertMessage}}
 				<a
@@ -84,7 +130,6 @@
 					hidden$="[[_hasEnrollments]]"
 					on-tap="_refreshPage">{{localize('refresh')}}</a>
 			</d2l-alert>
-
 			<d2l-course-tile-grid
 				enrollments="{{pinnedEnrollments}}">
 			</d2l-course-tile-grid>
@@ -96,10 +141,6 @@
 				{{localize('viewAllCourses')}}
 			</button>
 		</div>
-
-		<d2l-course-list
-			enrollments-url="[[_recentEnrollmentsSearchUrl]]">
-		</d2l-course-list>
 
 		<d2l-simple-overlay
 			id="all-courses"
@@ -164,6 +205,14 @@
 				*/
 				_recentEnrollmentsSearchUrl: {
 					type: String
+				},
+				/*
+				* Currently-selected tab - set by paper-tabs, used by iron-pages
+				* @type {Number}
+				*/
+				_selectedTab: {
+					type: Number,
+					value: 0
 				}
 			},
 			behaviors: [
@@ -174,6 +223,10 @@
 			],
 			ready: function() {
 				this._alertMessage = this.localize('noCoursesMessage');
+
+				// Hide the secondary (tile) view initially
+				this.toggleClass('hidden', true, this.$$('d2l-alert'));
+				this.toggleClass('hidden', true, this.$$('d2l-course-tile-grid'));
 
 				var overlay = this.$$('d2l-simple-overlay');
 				var allCourses = this.$$('d2l-all-courses');
@@ -209,7 +262,7 @@
 					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 					this.$.enrollmentsSearchRequest.generateRequest();
 
-					query.pageSize = 10;
+					query.pageSize = 5;
 					query.sortBy = 'lastAccessed';
 					this._recentEnrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 				} else {
@@ -261,6 +314,20 @@
 			},
 			_refreshPage: function() {
 				document.location.reload(true);
+			},
+			_selectRecentView: function() {
+				this.toggleClass('hidden', true, this.$$('d2l-alert'));
+				this.toggleClass('hidden', true, this.$$('d2l-course-tile-grid'));
+				this.toggleClass('hidden', false, this.$$('d2l-course-list'));
+				this.toggleClass('view-button-selected', true, this.$.recentViewButton);
+				this.toggleClass('view-button-selected', false, this.$.tileViewButton);
+			},
+			_selectTileView: function() {
+				this.toggleClass('hidden', false, this.$$('d2l-alert'));
+				this.toggleClass('hidden', false, this.$$('d2l-course-tile-grid'));
+				this.toggleClass('hidden', true, this.$$('d2l-course-list'));
+				this.toggleClass('view-button-selected', false, this.$.recentViewButton);
+				this.toggleClass('view-button-selected', true, this.$.tileViewButton);
 			},
 			_showContent: function() {
 				this.toggleClass('hidden', true, this.$$('d2l-loading-spinner'));

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -2,13 +2,14 @@
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-link/d2l-link.html">
+<link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-simple-overlay.html">
 <link rel="import" href="d2l-all-courses.html">
+<link rel="import" href="d2l-course-tile-grid.html">
+<link rel="import" href="d2l-course-list.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-course-management-behavior.html">
-<link rel="import" href="d2l-course-tile-grid.html">
-<link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 
 <!--
 `<d2l-my-courses>` is the main component for My Courses widget
@@ -77,22 +78,28 @@
 		<div class="my-courses-content hidden">
 			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
 				{{_alertMessage}}
-				<a is="d2l-link"
+				<a
+					is="d2l-link"
 					href="Javascript:void(0);"
-				hidden$="[[_hasEnrollments]]"
-				on-tap="_refreshPage">{{localize('refresh')}}</a>
+					hidden$="[[_hasEnrollments]]"
+					on-tap="_refreshPage">{{localize('refresh')}}</a>
 			</d2l-alert>
 
 			<d2l-course-tile-grid
-			enrollments="{{pinnedEnrollments}}">
+				enrollments="{{pinnedEnrollments}}">
 			</d2l-course-tile-grid>
 
-			<button class="all-courses-button"
-			hidden$="{{!_hasEnrollments}}"
-			on-tap="_openAllCoursesView">
+			<button
+				class="all-courses-button"
+				hidden$="{{!_hasEnrollments}}"
+				on-tap="_openAllCoursesView">
 				{{localize('viewAllCourses')}}
 			</button>
 		</div>
+
+		<d2l-course-list
+			enrollments-url="[[_recentEnrollmentsSearchUrl]]">
+		</d2l-course-list>
 
 		<d2l-simple-overlay
 			id="all-courses"
@@ -150,6 +157,13 @@
 				*/
 				_enrollmentsSearchUrl: {
 					type: String
+				},
+				/*
+				* URL constructed to fetch a user's recent enrollments with the enrollments search Action
+				* @type {String}
+				*/
+				_recentEnrollmentsSearchUrl: {
+					type: String
 				}
 			},
 			behaviors: [
@@ -196,13 +210,21 @@
 					if (searchAction.hasFieldByName('embedDepth')) {
 						query.embedDepth = 1;
 					}
+
 					var queryString = Object.keys(query).map(function(key) {
 						return key + '=' + query[key];
 					}).join('&');
-
-					this._enrollmentsSearchUrl += queryString;
-
+					this._enrollmentsSearchUrl = searchAction.href + '?' + queryString;
 					this.$.enrollmentsSearchRequest.generateRequest();
+
+					// Update the recent courses list URL to sort by last accessed
+					if (searchAction.hasFieldByName('sortBy')) {
+						query.sortBy = 'lastAccessed';
+					}
+					queryString = Object.keys(query).map(function(key) {
+						return key + '=' + query[key];
+					}).join('&');
+					this._recentEnrollmentsSearchUrl = searchAction.href + '?' + queryString;
 				} else {
 					this._showContent();
 				}
@@ -226,6 +248,7 @@
 
 					this.set('pinnedEnrollments', pinnedEnrollments);
 					this.set('unpinnedEnrollments', unpinnedEnrollments);
+					this.set('enrollments', enrollmentEntities);
 
 					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
 					this._hasEnrollments = this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -107,13 +107,15 @@
 				<button
 					id="recentViewButton"
 					class="view-button view-button-selected"
-					on-tap="_selectRecentView">
+					on-tap="_selectRecentView"
+					aria-pressed="true">
 					Last Accessed
 				</button>
 				<button
 					id="tileViewButton"
 					class="view-button"
-					on-tap="_selectTileView">
+					on-tap="_selectTileView"
+					aria-pressed="false">
 					My Courses
 				</button>
 			</div>
@@ -182,38 +184,22 @@
 				* URL that is called by the widget to fetch enrollments
 				* @type {String}
 				*/
-				enrollmentsUrl: {
-					type: String
-				},
+				enrollmentsUrl: String,
 				/*
 				* Message to display in alert if no enrollments are found
 				* @type {String}
 				*/
-				_alertMessage: {
-					type: String
-				},
+				_alertMessage: String,
 				/*
 				* URL constructed to fetch a user's enrollments with the enrollments search Action
 				* @type {String}
 				*/
-				_enrollmentsSearchUrl: {
-					type: String
-				},
+				_enrollmentsSearchUrl: String,
 				/*
 				* URL constructed to fetch a user's recent enrollments with the enrollments search Action
 				* @type {String}
 				*/
-				_recentEnrollmentsSearchUrl: {
-					type: String
-				},
-				/*
-				* Currently-selected tab - set by paper-tabs, used by iron-pages
-				* @type {Number}
-				*/
-				_selectedTab: {
-					type: Number,
-					value: 0
-				}
+				_recentEnrollmentsSearchUrl: String
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -322,6 +308,8 @@
 				this.toggleClass('hidden', false, this.$$('d2l-course-list'));
 				this.toggleClass('view-button-selected', true, this.$.recentViewButton);
 				this.toggleClass('view-button-selected', false, this.$.tileViewButton);
+				this.$.recentViewButton.setAttribute('aria-pressed', true);
+				this.$.tileViewButton.setAttribute('aria-pressed', false);
 			},
 			_selectTileView: function() {
 				this.toggleClass('hidden', false, this.$$('d2l-alert'));
@@ -329,6 +317,8 @@
 				this.toggleClass('hidden', true, this.$$('d2l-course-list'));
 				this.toggleClass('view-button-selected', false, this.$.recentViewButton);
 				this.toggleClass('view-button-selected', true, this.$.tileViewButton);
+				this.$.recentViewButton.setAttribute('aria-pressed', false);
+				this.$.tileViewButton.setAttribute('aria-pressed', true);
 			},
 			_showContent: function() {
 				this.toggleClass('hidden', true, this.$$('d2l-loading-spinner'));

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -263,7 +263,8 @@
 					this.$.enrollmentsSearchRequest.generateRequest();
 
 					query.pageSize = 5;
-					query.sortBy = 'lastAccessed';
+					query.sortField = 'lastAccessed';
+					query.sortDescending = true;
 					this._recentEnrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 				} else {
 					this._showContent();

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -201,30 +201,17 @@
 					}
 
 					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
-					this._enrollmentsSearchUrl = searchAction.href + '?';
 
-					var query = {};
-					if (searchAction.hasFieldByName('pageSize')) {
-						query.pageSize = 20;
-					}
-					if (searchAction.hasFieldByName('embedDepth')) {
-						query.embedDepth = 1;
-					}
-
-					var queryString = Object.keys(query).map(function(key) {
-						return key + '=' + query[key];
-					}).join('&');
-					this._enrollmentsSearchUrl = searchAction.href + '?' + queryString;
+					var query = {
+						pageSize: 20,
+						embedDepth: 1
+					};
+					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 					this.$.enrollmentsSearchRequest.generateRequest();
 
-					// Update the recent courses list URL to sort by last accessed
-					if (searchAction.hasFieldByName('sortBy')) {
-						query.sortBy = 'lastAccessed';
-					}
-					queryString = Object.keys(query).map(function(key) {
-						return key + '=' + query[key];
-					}).join('&');
-					this._recentEnrollmentsSearchUrl = searchAction.href + '?' + queryString;
+					query.pageSize = 10;
+					query.sortBy = 'lastAccessed';
+					this._recentEnrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 				} else {
 					this._showContent();
 				}

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -16,6 +16,30 @@
 	*/
 	Polymer.D2L.MyCourses.UtilityBehavior = {
 		/*
+		* Creates a URL with a query from an Action and an object of required parameters
+		* @param {Action} action
+		* @param {Object} parameters Query parameters, as { parameterName: desiredValue, ... }
+		*/
+		createActionUrl: function(action, parameters) {
+			parameters = parameters || {};
+			action.fields = action.fields || [];
+			var query = {};
+
+			action.fields.forEach(function(field) {
+				if (parameters.hasOwnProperty(field.name)) {
+					query[field.name] = parameters[field.name];
+				} else {
+					query[field.name] = field.value;
+				}
+			});
+
+			var queryString = Object.keys(query).map(function(key) {
+				return key + '=' + query[key];
+			}).join('&');
+
+			return queryString ? action.href + '?' + queryString : action.href;
+		},
+		/*
 		* Creates a unique identifier for an enrollment (really just the self Link href)
 		* @param {Entity} enrollment
 		* @return {String}

--- a/demo/enrollmentsRootResponse.json
+++ b/demo/enrollmentsRootResponse.json
@@ -25,9 +25,14 @@
           "value": 0
         },
         {
-          "name": "sortBy",
+          "name": "sortField",
           "type": "radio",
           "value": ""
+        },
+        {
+          "name": "sortDescending",
+          "type": "checkbox",
+          "value": false
         }
       ]
     }

--- a/demo/enrollmentsRootResponse.json
+++ b/demo/enrollmentsRootResponse.json
@@ -23,6 +23,11 @@
           "name": "embedDepth",
           "type": "number",
           "value": 0
+        },
+        {
+          "name": "sortBy",
+          "type": "radio",
+          "value": ""
         }
       ]
     }

--- a/test/d2l-course-list-item/d2l-course-list-item.html
+++ b/test/d2l-course-list-item/d2l-course-list-item.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="../../../d2l-siren-parser/d2l-siren-parser.html">
+		<link rel="import" href="../../d2l-course-list-item.html">
+	</head>
+	<body>
+		<test-fixture id="d2l-course-list-item-fixture">
+			<template>
+				<d2l-course-list-item></d2l-course-list-item>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-course-list-item.js"></script>
+	</body>
+</html>

--- a/test/d2l-course-list-item/d2l-course-list-item.js
+++ b/test/d2l-course-list-item/d2l-course-list-item.js
@@ -1,0 +1,134 @@
+/* global describe, it, before, beforeEach, afterEach, fixture, expect, sinon */
+
+'use strict';
+
+describe('d2l-course-list-item', function() {
+	var server,
+		widget,
+		enrollment = {
+			class: ['pinned', 'enrollment'],
+			rel: ['https://api.brightspace.com/rels/user-enrollment'],
+			actions: [{
+				name: 'unpin-course',
+				method: 'PUT',
+				href: '/enrollments/users/169/organizations/1',
+				fields: [{
+					name: 'pinned',
+					type: 'hidden',
+					value: false
+				}]
+			}],
+			links: [{
+				rel: ['https://api.brightspace.com/rels/organization'],
+				href: '/organizations/1'
+			}, {
+				rel: ['self'],
+				href: '/enrollments/users/169/organizations/1'
+			}]
+		},
+		organization = {
+			class: ['active', 'course-offering'],
+			properties: {
+				name: 'Course name',
+				code: 'COURSE100'
+			},
+			links: [{
+				rel: ['self'],
+				href: '/organizations/1'
+			}, {
+				rel: ['https://api.brightspace.com/rels/organization-homepage'],
+				href: 'http://example.com/1/home',
+				type: 'text/html'
+			}],
+			entities: [{
+				class: ['course-image'],
+				propeties: {
+					name: '1.jpg',
+					type: 'image/jpeg'
+				},
+				rel: ['https://api.brightspace.com/rels/organization-image'],
+				links: [{
+					rel: ['self'],
+					href: '/organizations/1/image'
+				}, {
+					rel: ['alternate'],
+					href: ''
+				}]
+			}]
+		},
+		enrollmentEntity,
+		organizationEntity;
+
+	before(function() {
+		var parser = document.createElement('d2l-siren-parser');
+		enrollmentEntity = parser.parse(enrollment);
+		organizationEntity = parser.parse(organization);
+	});
+
+	beforeEach(function() {
+		server = sinon.fakeServer.create();
+		server.respondImmediately = true;
+
+		widget = fixture('d2l-course-list-item-fixture');
+	});
+
+	afterEach(function() {
+		server.restore();
+	});
+
+	it('loads element', function() {
+		expect(widget).to.exist;
+	});
+
+	it('should fetch the organization when the enrollment is changed', function(done) {
+		server.respondWith(
+			'GET',
+			'/organizations/1?embedDepth=1',
+			[200, {}, JSON.stringify(organization)]);
+
+		var organizationSpy = sinon.spy(widget.$.organizationRequest, 'generateRequest');
+
+		widget.$.organizationRequest.addEventListener('iron-ajax-response', function() {
+			expect(organizationSpy.called);
+			done();
+		});
+
+		widget.enrollment = enrollmentEntity;
+	});
+
+	describe('setting the enrollment attribute', function() {
+		beforeEach(function(done) {
+			server.respondWith(
+				'GET',
+				'/organizations/1?embedDepth=1',
+				[200, {}, JSON.stringify(organization)]);
+
+			widget.$.organizationRequest.addEventListener('iron-ajax-response', function() {
+				// Ensure organization has been received before doing tests
+				done();
+			});
+
+			widget.enrollment = enrollmentEntity;
+		});
+
+		it('should parse and update the internal Siren representation', function() {
+			expect(widget._organization.properties).to.be.an('object');
+		});
+
+		it('should have the correct href', function() {
+			var anchor = widget.$$('a');
+			var homepageLink = organizationEntity.getLinkByRel('https://api.brightspace.com/rels/organization-homepage');
+			expect(anchor.href).to.equal(homepageLink.href);
+		});
+
+		it('should update the course name', function() {
+			var courseText = widget.$$('.course-text');
+			expect(courseText.innerHTML).to.equal(organizationEntity.properties.name);
+		});
+
+		it('should hide image from screen readers', function() {
+			var courseImage = widget.$$('.course-image img');
+			expect(courseImage.getAttribute('aria-hidden')).to.equal('true');
+		});
+	});
+});

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -193,6 +193,24 @@ describe('d2l-my-courses', function() {
 			});
 		});
 
+		it('should set the request URL for lastAccessed courses, sortDescending', function(done) {
+			server.respondWith(
+				'GET',
+				widget.enrollmentsUrl,
+				function(req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					req.respond(200, {}, JSON.stringify(enrollmentsRootResponse));
+				});
+
+			widget.$.enrollmentsRootRequest.generateRequest();
+
+			widget.$.enrollmentsRootRequest.addEventListener('iron-ajax-response', function() {
+				expect(widget._recentEnrollmentsSearchUrl).to.match(/sortField=lastAccessed/);
+				expect(widget._recentEnrollmentsSearchUrl).to.match(/sortDescending=true/);
+				done();
+			});
+		});
+
 		it('should rescale the course tile grid on search response', function(done) {
 			server.respondWith(
 				'GET',

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -27,9 +27,13 @@ describe('d2l-my-courses', function() {
 					type: 'number',
 					value: 0
 				}, {
-					name: 'sortBy',
+					name: 'sortField',
 					type: 'radio',
 					value: ''
+				}, {
+					name: 'sortDescending',
+					type: 'checkbox',
+					value: false
 				}]
 			}],
 			links: [{

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -8,7 +8,6 @@ describe('d2l-my-courses', function() {
 		// Using relative URLs here so that d2l-ajax just uses cookies (no need to mock the token fetching this way)
 		rootHref = '/enrollments',
 		searchHref = '/enrollments/users/169',
-		searchQuery = '?pageSize=20&embedDepth=1',
 		enrollmentsRootResponse = {
 			class: ['enrollments', 'root'],
 			actions: [{
@@ -27,6 +26,10 @@ describe('d2l-my-courses', function() {
 					name: 'embedDepth',
 					type: 'number',
 					value: 0
+				}, {
+					name: 'sortBy',
+					type: 'radio',
+					value: ''
 				}]
 			}],
 			links: [{
@@ -169,7 +172,7 @@ describe('d2l-my-courses', function() {
 
 			server.respondWith(
 				'GET',
-				searchHref + searchQuery,
+				new RegExp(searchHref),
 				function(req) {
 					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
 					req.respond(200, {}, JSON.stringify(enrollmentsSearchResponse));
@@ -197,7 +200,7 @@ describe('d2l-my-courses', function() {
 
 			server.respondWith(
 				'GET',
-				searchHref + searchQuery,
+				new RegExp(searchHref),
 				function(req) {
 					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
 					req.respond(200, {}, JSON.stringify(enrollmentsSearchResponse));
@@ -224,7 +227,7 @@ describe('d2l-my-courses', function() {
 
 			server.respondWith(
 				'GET',
-				searchHref + searchQuery,
+				new RegExp(searchHref),
 				function(req) {
 					req.respond(200, {}, JSON.stringify(noEnrollmentsResponse));
 				});
@@ -248,7 +251,7 @@ describe('d2l-my-courses', function() {
 
 			server.respondWith(
 				'GET',
-				searchHref + searchQuery,
+				new RegExp(searchHref),
 				function(req) {
 					req.respond(200, {}, JSON.stringify(noPinnedEnrollmentsResponse));
 				});
@@ -274,7 +277,7 @@ describe('d2l-my-courses', function() {
 
 			server.respondWith(
 				'GET',
-				searchHref + searchQuery,
+				new RegExp(searchHref),
 				function(req) {
 					req.respond(200, {}, JSON.stringify(enrollmentsSearchResponse));
 				});

--- a/test/d2l-utility-behavior/d2l-utility-behavior.js
+++ b/test/d2l-utility-behavior/d2l-utility-behavior.js
@@ -37,9 +37,37 @@ describe('d2l-utility-behavior', function() {
 		component = fixture('default-fixture');
 	});
 
-	it('should get the unique enrollment ID based off the self link', function() {
-		var id = component.getEnrollmentIdentifier(enrollmentEntity);
+	describe('createActionUrl', function() {
+		it('should return the URL with default values if no parameters are specified', function() {
+			var url = component.createActionUrl(enrollmentEntity.getActionByName('unpin-course'));
 
-		expect(id).to.equal(enrollment.links[1].href);
+			expect(url).to.equal(enrollment.actions[0].href + '?pinned=false');
+		});
+
+		it('should return the URL with the specified query parameter(s)', function() {
+			var url = component.createActionUrl(
+				enrollmentEntity.getActionByName('unpin-course'),
+				{ pinned: 'foo' }
+			);
+
+			expect(url).to.equal(enrollment.actions[0].href + '?pinned=foo');
+		});
+
+		it('should not add any fields that are not on the action', function() {
+			var url = component.createActionUrl(
+				enrollmentEntity.getActionByName('unpin-course'),
+				{ foo: 'bar' }
+			);
+
+			expect(url).to.not.match(/foo=bar/);
+		});
+	});
+
+	describe('getEnrollmentIdentifier', function() {
+		it('should get the unique enrollment ID based off the self link', function() {
+			var id = component.getEnrollmentIdentifier(enrollmentEntity);
+
+			expect(id).to.equal(enrollment.links[1].href);
+		});
 	});
 });

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
 			WCT.loadSuites([
 				'./d2l-alert/d2l-alert.html',
 				'./d2l-all-courses/d2l-all-courses.html',
+				'./d2l-course-list-item/d2l-course-list-item.html',
 				'./d2l-course-tile/d2l-course-tile.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
 				'./d2l-my-courses/d2l-my-courses.html',


### PR DESCRIPTION
API changes for this were just merged, so you'll need to pull/rebuild to get it to work properly.

Introduced the `d2l-course-list` and `d2l-course-list-item` - these are basically just different views of the course tile/course tile grid we already have, with similar functionality. I'd imagine could probably be factored out to some degree, but I'd rather not make this already-large-PR even larger =/