### PR TITLE
Pinning FF46 due to wct-local

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js:
 - 4
 sudo: false
 addons:
-  firefox: "47.0.1"
+  firefox: 46.0
 before_script:
 - npm run test:lint:js && npm run test:lint:wc
 script:


### PR DESCRIPTION
See https://github.com/Polymer/wct-local/commit/c3bfc75013a2d0b42700c805f3da57162e4f2017 for details; Selenium + FF47 broke, it was fixed in FF 47.0.1, but then broken again in 48, so wct-local is sticking with <=46 until that's all sorted out.