### PR TITLE
Fix d2l-course-tile margins in single column view-during animations

### DIFF
--- a/d2l-course-tile-grid-styles.html
+++ b/d2l-course-tile-grid-styles.html
@@ -38,6 +38,10 @@
 		* We can therefore find x (tile width) for any given y (margin).
 		* The following all use a 1% margin and the formula above.
 		*/
+		d2l-course-tile {
+			width: 100%;
+		}
+
 		.columns-2 > d2l-course-tile {
 			width: 49.5%;
 			margin-left: 0.5%;

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -283,16 +283,11 @@
 						newPositions.push(currPositions[currIndex]);
 					} else {
 						// Tile will shift into new position
-						var leftMarginPct = [
-							[0], //1 column
-							[0, .01666], //2 columns
-							[0, .01175, .023], //3 columns
-							[0, .00934, .01867, .02801] //4 columns
-						];
 						var newCol = newIndex % columns;
 						var newXPx = currPositions[currIndex].width * newCol;
+						var leftMarginPct = 0.01 * (newCol);
 
-						newXPx = newXPx + (leftMarginPct[columns - 1][newCol] * containerWidth);
+						newXPx = newXPx + (leftMarginPct * containerWidth);
 
 						newPositions.push({
 							width: currPositions[currIndex].width,


### PR DESCRIPTION
Fixes a couple of regressions:

* Course tile responsive margins were made much more sane in a previous PR, but there was some noticeable 'snap-to-grid' action at the end of pin/unpin slide animations, which is now fixed (or, no worse than they were before when they were approved, and as good as they can be without a bit of work).
* The rule to apply 100% width to course tiles in single-columns view was accidentally removed in the previous change, causing layout problems below mobile breakpoints