### PR TITLE
US75822 - Use sortBy=pinDate for default enrollments call

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -255,17 +255,22 @@
 
 					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
 
-					var query = {
+					var pinDateQuery = {
 						pageSize: 25,
-						embedDepth: 1
+						embedDepth: 1,
+						sortField: 'pinDate',
+						sortDescending: true
 					};
-					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
+					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, pinDateQuery);
 					this.$.enrollmentsSearchRequest.generateRequest();
 
-					query.pageSize = 5;
-					query.sortField = 'lastAccessed';
-					query.sortDescending = true;
-					this._recentEnrollmentsSearchUrl = this.createActionUrl(searchAction, query);
+					var lastAccessedQuery = {
+						pageSize: 5,
+						embedDepth: 1,
+						sortField: 'lastAccessed',
+						sortDescending: true
+					};
+					this._recentEnrollmentsSearchUrl = this.createActionUrl(searchAction, lastAccessedQuery);
 				} else {
 					this._showContent();
 				}

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -211,6 +211,24 @@ describe('d2l-my-courses', function() {
 			});
 		});
 
+		it('should set the request URL for pinned courses, sortDescending', function(done) {
+			server.respondWith(
+				'GET',
+				widget.enrollmentsUrl,
+				function(req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					req.respond(200, {}, JSON.stringify(enrollmentsRootResponse));
+				});
+
+			widget.$.enrollmentsRootRequest.generateRequest();
+
+			widget.$.enrollmentsRootRequest.addEventListener('iron-ajax-response', function() {
+				expect(widget._enrollmentsSearchUrl).to.match(/sortField=pinDate/);
+				expect(widget._enrollmentsSearchUrl).to.match(/sortDescending=true/);
+				done();
+			});
+		});
+
 		it('should rescale the course tile grid on search response', function(done) {
 			server.respondWith(
 				'GET',


### PR DESCRIPTION
This API change allows us to always get pinned courses, based off their pinDate, from the API. This solves the problem where an alphabetically-low pinned course wouldn't come back from the API, since it was ordering them by name and only grabbing the pinned ones.

(Note that I only just merged the API update today, so you'll have to pull LP for this to work properly.)