### PR TITLE
Add lazy loading of enrollments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 addons:
   firefox: 46.0
 before_script:
-- npm run test:lint:js && npm run test:lint:wc
+- npm run test:lint:js
 script:
 - xvfb-run wct
 after_success:

--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "/demo/"
   ],
   "dependencies": {
+    "polymer": "Polymer/polymer#^1.4.0",
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
     "d2l-ajax": "^2.0.0",
     "d2l-colors": "^2.0.0",
@@ -47,7 +48,8 @@
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
-    "polymer": "Polymer/polymer#^1.4.0"
+    "iron-a11y-keys": "^1.0.6",
+    "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,6 @@
     "/demo/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.4.0",
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
     "d2l-ajax": "^2.0.0",
     "d2l-colors": "^2.0.0",
@@ -48,7 +47,8 @@
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
-    "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2"
+    "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
+    "polymer": "Polymer/polymer#^1.4.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,6 @@
     "iron-overlay-behavior": "PolymerElements/iron-overlay-behavior#^1.7.1",
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
-    "iron-a11y-keys": "^1.0.6",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2"
   },
   "devDependencies": {

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -265,7 +265,7 @@ in that organization - student, teacher, TA, etc.
 			_pendingPinAction: false,
 			_pinAnimationInProgress: false,
 			_delayLoadChanged: function(delayLoad) {
-				if (!delayLoad && !this._organization) {
+				if (this.isAttached && !delayLoad && !this._organization) {
 					this.$.organizationRequest.generateRequest();
 				}
 			},

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -181,7 +181,12 @@
 				* Object containing the last response from an enrollments search request
 				* @type Object
 				*/
-				_lastEnrollmentsSearchResponse: Object
+				_lastEnrollmentsSearchResponse: Object,
+				/*
+				* Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
+				* @type Object
+				*/
+				_pinnedCoursesMap: Object
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -193,6 +198,7 @@
 				'open-change-image-view': '_openChangeImageView'
 			},
 			ready: function() {
+				this._pinnedCoursesMap = {};
 				this._alertMessage = this.localize('noCoursesMessage');
 
 				this.toggleClass('hidden', true, this.$.courseTiles);
@@ -249,7 +255,11 @@
 
 					enrollmentEntities.forEach(function(enrollment) {
 						if (enrollment.hasClass('pinned')) {
-							newPinnedEnrollments.push(enrollment);
+							var enrollmentId = this.getEnrollmentIdentifier(enrollment);
+							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+								newPinnedEnrollments.push(enrollment);
+								this._pinnedCoursesMap[enrollmentId] = true;
+							}
 						} else {
 							newUnpinnedEnrollments.push(enrollment);
 						}
@@ -259,7 +269,7 @@
 					this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
 
 					this.notifySplices('pinnedEnrollments', [{
-						index: this.pinnedEnrollments.length - newPinnedEnrollments.length,
+						index: this.pinnedEnrollments.length - newPinnedEnrollments.length + 1,
 						removed: [],
 						addedCount: newPinnedEnrollments.length,
 						object: this.pinnedEnrollments,
@@ -267,7 +277,7 @@
 					}]);
 
 					this.notifySplices('unpinnedEnrollments', [{
-						index: this.unpinnedEnrollments.length - newUnpinnedEnrollments.length,
+						index: this.unpinnedEnrollments.length - newUnpinnedEnrollments.length + 1,
 						removed: [],
 						addedCount: newUnpinnedEnrollments.length,
 						object: this.unpinnedEnrollments,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-link/d2l-link.html">
@@ -77,7 +78,8 @@
 			id="enrollmentsSearchRequest"
 			url="[[_enrollmentsSearchUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onEnrollmentsSearchResponse">
+			on-iron-ajax-response="_onEnrollmentsSearchResponse"
+			last-response="{{_lastEnrollmentsSearchResponse}}">
 		</d2l-ajax>
 
 		<d2l-loading-spinner size="100"></d2l-loading-spinner>
@@ -107,6 +109,10 @@
 			title$="{{localize('allCourses')}}"
 			locale="[[locale]]"
 			with-backdrop>
+
+			<iron-scroll-threshold
+				on-lower-threshold="_loadNextEnrollmentsPage">
+			</iron-scroll-threshold>
 
 			<d2l-all-courses
 				pinned-enrollments="{{pinnedEnrollments}}"
@@ -161,7 +167,12 @@
 				* URL constructed to fetch a user's enrollments with the enrollments search Action
 				* @type {String}
 				*/
-				_enrollmentsSearchUrl: String
+				_enrollmentsSearchUrl: String,
+				/*
+				* Object containing the last response from an enrollments search request
+				* @type Object
+				*/
+				_lastEnrollmentsSearchResponse: Object
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -186,6 +197,8 @@
 				if (!this.delayLoad) {
 					this.$.enrollmentsRootRequest.generateRequest();
 				}
+
+				this.$$('iron-scroll-threshold').scrollTarget = this.$$('d2l-simple-overlay').scrollRegion;
 			},
 			/*
 			* Count of `d2l-course-tile` elements in grid.
@@ -223,19 +236,14 @@
 					var enrollments = parser.parse(response.detail.xhr.response);
 					var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
 
-					var pinnedEnrollments = [];
-					var unpinnedEnrollments = [];
-
 					enrollmentEntities.forEach(function(enrollment) {
 						if (enrollment.hasClass('pinned')) {
-							pinnedEnrollments.push(enrollment);
+							this.push('pinnedEnrollments', enrollment);
 						} else {
-							unpinnedEnrollments.push(enrollment);
+							this.push('unpinnedEnrollments', enrollment);
 						}
-					});
+					}, this);
 
-					this.set('pinnedEnrollments', pinnedEnrollments);
-					this.set('unpinnedEnrollments', unpinnedEnrollments);
 					this.set('enrollments', enrollmentEntities);
 
 					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
@@ -248,6 +256,7 @@
 					this.fire('recalculate-columns');
 				}
 
+				this.$$('iron-scroll-threshold').clearTriggers();
 				this._showContent();
 			},
 			_openChangeImageView: function() {
@@ -274,6 +283,17 @@
 			_showContent: function() {
 				this.toggleClass('hidden', true, this.$$('d2l-loading-spinner'));
 				this.toggleClass('hidden', false, this.$$('.my-courses-content'));
+			},
+			_loadNextEnrollmentsPage: function() {
+				if (this.$['all-courses'].opened && this._lastEnrollmentsSearchResponse) {
+					var parser = document.createElement('d2l-siren-parser');
+					var lastResponseEntity = parser.parse(this._lastEnrollmentsSearchResponse);
+
+					if (lastResponseEntity.hasLink('next')) {
+						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
+						this.$.enrollmentsSearchRequest.generateRequest();
+					}
+				}
 			}
 		});
 	</script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -269,7 +269,7 @@
 					this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
 
 					this.notifySplices('pinnedEnrollments', [{
-						index: this.pinnedEnrollments.length - newPinnedEnrollments.length + 1,
+						index: this.pinnedEnrollments.length - newPinnedEnrollments.length,
 						removed: [],
 						addedCount: newPinnedEnrollments.length,
 						object: this.pinnedEnrollments,
@@ -277,7 +277,7 @@
 					}]);
 
 					this.notifySplices('unpinnedEnrollments', [{
-						index: this.unpinnedEnrollments.length - newUnpinnedEnrollments.length + 1,
+						index: this.unpinnedEnrollments.length - newUnpinnedEnrollments.length,
 						removed: [],
 						addedCount: newUnpinnedEnrollments.length,
 						object: this.unpinnedEnrollments,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -60,6 +60,10 @@
 				margin: auto;
 			}
 
+			#lazyLoadSpinner {
+				margin-bottom: 30px;
+			}
+
 			#basic-image-selector-overlay {
 				--simple-overlay-content-width: {
 					padding: 0;
@@ -126,7 +130,7 @@
 			<d2l-loading-spinner
 				id="lazyLoadSpinner"
 				class="hidden"
-				size="150">
+				size="100">
 			</d2l-loading-spinner>
 		</d2l-simple-overlay>
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -82,7 +82,11 @@
 			last-response="{{_lastEnrollmentsSearchResponse}}">
 		</d2l-ajax>
 
-		<d2l-loading-spinner size="100"></d2l-loading-spinner>
+		<d2l-loading-spinner
+			id="initialLoadingSpinner"
+			class="hidden"
+			size="100">
+		</d2l-loading-spinner>
 
 		<div class="my-courses-content hidden">
 			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
@@ -119,6 +123,11 @@
 				unpinned-enrollments="{{unpinnedEnrollments}}"
 				locale="[[locale]]">
 			</d2l-all-courses>
+			<d2l-loading-spinner
+				id="lazyLoadSpinner"
+				class="hidden"
+				size="150">
+			</d2l-loading-spinner>
 		</d2l-simple-overlay>
 
 		<d2l-simple-overlay
@@ -198,7 +207,7 @@
 					this.$.enrollmentsRootRequest.generateRequest();
 				}
 
-				this.$$('iron-scroll-threshold').scrollTarget = this.$$('d2l-simple-overlay').scrollRegion;
+				this.$$('iron-scroll-threshold').scrollTarget = this.$['all-courses'].scrollRegion;
 			},
 			/*
 			* Count of `d2l-course-tile` elements in grid.
@@ -235,14 +244,35 @@
 					var parser = document.createElement('d2l-siren-parser');
 					var enrollments = parser.parse(response.detail.xhr.response);
 					var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
+					var newPinnedEnrollments = [];
+					var newUnpinnedEnrollments = [];
 
 					enrollmentEntities.forEach(function(enrollment) {
 						if (enrollment.hasClass('pinned')) {
-							this.push('pinnedEnrollments', enrollment);
+							newPinnedEnrollments.push(enrollment);
 						} else {
-							this.push('unpinnedEnrollments', enrollment);
+							newUnpinnedEnrollments.push(enrollment);
 						}
 					}, this);
+
+					this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);
+					this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
+
+					this.notifySplices('pinnedEnrollments', [{
+						index: this.pinnedEnrollments.length - newPinnedEnrollments.length,
+						removed: [],
+						addedCount: newPinnedEnrollments.length,
+						object: this.pinnedEnrollments,
+						type: 'splice'
+					}]);
+
+					this.notifySplices('unpinnedEnrollments', [{
+						index: this.unpinnedEnrollments.length - newUnpinnedEnrollments.length,
+						removed: [],
+						addedCount: newUnpinnedEnrollments.length,
+						object: this.unpinnedEnrollments,
+						type: 'splice'
+					}]);
 
 					this.set('enrollments', enrollmentEntities);
 
@@ -256,6 +286,7 @@
 					this.fire('recalculate-columns');
 				}
 
+				this.toggleClass('hidden', true, this.$.lazyLoadSpinner);
 				this.$$('iron-scroll-threshold').clearTriggers();
 				this._showContent();
 			},
@@ -281,7 +312,7 @@
 				document.location.reload(true);
 			},
 			_showContent: function() {
-				this.toggleClass('hidden', true, this.$$('d2l-loading-spinner'));
+				this.toggleClass('hidden', true, this.$.initialLoadingSpinner);
 				this.toggleClass('hidden', false, this.$$('.my-courses-content'));
 			},
 			_loadNextEnrollmentsPage: function() {
@@ -292,6 +323,7 @@
 					if (lastResponseEntity.hasLink('next')) {
 						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
 						this.$.enrollmentsSearchRequest.generateRequest();
+						this.toggleClass('hidden', false, this.$.lazyLoadSpinner);
 					}
 				}
 			}

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -182,6 +182,9 @@ The overlay supports using different animations and transitions for desktop and 
 				var style = document.createElement('style', 'custom-style');
 				style.innerHTML = 'iron-overlay-backdrop { --iron-overlay-backdrop-opacity: 0.0; }';
 				document.body.appendChild(style);
+			},
+			get scrollRegion() {
+				return this.$$('.scrollable');
 			}
 		});
 	</script>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "postinstall": "bower install",
     "publish:cdn": "npm run build -s && frau-publisher",
     "serve": "polymer serve",
-    "test": "npm run test:lint:js && npm run test:lint:wc && wct",
+    "test": "npm run test:lint:js && wct",
     "test:lint:js": "eslint test/ --ext .js,.html && eslint *.html",
     "test:lint:wc": "polylint",
     "test:no-lint": "wct -p"

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -108,22 +108,22 @@ describe('smoke test', function() {
 		expect(widget).to.exist;
 	});
 
-	it('should return the correct value from getCourseTileItemCount', function() {
-		widget.pinnedEnrollments = [pinnedEnrollmentEntity, pinnedEnrollmentEntity, pinnedEnrollmentEntity];
+	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {
+		widget.pinnedEnrollments = [pinnedEnrollmentEntity];
 		widget.unpinnedEnrollments = [unpinnedEnrollmentEntity];
 
-		expect(widget.getCourseTileItemCount()).to.equal(3);
+		expect(widget.getCourseTileItemCount()).to.equal(1);
 	});
 
 	it('should set getCourseTileItemCount on its child course-tile-grids', function() {
-		widget.pinnedEnrollments = [pinnedEnrollmentEntity, pinnedEnrollmentEntity, pinnedEnrollmentEntity];
+		widget.pinnedEnrollments = [pinnedEnrollmentEntity];
 		widget.unpinnedEnrollments = [unpinnedEnrollmentEntity];
 
 		var courseTileGrids = widget.querySelectorAll('d2l-course-tile-grid');
 		expect(courseTileGrids.length).to.equal(2);
 
 		for (var i = 0; i < courseTileGrids.length; i++) {
-			expect(courseTileGrids[i].getCourseTileItemCount()).to.equal(3);
+			expect(courseTileGrids[i].getCourseTileItemCount()).to.equal(1);
 		}
 	});
 


### PR DESCRIPTION
`iron-scroll-threshold` is a simple solution for getting this working, but (as you might see from the red X), [Polylint has a bug](https://github.com/Polymer/polymer-analyzer/issues/205) where it will break if an element (in this case, `iron-scroll-threshold`) uses a property defined on `Polymer.Base` (in this case, `isAttached`), which is perfectly valid. You can't configure or suppress errors, nor can you whitelist files/properties/etc.

Possible solutions:

1) Turn off Polylint (not ideal, but the Polymer core team seems to do this, [not only on `iron-scroll-threshold`](https://github.com/PolymerElements/iron-scroll-threshold/commit/35a555136e29c684dbe0dad2a6a2f06a7e67b097) but [ elsewhere as well ](https://github.com/PolymerElements/app-layout/commit/be2bf470e292b094fb160dc23ff2c0fb2904d32a))
2) Fork `iron-scroll-threshold` and change references to `isAttached` to refer to a property defined within that element (so long as it's possible without changing behavior)
3) Write our own behavior