### PR TITLE
Don't show Last Accessed for <20 enrollments

### DIFF
--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -97,6 +97,17 @@
 				_hasEnrollments: {
 					type: Boolean,
 					value: false
+				},
+				/*
+				* True when user has "a lot" of enrollments.
+				*
+				* Used to determine whether to show recent courses list as well as tile view.
+				*
+				* @type {Boolean}
+				*/
+				_hasManyEnrollments: {
+					type: Boolean,
+					value: false
 				}
 			},
 			listeners: {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -52,7 +52,6 @@
 			}
 			.button-bar {
 				margin-bottom: 10px;
-				display: block;
 				overflow: auto;
 			}
 			.button-bar .view-button {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -103,7 +103,7 @@
 		<d2l-loading-spinner size="100"></d2l-loading-spinner>
 
 		<div class="my-courses-content hidden">
-			<div class="button-bar">
+			<div class="button-bar" hidden$="[[!_hasManyEnrollments]]">
 				<button
 					id="recentViewButton"
 					class="view-button view-button-selected"
@@ -210,9 +210,9 @@
 			ready: function() {
 				this._alertMessage = this.localize('noCoursesMessage');
 
-				// Hide the secondary (tile) view initially
 				this.toggleClass('hidden', true, this.$$('d2l-alert'));
 				this.toggleClass('hidden', true, this.$$('d2l-course-tile-grid'));
+				this.toggleClass('hidden', true, this.$$('d2l-course-list'));
 
 				var overlay = this.$$('d2l-simple-overlay');
 				var allCourses = this.$$('d2l-all-courses');
@@ -242,7 +242,7 @@
 					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
 
 					var query = {
-						pageSize: 20,
+						pageSize: 25,
 						embedDepth: 1
 					};
 					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
@@ -279,6 +279,10 @@
 
 					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
 					this._hasEnrollments = this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0;
+
+					// Only show Recent Courses view to users with >20 enrollments
+					this._hasManyEnrollments = this.enrollments.length > 20;
+					this._hasManyEnrollments ? this._selectRecentView() : this._selectTileView();
 
 					if (this._hasEnrollments) {
 						this._alertMessage = this.localize('noPinnedCoursesMessage');

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -104,18 +104,18 @@
 		<div class="my-courses-content hidden">
 			<div class="button-bar" hidden$="[[!_hasManyEnrollments]]">
 				<button
+					id="tileViewButton"
+					class="view-button"
+					on-tap="_selectTileView"
+					aria-pressed="false">
+					Pinned Courses
+				</button>
+				<button
 					id="recentViewButton"
 					class="view-button view-button-selected"
 					on-tap="_selectRecentView"
 					aria-pressed="true">
 					Last Accessed
-				</button>
-				<button
-					id="tileViewButton"
-					class="view-button"
-					on-tap="_selectTileView"
-					aria-pressed="false">
-					My Courses
 				</button>
 			</div>
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -120,28 +120,31 @@
 				</button>
 			</div>
 
-			<d2l-course-list
-				enrollments-url="[[_recentEnrollmentsSearchUrl]]">
-			</d2l-course-list>
+			<div id="recentView">
+				<d2l-course-list
+					enrollments-url="[[_recentEnrollmentsSearchUrl]]">
+				</d2l-course-list>
+			</div>
 
-			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
-				{{_alertMessage}}
-				<a
-					is="d2l-link"
-					href="Javascript:void(0);"
-					hidden$="[[_hasEnrollments]]"
-					on-tap="_refreshPage">{{localize('refresh')}}</a>
-			</d2l-alert>
-			<d2l-course-tile-grid
-				enrollments="{{pinnedEnrollments}}">
-			</d2l-course-tile-grid>
-
-			<button
-				class="all-courses-button"
-				hidden$="{{!_hasEnrollments}}"
-				on-tap="_openAllCoursesView">
-				{{localize('viewAllCourses')}}
-			</button>
+			<div id="tileView">
+				<d2l-alert visible="[[!_hasPinnedEnrollments]]">
+					{{_alertMessage}}
+					<a
+						is="d2l-link"
+						href="Javascript:void(0);"
+						hidden$="[[_hasEnrollments]]"
+						on-tap="_refreshPage">{{localize('refresh')}}</a>
+				</d2l-alert>
+				<d2l-course-tile-grid
+					enrollments="{{pinnedEnrollments}}">
+				</d2l-course-tile-grid>
+				<button
+					class="all-courses-button"
+					hidden$="{{!_hasEnrollments}}"
+					on-tap="_openAllCoursesView">
+					{{localize('viewAllCourses')}}
+				</button>
+			</div>
 		</div>
 
 		<d2l-simple-overlay
@@ -210,9 +213,8 @@
 			ready: function() {
 				this._alertMessage = this.localize('noCoursesMessage');
 
-				this.toggleClass('hidden', true, this.$$('d2l-alert'));
-				this.toggleClass('hidden', true, this.$$('d2l-course-tile-grid'));
-				this.toggleClass('hidden', true, this.$$('d2l-course-list'));
+				this.toggleClass('hidden', true, this.$.courseTiles);
+				this.toggleClass('hidden', true, this.$.courseList);
 
 				var overlay = this.$$('d2l-simple-overlay');
 				var allCourses = this.$$('d2l-all-courses');
@@ -307,18 +309,16 @@
 				document.location.reload(true);
 			},
 			_selectRecentView: function() {
-				this.toggleClass('hidden', true, this.$$('d2l-alert'));
-				this.toggleClass('hidden', true, this.$$('d2l-course-tile-grid'));
-				this.toggleClass('hidden', false, this.$$('d2l-course-list'));
+				this.toggleClass('hidden', false, this.$.recentView);
+				this.toggleClass('hidden', true, this.$.tileView);
 				this.toggleClass('view-button-selected', true, this.$.recentViewButton);
 				this.toggleClass('view-button-selected', false, this.$.tileViewButton);
 				this.$.recentViewButton.setAttribute('aria-pressed', true);
 				this.$.tileViewButton.setAttribute('aria-pressed', false);
 			},
 			_selectTileView: function() {
-				this.toggleClass('hidden', false, this.$$('d2l-alert'));
-				this.toggleClass('hidden', false, this.$$('d2l-course-tile-grid'));
-				this.toggleClass('hidden', true, this.$$('d2l-course-list'));
+				this.toggleClass('hidden', true, this.$.recentView);
+				this.toggleClass('hidden', false, this.$.tileView);
 				this.toggleClass('view-button-selected', false, this.$.recentViewButton);
 				this.toggleClass('view-button-selected', true, this.$.tileViewButton);
 				this.$.recentViewButton.setAttribute('aria-pressed', false);

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -320,6 +320,11 @@ describe('d2l-my-courses', function() {
 			expect(widget._hasEnrollments).to.be.true;
 			expect(widget._hasPinnedEnrollments).to.be.true;
 		});
+
+		it('should not display the Last Accessed course list for users with a small number of enrollments', function() {
+			expect(widget._hasManyEnrollments).to.be.false;
+			expect(widget.$$('d2l-course-list').classList.contains('hidden')).to.be.true;
+		});
 	});
 
 	describe('User interaction', function() {

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -323,7 +323,8 @@ describe('d2l-my-courses', function() {
 
 		it('should not display the Last Accessed course list for users with a small number of enrollments', function() {
 			expect(widget._hasManyEnrollments).to.be.false;
-			expect(widget.$$('d2l-course-list').classList.contains('hidden')).to.be.true;
+			expect(widget.$.recentView.classList.contains('hidden')).to.be.true;
+			expect(widget.$$('d2l-course-list').offsetParent).is.null;
 		});
 	});
 


### PR DESCRIPTION
Slightly increasing pageSize to accomodate for this check as well. If a user has <20 enrollments, only show the tile-based view.

Only increased it to 25 as this gives us enough information to know whether the user has "lots" of enrollments or not, and I'd rather not increase it too much until we've done better analysis on the API performance.