### PR TITLE
US74383 - Add load delay

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -36,14 +36,16 @@
 
 		<d2l-course-tile-grid
 			enrollments="{{pinnedEnrollments}}"
-			enrollments-queue="{{pinnedEnrollmentsQueue}}">
+			enrollments-queue="{{pinnedEnrollmentsQueue}}"
+			delay-course-tile-load="true">
 		</d2l-course-tile-grid>
 
 		<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
 
 		<d2l-course-tile-grid
 			enrollments="{{unpinnedEnrollments}}"
-			enrollments-queue="{{unpinnedEnrollmentsQueue}}">
+			enrollments-queue="{{unpinnedEnrollmentsQueue}}"
+			delay-course-tile-load="true">
 		</d2l-course-tile-grid>
 	</template>
 
@@ -92,6 +94,11 @@
 				var itemCount = Math.max(this.pinnedEnrollments.length, this.unpinnedEnrollments.length);
 
 				return itemCount;
+			},
+			loadCourseTiles: function() {
+				Polymer.dom(this.root).querySelectorAll('d2l-course-tile-grid').forEach(function(grid) {
+					grid.delayCourseTileLoad = false;
+				});
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -37,7 +37,7 @@
 		<d2l-course-tile-grid
 			enrollments="{{pinnedEnrollments}}"
 			enrollments-queue="{{pinnedEnrollmentsQueue}}"
-			delay-course-tile-load="true">
+			delay-course-tile-load="[[delayCourseTileLoad]]">
 		</d2l-course-tile-grid>
 
 		<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
@@ -45,7 +45,7 @@
 		<d2l-course-tile-grid
 			enrollments="{{unpinnedEnrollments}}"
 			enrollments-queue="{{unpinnedEnrollmentsQueue}}"
-			delay-course-tile-load="true">
+			delay-course-tile-load="[[delayCourseTileLoad]]">
 		</d2l-course-tile-grid>
 	</template>
 
@@ -54,6 +54,16 @@
 
 		Polymer({
 			is: 'd2l-all-courses',
+			properties: {
+				/*
+				* Sets the delay-load property on the course tile grid
+				* @type {Boolean}
+				*/
+				delayCourseTileLoad: {
+					type: Boolean,
+					value: true
+				}
+			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				Polymer.D2L.MyCourses.LocalizeBehavior,
@@ -96,9 +106,7 @@
 				return itemCount;
 			},
 			loadCourseTiles: function() {
-				Polymer.dom(this.root).querySelectorAll('d2l-course-tile-grid').forEach(function(grid) {
-					grid.delayCourseTileLoad = false;
-				});
+				this.delayCourseTileLoad = false;
 			}
 		});
 	</script>

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -19,7 +19,8 @@
 					enrollment="[[item]]"
 					hover-enabled="[[_hoverInteractionEnabled]]"
 					animate-insertion="[[_removeEnrollmentFromTransitionList(item)]]"
-					enrollment-id="[[getEnrollmentIdentifier(item)]]">
+					enrollment-id="[[getEnrollmentIdentifier(item)]]"
+					delay-load="[[delayCourseTileLoad]]">
 				</d2l-course-tile>
 			</template>
 		</div>
@@ -46,6 +47,11 @@
 			*/
 
 			properties: {
+				/*
+				* Sets the delay-load property on the course tiles
+				* @type {Boolean}
+				*/
+				delayCourseTileLoad: Boolean,
 				/*
 				* Set of enrollment entities for which to display course tiles
 				* @type {Array<Entity>}

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -197,6 +197,12 @@ in that organization - student, teacher, TA, etc.
 				}
 			},
 			ready: function() {
+				// Currently only needed in tests, but it is entirely possible
+				// to render the element without an enrollment initially
+				if (!this.enrollment) {
+					return;
+				}
+
 				this.pinned = this.enrollment.hasClass('pinned');
 
 				var organizationLink = this.enrollment.getLinkByRel(/\/organization$/);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -106,6 +106,14 @@ in that organization - student, teacher, TA, etc.
 					type: Boolean
 				},
 				/*
+				* Delays initial loading of the organization until explicitly triggered by `loadOrganization`
+				* @type {Boolean}
+				*/
+				delayLoad: {
+					type: Boolean,
+					observer: '_delayLoadChanged'
+				},
+				/*
 				* Course tile enrollment
 				*
 				* When the enrollment is set, the course tile will automatically fetch information about the
@@ -193,7 +201,9 @@ in that organization - student, teacher, TA, etc.
 
 				var organizationLink = this.enrollment.getLinkByRel(/\/organization$/);
 				this._organizationUrl = organizationLink.href + '?embedDepth=1';
-				this.$.organizationRequest.generateRequest();
+				if (!this.delayLoad) {
+					this.$.organizationRequest.generateRequest();
+				}
 			},
 			/*
 			* Handler that triggers the API call to change an enrollment's pin state when the user says DO IT
@@ -248,6 +258,11 @@ in that organization - student, teacher, TA, etc.
 			},
 			_pendingPinAction: false,
 			_pinAnimationInProgress: false,
+			_delayLoadChanged: function(delayLoad) {
+				if (!delayLoad && !this._organization) {
+					this.$.organizationRequest.generateRequest();
+				}
+			},
 			_hoverCourseTile: function() {
 				if (this.hoverEnabled) {
 					this._setCourseTileHovered(true);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -113,17 +113,12 @@ in that organization - student, teacher, TA, etc.
 				*
 				* @type {Entity}
 				*/
-				enrollment: {
-					type: Object,
-					observer: '_enrollmentChanged'
-				},
+				enrollment: Object,
 				/*
 				* TODO: Erm... same thing. Something something animation?
 				* @type {Boolean}
 				*/
-				enrollmentId: {
-					type: Number
-				},
+				enrollmentId: Number,
 				/*
 				* Specifies whether the (desktop) hover menu is enabled on the course tile
 				* @type {Boolean}
@@ -152,44 +147,32 @@ in that organization - student, teacher, TA, etc.
 				* Body sent for pin/unpin action
 				* @type {String}
 				*/
-				_enrollmentPinBody: {
-					type: String
-				},
+				_enrollmentPinBody: String,
 				/*
 				* HTTP method used by the pin/unpin action
 				* @type {String}
 				*/
-				_enrollmentPinMethod: {
-					type: String
-				},
+				_enrollmentPinMethod: String,
 				/*
 				* URL used by the pin/unpin action
 				* @type {String}
 				*/
-				_enrollmentPinUrl: {
-					type: String
-				},
+				_enrollmentPinUrl: String,
 				/*
 				* The organization, fetched by the course tile when the `enrollment` Entity is changed
 				* @type {Entity}
 				*/
-				_organization: {
-					type: Object
-				},
+				_organization: Object,
 				/*
 				* The URL to of the `_organization`'s homepage - when the course tile is clicked, this is the URL we go to
 				* @type {String}
 				*/
-				_organizationHomepageUrl: {
-					type: String
-				},
+				_organizationHomepageUrl: String,
 				/*
 				* The URL to fetch the `_organization` Entity from (determined from the `enrollment`'s Links)
 				* @type {String}
 				*/
-				_organizationUrl: {
-					type: String
-				}
+				_organizationUrl: String
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.LocalizeBehavior
@@ -204,6 +187,13 @@ in that organization - student, teacher, TA, etc.
 				if (this.animateInsertion) {
 					this.toggleClass('animate-insertion-pre', true, this);
 				}
+			},
+			ready: function() {
+				this.pinned = this.enrollment.hasClass('pinned');
+
+				var organizationLink = this.enrollment.getLinkByRel(/\/organization$/);
+				this._organizationUrl = organizationLink.href + '?embedDepth=1';
+				this.$.organizationRequest.generateRequest();
 			},
 			/*
 			* Handler that triggers the API call to change an enrollment's pin state when the user says DO IT
@@ -258,17 +248,6 @@ in that organization - student, teacher, TA, etc.
 			},
 			_pendingPinAction: false,
 			_pinAnimationInProgress: false,
-			_enrollmentChanged: function(enrollment) {
-				this.pinned = enrollment.hasClass('pinned');
-
-				// The enrollment is updated (i.e. this handler is called) upon a pin/unpin response as well, but
-				// there's no need to update the organization in that case
-				if (!this._organization) {
-					var organizationLink = enrollment.getLinkByRel(/\/organization$/);
-					this._organizationUrl = organizationLink.href + '?embedDepth=1';
-					this.$.organizationRequest.generateRequest();
-				}
-			},
 			_hoverCourseTile: function() {
 				if (this.hoverEnabled) {
 					this._setCourseTileHovered(true);
@@ -306,9 +285,11 @@ in that organization - student, teacher, TA, etc.
 			},
 			_onEnrollmentPinResponse: function(response) {
 				if (response.detail.status === 200) {
-					// The pin action returns the updated enrollment, so update this.enrollment with the modified one
+					// The pin action returns the updated enrollment, so update
+					// this.enrollment with the modified one
 					var parser = document.createElement('d2l-siren-parser');
 					this.enrollment = parser.parse(response.detail.xhr.response);
+					this.pinned = this.enrollment.hasClass('pinned');
 				}
 			},
 			_onOrganizationResponse: function(response) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -311,6 +311,7 @@
 				e.preventDefault();
 				e.stopPropagation();
 				this.$$('d2l-simple-overlay').open();
+				this.$$('d2l-all-courses').loadCourseTiles();
 
 				setTimeout(function() {
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation

--- a/test/d2l-course-tile/d2l-course-tile.html
+++ b/test/d2l-course-tile/d2l-course-tile.html
@@ -16,6 +16,12 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="d2l-course-tile-fixture-delayed">
+			<template>
+				<d2l-course-tile delay-load></d2l-course-tile>
+			</template>
+		</test-fixture>
+
 		<script src="d2l-course-tile.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Kind of a WIP (haven't added tests yet), but works surprisingly well! The `d2l-course-tile` now supports a `delay-load` attribute, which will prevent it from fetching the organization when it's first rendered. Since we fetch a bunch of enrollments, but only display the pinned ones, this means we can save a lot of network chattiness at page load - possibly even avoid it entirely, if the user doesn't open the all courses view (e.g. an admin, with many courses, who may instead just go to Last Accessed, or do a search).

In testing this out with various network throttling settings in Chrome, only on GPRS does this give a noticeable delay to loading the course names/images when you open the overlay. Granted, our home page takes like 90 seconds on that sort of connection, so... yeah. Any other throttling, the loading is "near-instantaneous", partially thanks to the animation delay of opening the overlay.

The use case where this doesn't help would be somebody with a lot of pinned enrollments, since we'd still be fetching organizations for all of them. However, this doesn't make that case any worse, and we had discussed limiting the number of pinned enrollments anyway.