### PR TITLE
US76123 - Filter and Sort UI

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -451,24 +451,18 @@
 				}
 			},
 			_selectSemesterList: function() {
-				this.toggleClass('hidden', false, this.$.semesterList);
-				this.toggleClass('hidden', true, this.$.departmentList);
-				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.semesterListButton);
-				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.departmentListButton);
-				this.toggleClass('invisible', false, this.$.semesterListHighlight);
-				this.toggleClass('invisible', true, this.$.departmentListHighlight);
-				this.$.semesterListButton.setAttribute('aria-pressed', true);
-				this.$.departmentListButton.setAttribute('aria-pressed', false);
+				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
+				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
 			},
 			_selectDepartmentList: function() {
-				this.toggleClass('hidden', true, this.$.semesterList);
-				this.toggleClass('hidden', false, this.$.departmentList);
-				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.semesterListButton);
-				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.departmentListButton);
-				this.toggleClass('invisible', true, this.$.semesterListHighlight);
-				this.toggleClass('invisible', false, this.$.departmentListHighlight);
-				this.$.semesterListButton.setAttribute('aria-pressed', false);
-				this.$.departmentListButton.setAttribute('aria-pressed', true);
+				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
+				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
+			},
+			_toggleSelectedList(list, button, highlight, selected) {
+				this.toggleClass('hidden', !selected, list);
+				this.toggleClass('dropdown-content-tab-button-selected', selected, button);
+				this.toggleClass('invisible', !selected, highlight);
+				button.setAttribute('aria-pressed', selected);
 			},
 			_toggleFilterDropdown: function() {
 				this.$.filterDropdown.toggleOpen();

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
-<link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-menu/d2l-menu.html">
@@ -132,9 +131,9 @@
 				visibility: visible;
 				width: 1rem;
 				height: 1rem;
-				margin-top: -0.2rem;
+				margin-top: -0.1rem;
 				margin-right: 0.5rem;
-				margin-left: -0.5rem;
+				margin-left: -0.2rem;
 				border-radius: 0.3rem;
 				border-style: solid;
 				border-color: var(--d2l-color-titanius);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -43,6 +43,7 @@
 				border: none;
 				padding: 0;
 				cursor: pointer;
+				margin-left: 30px;
 			}
 			.filter-item {
 				display: block;
@@ -56,9 +57,6 @@
 			}
 			.search-and-filter > d2l-search-widget {
 				width: 50%;
-			}
-			.search-and-filter d2l-dropdown {
-				margin-left: 30px;
 			}
 			.search-and-filter .dropdown-icon {
 				margin-left: 12px;
@@ -135,11 +133,9 @@
 			</d2l-search-widget>
 
 			<div>
-				<d2l-dropdown id="filterDropdown" no-auto-open>
-					<div class="d2l-dropdown-opener">
-						<button class="d2l-dropdown-opener filter-button">Filter</button>
-						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
-					</div>
+				<button class="filter-button" on-tap="_toggleFilterDropdown">Filter</button>
+				<d2l-dropdown id="filterDropdown">
+					<iron-icon class="d2l-dropdown-opener dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					<d2l-dropdown-content>
 						<div class="filter-and-clear">
 							<span>Filter by</span>
@@ -192,11 +188,9 @@
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
+				<button class="filter-button" on-tap="_toggleSortDropdown">Sort: Date Pinned</button>
 				<d2l-dropdown id="sortDropdown">
-					<div class="d2l-dropdown-opener">
-						<button class="d2l-dropdown-opener filter-button">Sort: Date Pinned</button>
-						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
-					</div>
+					<iron-icon class="d2l-dropdown-opener dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					<d2l-dropdown-content>
 						Sort by
 						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">Date Pinned</a>
@@ -285,12 +279,9 @@
 				for (var i = 0; i < courseTileGrids.length; i++) {
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
-			},
-			attached: function() {
-				this.listen(this.$$('d2l-dropdown'), 'click', '_onFilterDropdownClick');
-			},
-			detached: function() {
-				this.unlisten(this.$$('d2l-dropdown'), 'click', '_onFilterDropdownClick');
+
+				this.$.semestersRequest.generateRequest();
+				this.$.departmentsRequest.generateRequest();
 			},
 			/*
 			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
@@ -328,27 +319,13 @@
 				});
 				this._isFiltered = false;
 				this._parentOrganizationIds = [];
-				this.$$('.filter-button').innerHTML = 'Filter';
-			},
-			_onFilterDropdownClick: function() {
-				if (!this._semesterOrganizations) {
-					this.$.semestersRequest.generateRequest();
-					this.$.departmentsRequest.generateRequest();
-				}
+				this.$$('.filter-button').textContent = 'Filter';
 			},
 			_onDepartmentsResponse: function(response) {
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var departments = parser.parse(response.detail.xhr.response);
 					this._departmentOrganizations = departments.entities;
-
-					if (this._semesterOrganizations) {
-						// We delay the opening of the menu until we have a response, so that the
-						// dropdown is sized correctly. Once we have the semesters and departments,
-						// we can just immediately open it on future clicks
-						this.$.filterDropdown.removeAttribute('no-auto-open', false);
-						this.$.filterDropdown.toggleOpen();
-					}
 				}
 			},
 			_onSemestersResponse: function(response) {
@@ -356,14 +333,6 @@
 					var parser = document.createElement('d2l-siren-parser');
 					var semesters = parser.parse(response.detail.xhr.response);
 					this._semesterOrganizations = semesters.entities;
-
-					if (this._departmentOrganizations) {
-						// We delay the opening of the menu until we have a response, so that the
-						// dropdown is sized correctly. Once we have the semesters and departments,
-						// we can just immediately open it on future clicks
-						this.$.filterDropdown.removeAttribute('no-auto-open', false);
-						this.$.filterDropdown.toggleOpen();
-					}
 				}
 			},
 			_selectSemesterList: function() {
@@ -382,6 +351,12 @@
 				this.$.semesterListButton.setAttribute('aria-pressed', false);
 				this.$.departmentListButton.setAttribute('aria-pressed', true);
 			},
+			_toggleFilterDropdown: function() {
+				this.$.filterDropdown.toggleOpen();
+			},
+			_toggleSortDropdown: function() {
+				this.$.sortDropdown.toggleOpen();
+			},
 			_updateFilter: function(e) {
 				if (e.target.checked) {
 					this.push('_parentOrganizationIds', e.target.value);
@@ -393,11 +368,11 @@
 
 				var filterButton = this.$$('.filter-button');
 				if (this._parentOrganizationIds.length === 0) {
-					filterButton.innerHTML = 'Filter';
+					filterButton.textContent = 'Filter';
 				} else if (this._parentOrganizationIds.length === 1) {
-					filterButton.innerHTML = 'Filter: 1 Filter';
+					filterButton.textContent = 'Filter: 1 Filter';
 				} else {
-					filterButton.innerHTML = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
+					filterButton.textContent = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
 				}
 			},
 			_updateSortBy: function(e) {
@@ -408,7 +383,7 @@
 					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
 				}.bind(this));
 
-				this.$$('#sortDropdown button.d2l-dropdown-opener').innerHTML = 'Sort: ' + e.target.innerHTML;
+				this.$$('#sortDropdown button.d2l-dropdown-opener').textContent = 'Sort: ' + e.target.textContent;
 
 				this.$.sortDropdown.toggleOpen();
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -70,11 +70,13 @@
 				/* end overrides */
 				background: none;
 				border: none;
-				padding: 0;
+				padding: 10px;
 				cursor: pointer;
 			}
 			.view-button-selected {
 				color: var(--d2l-color-celestine);
+				border-top-width: 2px;
+				border-top-style: solid;
 			}
 			.hidden {
 				display: none;
@@ -82,15 +84,15 @@
 			.clear-button {
 				@apply(--d2l-small-text);
 				/* overrides to d2l-small-text */
-				font-size: 1rem;
 				color: var(--d2l-color-celestine);
 				/* end overrides */
 				background: none;
 				border: none;
 				padding: 0;
 				cursor: pointer;
+				margin: 0;
 			}
-			.filter-and-clear {
+			.filter-and-clear, .button-bar {
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
@@ -103,7 +105,6 @@
 				display: block;
 				background: none;
 				border: none;
-				padding: 0;
 				cursor: pointer;
 			}
 			.sort-button-selected {
@@ -142,7 +143,9 @@
 					<d2l-dropdown-content>
 						<div class="filter-and-clear">
 							<span>Filter by</span>
-							<button on-tap="_clearFilters">Clear</button>
+							<template is="dom-if" if="[[_isFiltered]]">
+								<button class="clear-button" on-tap="_clearFilters">Clear</button>
+							</template>
 						</div>
 						<div class="button-bar">
 							<button
@@ -180,7 +183,7 @@
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
-											on-click="_updateFilter">
+											on-click="_updateFilter" />
 										[[item.properties.name]]
 									</label>
 								</div>
@@ -252,6 +255,10 @@
 					type: String,
 					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=203'
 				},
+				_isFiltered: {
+					type: Boolean,
+					value: false
+				},
 				_semesterOrganizations: Object,
 				_semestersUrl: {
 					type: String,
@@ -316,9 +323,12 @@
 				this.delayCourseTileLoad = false;
 			},
 			_clearFilters: function() {
-				Polymer.dom(this.root).querySelectorAll('.filter-item > input').forEach(function(checkbox) {
+				Polymer.dom(this.root).querySelectorAll('.filter-item input').forEach(function(checkbox) {
 					checkbox.checked = false;
 				});
+				this._isFiltered = false;
+				this._parentOrganizationIds = [];
+				this.$$('.filter-button').innerHTML = 'Filter';
 			},
 			_onFilterDropdownClick: function() {
 				if (!this._semesterOrganizations) {
@@ -375,9 +385,19 @@
 			_updateFilter: function(e) {
 				if (e.target.checked) {
 					this.push('_parentOrganizationIds', e.target.value);
+					this._isFiltered = true;
 				} else {
 					var index = this._parentOrganizationIds.indexOf(e.target.value);
 					this.splice('_parentOrganizationIds', index, 1);
+				}
+
+				var filterButton = this.$$('.filter-button');
+				if (this._parentOrganizationIds.length === 0) {
+					filterButton.innerHTML = 'Filter';
+				} else if (this._parentOrganizationIds.length === 1) {
+					filterButton.innerHTML = 'Filter: 1 Filter';
+				} else {
+					filterButton.innerHTML = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
 				}
 			},
 			_updateSortBy: function(e) {
@@ -388,7 +408,7 @@
 					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
 				}.bind(this));
 
-				this.$$('#sortDropdown button.d2l-dropdown-opener').innerHTML = "Sort: " + e.target.innerHTML;
+				this.$$('#sortDropdown button.d2l-dropdown-opener').innerHTML = 'Sort: ' + e.target.innerHTML;
 
 				this.$.sortDropdown.toggleOpen();
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -140,6 +140,7 @@
 				border-color: var(--d2l-color-titanius);
 				border-width: 1px;
 				background-color: var(--d2l-color-woolonardo);
+				box-sizing: border-box;
 			}
 			.dropdown-content-item input[type=checkbox]:focus::after {
 				border-color: var(--d2l-color-celestine);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -50,13 +50,25 @@
 				@apply(--d2l-small-text);
 				/* overrides to d2l-small-text */
 				font-size: 1rem;
+				font-weight: 300;
+				color: var(--d2l-color-tungsten);
 				/* end overrides */
 				cursor: pointer;
-				margin-left: 30px;
-				margin-right: 12px;
 				padding: 0;
+				margin-left: 1rem;
+				padding-right: 0.3rem;
 			}
-			.selected {
+			.dropdown-text:hover,
+			.dropdown-text:focus {
+				color: var(--d2l-color-celestine);
+				text-decoration: underline;
+			}
+			.dropdown-text:hover + d2l-dropdown button,
+			.dropdown-text:focus + d2l-dropdown button {
+				color: var(--d2l-color-celestine);
+			}
+			d2l-dropdown > button:hover,
+			d2l-dropdown > button:focus {
 				color: var(--d2l-color-celestine);
 			}
 			.dropdown-button {
@@ -64,10 +76,12 @@
 				border: none;
 				cursor: pointer;
 				padding: 0;
+				color: var(--d2l-color-tungsten);
 			}
 			iron-icon {
-				--iron-icon-height: 10px;
-				--iron-icon-width: 10px;
+				--iron-icon-height: 15px;
+				--iron-icon-width: 15px;
+				margin-top: -0.35rem;
 			}
 			.clear-button {
 				@apply(--d2l-small-text);
@@ -129,11 +143,14 @@
 				border: none;
 				cursor: pointer;
 				margin: 0;
-				padding-top: 10px;
-				padding-bottom: 10px;
+				padding-top: 20px;
+				padding-bottom: 20px;
 				padding-left: 20px;
 				width: 100%;
 				text-align: left;
+			}
+			.dropdown-content-item input[type=checkbox] {
+				margin-right: 15px;
 			}
 			.dropdown-content-item input[type=checkbox]:after {
 				content: '';
@@ -141,8 +158,6 @@
 				visibility: visible;
 				width: 1rem;
 				height: 1rem;
-				margin-top: -0.1rem;
-				margin-right: 0.5rem;
 				margin-left: -0.2rem;
 				border-radius: 0.3rem;
 				border-style: solid;
@@ -159,22 +174,27 @@
 				background-image: url('../images/tier1/check.svg');
 				background-position: center center;
 				background-repeat: no-repeat;
+				background-size: 13px;
 			}
 			.dropdown-content-item > iron-icon {
 				visibility: hidden;
 				margin-right: 20px;
+				margin-top: -5px;
 				--iron-icon-height: 20px;
 				--iron-icon-width: 20px;
-			}
-			.dropdown-content-item-selected {
-				color: var(--d2l-color-celestine);
-			}
-			.dropdown-content-item-selected > iron-icon {
-				visibility: visible;
 			}
 			#sortDropdown d2l-dropdown-content button {
 				border-bottom: 1px solid var(--d2l-color-gypsum);
 				font-size: 1rem;
+			}
+			.selected {
+				color: var(--d2l-color-celestine);
+			}
+			.selected > iron-icon {
+				visibility: visible;
+			}
+			.highlight {
+				text-decoration: underline;
 			}
 		</style>
 
@@ -203,7 +223,11 @@
 			<div>
 				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 				<d2l-dropdown id="filterDropdown">
-					<button id="filterButton" class="d2l-dropdown-opener dropdown-button">
+					<button
+						id="filterButton"
+						on-mouseenter="_onFocusFilterText"
+						on-mouseout="_onBlurFilterText"
+						class="d2l-dropdown-opener dropdown-button">
 						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content no-padding min-width="350">
@@ -268,7 +292,11 @@
 
 				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">{{localize('sorting.sortDatePinned')}}</span>
 				<d2l-dropdown id="sortDropdown">
-					<button id="sortButton" class="d2l-dropdown-opener dropdown-button">
+					<button
+						id="sortButton"
+						on-mouseenter="_onFocusSortText"
+						on-mouseout="_onBlurSortText"
+						class="d2l-dropdown-opener dropdown-button">
 						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content no-padding min-width="350">
@@ -284,7 +312,7 @@
 								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
 								{{localize('sorting.courseName')}}
 							</button>
-							<button class="dropdown-content-item dropdown-content-item-selected" value="pinDate" on-tap="_updateSortBy">
+							<button class="dropdown-content-item selected" value="pinDate" on-tap="_updateSortBy">
 								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
 								{{localize('sorting.datePinned')}}
 							</button>
@@ -385,18 +413,6 @@
 				this.$.semestersRequest.generateRequest();
 				this.$.departmentsRequest.generateRequest();
 			},
-			attached: function() {
-				this.listen(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownOpen');
-				this.listen(this.$.filterDropdown, 'd2l-dropdown-close', '_onFilterDropdownClose');
-				this.listen(this.$.sortDropdown, 'd2l-dropdown-open', '_onSortDropdownOpen');
-				this.listen(this.$.sortDropdown, 'd2l-dropdown-close', '_onSortDropdownClose');
-			},
-			detached: function() {
-				this.unlisten(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownOpen');
-				this.unlisten(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownClose');
-				this.unlisten(this.$.sortDropdown, 'd2l-dropdown-open', '_onSortDropdownOpen');
-				this.unlisten(this.$.sortDropdown, 'd2l-dropdown-close', '_onSortDropdownClose');
-			},
 			/*
 			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
 			*
@@ -448,6 +464,22 @@
 				this._numSemesterFilters = 0;
 				this._numDepartmentFilters = 0;
 			},
+			_onBlurFilterText: function() {
+				this.toggleClass('highlight', false, this.$.filterText);
+				this.toggleClass('selected', false, this.$.filterText);
+			},
+			_onBlurSortText: function() {
+				this.toggleClass('highlight', false, this.$.sortText);
+				this.toggleClass('selected', false, this.$.sortText);
+			},
+			_onFocusFilterText: function() {
+				this.toggleClass('highlight', true, this.$.filterText);
+				this.toggleClass('selected', true, this.$.filterText);
+			},
+			_onFocusSortText: function() {
+				this.toggleClass('highlight', true, this.$.sortText);
+				this.toggleClass('selected', true, this.$.sortText);
+			},
 			_onDepartmentsResponse: function(response) {
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
@@ -461,22 +493,6 @@
 					var semesters = parser.parse(response.detail.xhr.response);
 					this._semesterOrganizations = semesters.entities;
 				}
-			},
-			_onFilterDropdownOpen: function() {
-				this.toggleClass('selected', true, this.$.filterText);
-				this.toggleClass('selected', true, this.$.filterButton);
-			},
-			_onFilterDropdownClose: function() {
-				this.toggleClass('selected', false, this.$.filterText);
-				this.toggleClass('selected', false, this.$.filterButton);
-			},
-			_onSortDropdownOpen: function() {
-				this.toggleClass('selected', true, this.$.sortText);
-				this.toggleClass('selected', true, this.$.sortButton);
-			},
-			_onSortDropdownClose: function() {
-				this.toggleClass('selected', false, this.$.sortText);
-				this.toggleClass('selected', false, this.$.sortButton);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
@@ -531,7 +547,7 @@
 
 				var buttons = Polymer.dom(this.root).querySelectorAll('#sortDropdown .dropdown-content-item');
 				buttons.forEach(function(button) {
-					this.toggleClass('dropdown-content-item-selected', button.value === e.target.value, button);
+					this.toggleClass('selected', button.value === e.target.value, button);
 				}.bind(this));
 
 				var sortText = this.localize(this._sortTextOptions[this._sortField] || '');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -33,14 +33,14 @@
 			}
 			.filter-button {
 				@apply(--d2l-small-text);
- 				/* overrides to d2l-small-text */
- 				font-size: 1rem;
- 				color: var(--d2l-color-ferrite);
- 				/* end overrides */
- 				background: none;
- 				border: none;
- 				padding: 0;
- 				cursor: pointer;
+				/* overrides to d2l-small-text */
+				font-size: 1rem;
+				color: var(--d2l-color-ferrite);
+				/* end overrides */
+				background: none;
+				border: none;
+				padding: 0;
+				cursor: pointer;
 			}
 			.filter-item {
 				display: block;
@@ -50,7 +50,7 @@
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
-					margin-bottom: 60px;
+				margin-bottom: 60px;
 			}
 			.search-and-filter > d2l-search-widget {
 				width: 50%;
@@ -60,6 +60,38 @@
 			}
 			.search-and-filter .dropdown-icon {
 				margin-left: 12px;
+			}
+			.view-button {
+				@apply(--d2l-small-text);
+				/* overrides to d2l-small-text */
+				color: var(--d2l-color-ferrite);
+				/* end overrides */
+				background: none;
+				border: none;
+				padding: 0;
+				cursor: pointer;
+			}
+			.view-button-selected {
+				color: var(--d2l-color-celestine);
+			}
+			.hidden {
+				display: none;
+			}
+			.clear-button {
+				@apply(--d2l-small-text);
+				/* overrides to d2l-small-text */
+				font-size: 1rem;
+				color: var(--d2l-color-celestine);
+				/* end overrides */
+				background: none;
+				border: none;
+				padding: 0;
+				cursor: pointer;
+			}
+			.filter-and-clear {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
 			}
 		</style>
 
@@ -91,25 +123,52 @@
 						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</div>
 					<d2l-dropdown-content>
-						Filter by
-						<template is="dom-repeat" items="[[_semesterOrganizations]]">
-							<div class="filter-item">
-								<input
-									type="checkbox"
-									value="[[item.properties.id]]"
-									on-click="_updateParentOrganizations"
-									>[[item.properties.name]]</input>
-							</div>
-						</template>
-						<template is="dom-repeat" items="[[_departmentOrganizations]]">
-							<div class="filter-item">
-								<input
-									type="checkbox"
-									value="[[item.properties.id]]"
-									on-click="_updateParentOrganizations"
-									>[[item.properties.name]]</input>
-							</div>
-						</template>
+						<div class="filter-and-clear">
+							<span>Filter by</span>
+							<button on-tap="_clearFilters">Clear</button>
+						</div>
+						<div class="button-bar">
+							<button
+								id="semesterListButton"
+								class="view-button view-button-selected"
+								on-tap="_selectSemesterList"
+								aria-pressed="true">
+								Semester
+							</button>
+							<button
+								id="departmentListButton"
+								class="view-button"
+								on-tap="_selectDepartmentList"
+								aria-pressed="false">
+								Department
+							</button>
+						</div>
+						<div id="semesterList">
+							<template is="dom-repeat" items="[[_semesterOrganizations]]">
+								<div class="filter-item">
+									<label>
+										<input
+											type="checkbox"
+											value="[[item.properties.id]]"
+											on-click="_updateParentOrganizations" />
+										[[item.properties.name]]
+									</label>
+								</div>
+							</template>
+						</div>
+						<div id="departmentList" class="hidden">
+							<template is="dom-repeat" items="[[_departmentOrganizations]]">
+								<div class="filter-item">
+									<label>
+										<input
+											type="checkbox"
+											value="[[item.properties.id]]"
+											on-click="_updateParentOrganizations">
+										[[item.properties.name]]
+									</label>
+								</div>
+							</template>
+						</div>
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
@@ -243,6 +302,11 @@
 			loadCourseTiles: function() {
 				this.delayCourseTileLoad = false;
 			},
+			_clearFilters: function() {
+				Polymer.dom(this.root).querySelectorAll('.filter-item > input').forEach(function(checkbox) {
+					checkbox.checked = false;
+				});
+			},
 			_onFilterDropdownClick: function() {
 				if (!this._semesterOrganizations) {
 					this.$.semestersRequest.generateRequest();
@@ -262,6 +326,22 @@
 					var semesters = parser.parse(response.detail.xhr.response);
 					this._semesterOrganizations = semesters.entities;
 				}
+			},
+			_selectSemesterList: function() {
+				this.toggleClass('hidden', false, this.$.semesterList);
+				this.toggleClass('hidden', true, this.$.departmentList);
+				this.toggleClass('view-button-selected', true, this.$.semesterListButton);
+				this.toggleClass('view-button-selected', false, this.$.departmentListButton);
+				this.$.semesterListButton.setAttribute('aria-pressed', true);
+				this.$.departmentListButton.setAttribute('aria-pressed', false);
+			},
+			_selectDepartmentList: function() {
+				this.toggleClass('hidden', true, this.$.semesterList);
+				this.toggleClass('hidden', false, this.$.departmentList);
+				this.toggleClass('view-button-selected', false, this.$.semesterListButton);
+				this.toggleClass('view-button-selected', true, this.$.departmentListButton);
+				this.$.semesterListButton.setAttribute('aria-pressed', false);
+				this.$.departmentListButton.setAttribute('aria-pressed', true);
 			},
 			_updateParentOrganizations: function(e) {
 				if (e.target.checked) {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -33,17 +33,21 @@
 			d2l-alert {
 				margin-bottom: 20px;
 			}
-			.filter-button {
+			.dropdown-text {
 				@apply(--d2l-small-text);
 				/* overrides to d2l-small-text */
 				font-size: 1rem;
-				color: var(--d2l-color-ferrite);
 				/* end overrides */
-				background: none;
-				border: none;
-				padding: 0;
 				cursor: pointer;
 				margin-left: 30px;
+				padding: 0;
+			}
+			.dropdown-button {
+				background: none;
+				border: none;
+				cursor: pointer;
+				margin-left: 12px;
+				padding: 0;
 			}
 			.filter-item {
 				display: block;
@@ -58,14 +62,8 @@
 			.search-and-filter > d2l-search-widget {
 				width: 50%;
 			}
-			.search-and-filter .dropdown-icon {
-				margin-left: 12px;
-			}
 			.view-button {
 				@apply(--d2l-small-text);
-				/* overrides to d2l-small-text */
-				color: var(--d2l-color-ferrite);
-				/* end overrides */
 				background: none;
 				border: none;
 				padding: 10px;
@@ -86,9 +84,9 @@
 				/* end overrides */
 				background: none;
 				border: none;
-				padding: 0;
 				cursor: pointer;
 				margin: 0;
+				padding: 0;
 			}
 			.filter-and-clear, .button-bar {
 				display: flex;
@@ -133,9 +131,11 @@
 			</d2l-search-widget>
 
 			<div>
-				<button class="filter-button" on-tap="_toggleFilterDropdown">Filter</button>
+				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">Filter</span>
 				<d2l-dropdown id="filterDropdown">
-					<iron-icon class="d2l-dropdown-opener dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					<button class="d2l-dropdown-opener dropdown-button">
+						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					</button>
 					<d2l-dropdown-content>
 						<div class="filter-and-clear">
 							<span>Filter by</span>
@@ -188,9 +188,11 @@
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
-				<button class="filter-button" on-tap="_toggleSortDropdown">Sort: Date Pinned</button>
+				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">Sort: Date Pinned</span>
 				<d2l-dropdown id="sortDropdown">
-					<iron-icon class="d2l-dropdown-opener dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					<button class="d2l-dropdown-opener dropdown-button">
+						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					</button>
 					<d2l-dropdown-content>
 						Sort by
 						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">Date Pinned</a>
@@ -319,7 +321,7 @@
 				});
 				this._isFiltered = false;
 				this._parentOrganizationIds = [];
-				this.$$('.filter-button').textContent = 'Filter';
+				this.$.filterText.textContent = 'Filter';
 			},
 			_onDepartmentsResponse: function(response) {
 				if (response.detail.status === 200) {
@@ -366,13 +368,12 @@
 					this.splice('_parentOrganizationIds', index, 1);
 				}
 
-				var filterButton = this.$$('.filter-button');
 				if (this._parentOrganizationIds.length === 0) {
-					filterButton.textContent = 'Filter';
+					this.$.filterText.textContent = 'Filter';
 				} else if (this._parentOrganizationIds.length === 1) {
-					filterButton.textContent = 'Filter: 1 Filter';
+					this.$.filterText.textContent = 'Filter: 1 Filter';
 				} else {
-					filterButton.textContent = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
+					this.$.filterText.textContent = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
 				}
 			},
 			_updateSortBy: function(e) {
@@ -383,7 +384,7 @@
 					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
 				}.bind(this));
 
-				this.$$('#sortDropdown button.d2l-dropdown-opener').textContent = 'Sort: ' + e.target.textContent;
+				this.$.sortText.textContent = 'Sort: ' + e.target.textContent;
 
 				this.$.sortDropdown.toggleOpen();
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -28,30 +28,12 @@
 				margin: 20px 0 10px 0;
 				font-size: 20px;
 				/* end overrides */
-				clear: both;
 			}
 			d2l-alert {
 				margin-bottom: 20px;
 			}
-			.dropdown-text {
-				@apply(--d2l-small-text);
-				/* overrides to d2l-small-text */
-				font-size: 1rem;
-				/* end overrides */
-				cursor: pointer;
-				margin-left: 30px;
-				padding: 0;
-			}
-			.dropdown-button {
-				background: none;
-				border: none;
-				cursor: pointer;
-				margin-left: 12px;
-				padding: 0;
-			}
-			.filter-item {
-				display: block;
-				padding: 10px;
+			.hidden {
+				display: none;
 			}
 			.search-and-filter {
 				display: flex;
@@ -62,20 +44,25 @@
 			.search-and-filter > d2l-search-widget {
 				width: 50%;
 			}
-			.view-button {
+			.dropdown-text {
 				@apply(--d2l-small-text);
+				/* overrides to d2l-small-text */
+				font-size: 1rem;
+				/* end overrides */
+				cursor: pointer;
+				margin-left: 30px;
+				margin-right: 12px;
+				padding: 0;
+			}
+			.dropdown-button {
 				background: none;
 				border: none;
-				padding: 10px;
 				cursor: pointer;
+				padding: 0;
 			}
-			.view-button-selected {
-				color: var(--d2l-color-celestine);
-				border-top-width: 2px;
-				border-top-style: solid;
-			}
-			.hidden {
-				display: none;
+			iron-icon {
+				--iron-icon-height: 10px;
+				--iron-icon-width: 10px;
 			}
 			.clear-button {
 				@apply(--d2l-small-text);
@@ -88,23 +75,96 @@
 				margin: 0;
 				padding: 0;
 			}
-			.filter-and-clear, .button-bar {
+			.dropdown-content-header {
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
+				border-bottom: 1px solid var(--d2l-color-gypsum);
+				width: 100%;
+				padding: 20px;
 			}
-			.sort-button {
+			.dropdown-content-header-text {
+				font-weight: bold;
+			}
+			.dropdown-content-gradient {
+				background: linear-gradient(to top, white, var(--d2l-color-regolith));
+			}
+			.dropdown-content-tabs {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				margin-left: 20px;
+				margin-right: 20px;
+			}
+			.dropdown-content-tab-button {
+				@apply(--d2l-small-text);
+				background: none;
+				border: none;
+				border-top: 3px solid transparent;
+				padding: 10px;
+				cursor: pointer;
+				flex: 1;
+			}
+			.dropdown-content-tab-button-selected {
+				color: var(--d2l-color-celestine);
+				border-top-width: 3px;
+				border-top-color: var(--d2l-color-celestine);
+			}
+			.dropdown-content-item {
 				@apply(--d2l-small-text);
 				/* overrides to d2l-small-text */
-				font-size: 1rem;
+				font-weight: lighter;
 				/* end overrides */
 				display: block;
 				background: none;
 				border: none;
 				cursor: pointer;
+				margin: 0;
+				padding-top: 10px;
+				padding-bottom: 10px;
+				padding-left: 20px;
+				width: 100%;
+				text-align: left;
 			}
-			.sort-button-selected {
+			.dropdown-content-item input[type=checkbox]:after {
+				content: '';
+				display: inline-block;
+				visibility: visible;
+				width: 1rem;
+				height: 1rem;
+				margin-top: -0.2rem;
+				margin-right: 0.5rem;
+				margin-left: -0.5rem;
+				border-radius: 0.3rem;
+				border-style: solid;
+				border-color: var(--d2l-color-titanius);
+				border-width: 1px;
+				background-color: var(--d2l-color-woolonardo);
+			}
+			.dropdown-content-item input[type=checkbox]:focus::after {
+				border-color: var(--d2l-color-celestine);
+				border-width: 2px;
+			}
+			.dropdown-content-item input[type=checkbox]:checked::after {
+				background-image: url('../images/tier1/check.svg');
+				background-position: center center;
+				background-repeat: no-repeat;
+			}
+			.dropdown-content-item > iron-icon {
+				visibility: hidden;
+				margin-right: 20px;
+				--iron-icon-height: 20px;
+				--iron-icon-width: 20px;
+			}
+			.dropdown-content-item-selected {
 				color: var(--d2l-color-celestine);
+			}
+			.dropdown-content-item-selected > iron-icon {
+				visibility: visible;
+			}
+			#sortDropdown d2l-dropdown-content button {
+				border-bottom: 1px solid var(--d2l-color-gypsum);
+				font-size: 1rem;
 			}
 		</style>
 
@@ -134,34 +194,36 @@
 				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 				<d2l-dropdown id="filterDropdown">
 					<button class="d2l-dropdown-opener dropdown-button">
-						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
-					<d2l-dropdown-content>
-						<div class="filter-and-clear">
-							<span>{{localize('filtering.filterBy')}}</span>
+					<d2l-dropdown-content no-padding min-width="350">
+						<div class="dropdown-content-header">
+							<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
 							<template is="dom-if" if="[[_isFiltered]]">
 								<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 							</template>
 						</div>
-						<div class="button-bar">
-							<button
-								id="semesterListButton"
-								class="view-button view-button-selected"
-								on-tap="_selectSemesterList"
-								aria-pressed="true">
-								{{localize('filtering.semester')}}
-							</button>
-							<button
-								id="departmentListButton"
-								class="view-button"
-								on-tap="_selectDepartmentList"
-								aria-pressed="false">
-								{{localize('filtering.department')}}
-							</button>
+						<div class="dropdown-content-gradient">
+							<div class="dropdown-content-tabs">
+								<button
+									id="semesterListButton"
+									class="dropdown-content-tab-button dropdown-content-tab-button-selected"
+									on-tap="_selectSemesterList"
+									aria-pressed="true">
+									{{localize('filtering.semester')}}
+								</button>
+								<button
+									id="departmentListButton"
+									class="dropdown-content-tab-button"
+									on-tap="_selectDepartmentList"
+									aria-pressed="false">
+									{{localize('filtering.department')}}
+								</button>
+							</div>
 						</div>
 						<div id="semesterList">
 							<template is="dom-repeat" items="[[_semesterOrganizations]]">
-								<div class="filter-item">
+								<div class="dropdown-content-item">
 									<label>
 										<input
 											type="checkbox"
@@ -174,7 +236,7 @@
 						</div>
 						<div id="departmentList" class="hidden">
 							<template is="dom-repeat" items="[[_departmentOrganizations]]">
-								<div class="filter-item">
+								<div class="dropdown-content-item">
 									<label>
 										<input
 											type="checkbox"
@@ -191,12 +253,34 @@
 				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">{{localize('sorting.sortDatePinned')}}</span>
 				<d2l-dropdown id="sortDropdown">
 					<button class="d2l-dropdown-opener dropdown-button">
-						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
-					<d2l-dropdown-content>
-						{{localize('sorting.sortBy')}}
-						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">{{localize('sorting.datePinned')}}</a>
-						<button class="sort-button" value="lastAccessed" on-tap="_updateSortBy">{{localize('sorting.lastAccessed')}}</a>
+					<d2l-dropdown-content no-padding min-width="350">
+						<div class="dropdown-content-header">
+							<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+						</div>
+						<div class="dropdown-content-gradient">
+							<button class="dropdown-content-item" value="courseCode" on-tap="_updateSortBy">
+								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								{{localize('sorting.courseCode')}}
+							</button>
+							<button class="dropdown-content-item" value="courseName" on-tap="_updateSortBy">
+								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								{{localize('sorting.courseName')}}
+							</button>
+							<button class="dropdown-content-item dropdown-content-item-selected" value="pinDate" on-tap="_updateSortBy">
+								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								{{localize('sorting.datePinned')}}
+							</button>
+							<button class="dropdown-content-item" value="department" on-tap="_updateSortBy">
+								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								{{localize('sorting.department')}}
+							</button>
+							<button class="dropdown-content-item" value="lastAccessed" on-tap="_updateSortBy">
+								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								{{localize('sorting.lastAccessed')}}
+							</button>
+						</div>
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 			</div>
@@ -315,13 +399,19 @@
 			loadCourseTiles: function() {
 				this.delayCourseTileLoad = false;
 			},
+			_numSemesterFilters: 0,
+			_numDepartmentFilters: 0,
 			_clearFilters: function() {
-				Polymer.dom(this.root).querySelectorAll('.filter-item input').forEach(function(checkbox) {
+				Polymer.dom(this.root).querySelectorAll('.dropdown-content-item input').forEach(function(checkbox) {
 					checkbox.checked = false;
 				});
 				this._isFiltered = false;
 				this._parentOrganizationIds = [];
 				this.$.filterText.textContent = this.localize('filtering.filter');
+				this.$.semesterListButton.textContent = this.localize('filtering.semester');
+				this.$.departmentListButton.textContent = this.localize('filtering.department');
+				this._numSemesterFilters = 0;
+				this._numDepartmentFilters = 0;
 			},
 			_onDepartmentsResponse: function(response) {
 				if (response.detail.status === 200) {
@@ -340,16 +430,16 @@
 			_selectSemesterList: function() {
 				this.toggleClass('hidden', false, this.$.semesterList);
 				this.toggleClass('hidden', true, this.$.departmentList);
-				this.toggleClass('view-button-selected', true, this.$.semesterListButton);
-				this.toggleClass('view-button-selected', false, this.$.departmentListButton);
+				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.semesterListButton);
+				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.departmentListButton);
 				this.$.semesterListButton.setAttribute('aria-pressed', true);
 				this.$.departmentListButton.setAttribute('aria-pressed', false);
 			},
 			_selectDepartmentList: function() {
 				this.toggleClass('hidden', true, this.$.semesterList);
 				this.toggleClass('hidden', false, this.$.departmentList);
-				this.toggleClass('view-button-selected', false, this.$.semesterListButton);
-				this.toggleClass('view-button-selected', true, this.$.departmentListButton);
+				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.semesterListButton);
+				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.departmentListButton);
 				this.$.semesterListButton.setAttribute('aria-pressed', false);
 				this.$.departmentListButton.setAttribute('aria-pressed', true);
 			},
@@ -360,36 +450,58 @@
 				this.$.sortDropdown.toggleOpen();
 			},
 			_updateFilter: function(e) {
+				var isSemester = this.$.semesterList.contains(e.target);
+
 				if (e.target.checked) {
 					this.push('_parentOrganizationIds', e.target.value);
-					this._isFiltered = true;
+					isSemester ? this._numSemesterFilters++ : this._numDepartmentFilters++;
 				} else {
 					var index = this._parentOrganizationIds.indexOf(e.target.value);
 					this.splice('_parentOrganizationIds', index, 1);
+					isSemester ? this._numSemesterFilters-- : this._numDepartmentFilters--;
 				}
 
 				if (this._parentOrganizationIds.length === 0) {
-					this.$.filterText.textContent = this.localize('filtering.filter')
+					this.$.filterText.textContent = this.localize('filtering.filter');
 				} else if (this._parentOrganizationIds.length === 1) {
-					this.$.filterText.textContent = this.localize('filtering.filterSingle')
+					this.$.filterText.textContent = this.localize('filtering.filterSingle');
 				} else {
-					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'numFilters', this._parentOrganizationIds.length);
+					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'num', this._parentOrganizationIds.length);
 				}
+
+				this._isFiltered = this._parentOrganizationIds.length > 0;
+				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
+					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
+					: this.localize('filtering.semester');
+				this.$.departmentListButton.textContent = this._numDepartmentFilters > 0
+					? this.localize('filtering.departmentMultiple', 'num', this._numDepartmentFilters)
+					: this.localize('filtering.department');
 			},
 			_updateSortBy: function(e) {
 				this._sortField = e.target.value;
 
-				var buttons = Polymer.dom(this.root).querySelectorAll('#sortDropdown .sort-button');
+				var buttons = Polymer.dom(this.root).querySelectorAll('#sortDropdown .dropdown-content-item');
 				buttons.forEach(function(button) {
-					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
+					this.toggleClass('dropdown-content-item-selected', button.value === e.target.value, button);
 				}.bind(this));
 
 				var sortText;
-				switch(this._sortField) {
+				switch (this._sortField) {
+					case 'courseCode':
+						sortText = this.localize('sorting.sortCourseCode');
+						break;
+					case 'courseName':
+						sortText = this.localize('sorting.sortCourseName');
+						break;
 					case 'pinDate':
 						sortText = this.localize('sorting.sortDatePinned');
+						break;
+					case 'department':
+						sortText = this.localize('sorting.sortDepartment');
+						break;
 					case 'lastAccessed':
 						sortText = this.localize('sorting.sortLastAccessed');
+						break;
 				}
 
 				this.$.sortText.textContent = sortText;

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -34,6 +34,9 @@
 			.hidden {
 				display: none;
 			}
+			.invisible {
+				visibility: hidden;
+			}
 			.search-and-filter {
 				display: flex;
 				align-items: center;
@@ -95,19 +98,26 @@
 				margin-left: 20px;
 				margin-right: 20px;
 			}
+			.dropdown-content-tab {
+				flex: 1;
+			}
 			.dropdown-content-tab-button {
 				@apply(--d2l-small-text);
 				background: none;
 				border: none;
-				border-top: 3px solid transparent;
 				padding: 10px;
 				cursor: pointer;
-				flex: 1;
+				display: inherit;
 			}
 			.dropdown-content-tab-button-selected {
 				color: var(--d2l-color-celestine);
-				border-top-width: 3px;
-				border-top-color: var(--d2l-color-celestine);
+			}
+			.dropdown-content-tab-highlight {
+				background-color: var(--d2l-color-celestine);
+				border-bottom-left-radius: 4px;
+				border-bottom-right-radius: 4px;
+				height: 4px;
+				width: 100%;
 			}
 			.dropdown-content-item {
 				@apply(--d2l-small-text);
@@ -205,20 +215,26 @@
 						</div>
 						<div class="dropdown-content-gradient">
 							<div class="dropdown-content-tabs">
-								<button
-									id="semesterListButton"
-									class="dropdown-content-tab-button dropdown-content-tab-button-selected"
-									on-tap="_selectSemesterList"
-									aria-pressed="true">
-									{{localize('filtering.semester')}}
-								</button>
-								<button
-									id="departmentListButton"
-									class="dropdown-content-tab-button"
-									on-tap="_selectDepartmentList"
-									aria-pressed="false">
-									{{localize('filtering.department')}}
-								</button>
+								<div class="dropdown-content-tab">
+									<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
+									<button
+										id="semesterListButton"
+										class="dropdown-content-tab-button dropdown-content-tab-button-selected"
+										on-tap="_selectSemesterList"
+										aria-pressed="true">
+										{{localize('filtering.semester')}}
+									</button>
+								</div>
+								<div class="dropdown-content-tab">
+									<div class="dropdown-content-tab-highlight invisible" id="departmentListHighlight"></div>
+									<button
+										id="departmentListButton"
+										class="dropdown-content-tab-button"
+										on-tap="_selectDepartmentList"
+										aria-pressed="false">
+										{{localize('filtering.department')}}
+									</button>
+								</div>
 							</div>
 						</div>
 						<div id="semesterList">
@@ -432,6 +448,8 @@
 				this.toggleClass('hidden', true, this.$.departmentList);
 				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.semesterListButton);
 				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.departmentListButton);
+				this.toggleClass('invisible', false, this.$.semesterListHighlight);
+				this.toggleClass('invisible', true, this.$.departmentListHighlight);
 				this.$.semesterListButton.setAttribute('aria-pressed', true);
 				this.$.departmentListButton.setAttribute('aria-pressed', false);
 			},
@@ -440,6 +458,8 @@
 				this.toggleClass('hidden', false, this.$.departmentList);
 				this.toggleClass('dropdown-content-tab-button-selected', false, this.$.semesterListButton);
 				this.toggleClass('dropdown-content-tab-button-selected', true, this.$.departmentListButton);
+				this.toggleClass('invisible', true, this.$.semesterListHighlight);
+				this.toggleClass('invisible', false, this.$.departmentListHighlight);
 				this.$.semesterListButton.setAttribute('aria-pressed', false);
 				this.$.departmentListButton.setAttribute('aria-pressed', true);
 			},

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -30,9 +31,6 @@
 			d2l-alert {
 				margin-bottom: 20px;
 			}
-			d2l-search-widget {
-				margin-bottom: 60px;
-			}
 			.filter-button {
 				@apply(--d2l-small-text);
  				/* overrides to d2l-small-text */
@@ -47,6 +45,21 @@
 			.filter-item {
 				display: block;
 				padding: 10px;
+			}
+			.search-and-filter {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+					margin-bottom: 60px;
+			}
+			.search-and-filter > d2l-search-widget {
+				width: 50%;
+			}
+			.search-and-filter d2l-dropdown {
+				margin-left: 30px;
+			}
+			.search-and-filter .dropdown-icon {
+				margin-left: 12px;
 			}
 		</style>
 
@@ -64,39 +77,60 @@
 			on-iron-ajax-response="_onDepartmentsResponse">
 		</d2l-ajax>
 
-		<d2l-search-widget
-			hidden$="[[_hasEnrollments]]"
-			search-root-url="[[searchUrl]]"
-			parent-organization-ids="[[_parentOrganizationIds]]">
-		</d2l-search-widget>
+		<div class="search-and-filter">
+			<d2l-search-widget
+				hidden$="[[_hasEnrollments]]"
+				search-root-url="[[searchUrl]]"
+				parent-organization-ids="[[_parentOrganizationIds]]">
+			</d2l-search-widget>
 
-		<d2l-dropdown>
-			<div class="d2l-dropdown-opener">
-				<button class="d2l-dropdown-opener filter-button">Filter</button>
+			<div>
+				<d2l-dropdown>
+					<div class="d2l-dropdown-opener">
+						<button class="d2l-dropdown-opener filter-button">Filter</button>
+						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					</div>
+					<d2l-dropdown-content>
+						Filter by
+						<template is="dom-repeat" items="[[_semesterOrganizations]]">
+							<div class="filter-item">
+								<input
+									type="checkbox"
+									value="[[item.properties.id]]"
+									on-click="_updateParentOrganizations"
+									>[[item.properties.name]]</input>
+							</div>
+						</template>
+						<template is="dom-repeat" items="[[_departmentOrganizations]]">
+							<div class="filter-item">
+								<input
+									type="checkbox"
+									value="[[item.properties.id]]"
+									on-click="_updateParentOrganizations"
+									>[[item.properties.name]]</input>
+							</div>
+						</template>
+					</d2l-dropdown-content>
+				</d2l-dropdown>
+
+				<d2l-dropdown>
+					<div class="d2l-dropdown-opener">
+						<button class="d2l-dropdown-opener filter-button">Sort</button>
+						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+					</div>
+					<d2l-dropdown-content>
+						Sort by
+						<ul>
+							<li>Course Code</li>
+							<li>Course Name</li>
+							<li>Date Pinned</li>
+							<li>Department</li>
+							<li>Last Accessed</li>
+						</ul>
+					</d2l-dropdown-content>
+				</d2l-dropdown>
 			</div>
-			<d2l-dropdown-content>
-				Filter by
-				<template is="dom-repeat" items="[[_semesterOrganizations]]">
-					<div class="filter-item">
-						<input
-							type="checkbox"
-							value="[[item.properties.id]]"
-							on-click="_updateParentOrganizations"
-							>[[item.properties.name]]</input>
-					</div>
-				</template>
-				<template is="dom-repeat" items="[[_departmentOrganizations]]">
-					<div class="filter-item">
-						<input
-							type="checkbox"
-							value="[[item.properties.id]]"
-							on-click="_updateParentOrganizations"
-							>[[item.properties.name]]</input>
-					</div>
-				</template>
-			</d2l-dropdown-content>
-			</d2l-dropdown-button>
-		</d2l-dropdown>
+		</div>
 
 		<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -4,6 +4,8 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-menu/d2l-menu.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -93,6 +95,20 @@
 				align-items: center;
 				justify-content: space-between;
 			}
+			.sort-button {
+				@apply(--d2l-small-text);
+				/* overrides to d2l-small-text */
+				font-size: 1rem;
+				/* end overrides */
+				display: block;
+				background: none;
+				border: none;
+				padding: 0;
+				cursor: pointer;
+			}
+			.sort-button-selected {
+				color: var(--d2l-color-celestine);
+			}
 		</style>
 
 		<d2l-ajax
@@ -113,11 +129,12 @@
 			<d2l-search-widget
 				hidden$="[[_hasEnrollments]]"
 				search-root-url="[[searchUrl]]"
-				parent-organization-ids="[[_parentOrganizationIds]]">
+				parent-organization-ids="[[_parentOrganizationIds]]"
+				sort-field="[[_sortField]]">
 			</d2l-search-widget>
 
 			<div>
-				<d2l-dropdown>
+				<d2l-dropdown id="filterDropdown" no-auto-open>
 					<div class="d2l-dropdown-opener">
 						<button class="d2l-dropdown-opener filter-button">Filter</button>
 						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
@@ -150,7 +167,7 @@
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
-											on-click="_updateParentOrganizations" />
+											on-click="_updateFilter" />
 										[[item.properties.name]]
 									</label>
 								</div>
@@ -163,7 +180,7 @@
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
-											on-click="_updateParentOrganizations">
+											on-click="_updateFilter">
 										[[item.properties.name]]
 									</label>
 								</div>
@@ -172,20 +189,15 @@
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
-				<d2l-dropdown>
+				<d2l-dropdown id="sortDropdown">
 					<div class="d2l-dropdown-opener">
-						<button class="d2l-dropdown-opener filter-button">Sort</button>
+						<button class="d2l-dropdown-opener filter-button">Sort: Date Pinned</button>
 						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</div>
 					<d2l-dropdown-content>
 						Sort by
-						<ul>
-							<li>Course Code</li>
-							<li>Course Name</li>
-							<li>Date Pinned</li>
-							<li>Department</li>
-							<li>Last Accessed</li>
-						</ul>
+						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">Date Pinned</a>
+						<button class="sort-button" value="lastAccessed" on-tap="_updateSortBy">Last Accessed</a>
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 			</div>
@@ -245,6 +257,7 @@
 					type: String,
 					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=5'
 				},
+				_sortField: String,
 				_parentOrganizationIds: {
 					type: Array,
 					value: function() {
@@ -318,6 +331,14 @@
 					var parser = document.createElement('d2l-siren-parser');
 					var departments = parser.parse(response.detail.xhr.response);
 					this._departmentOrganizations = departments.entities;
+
+					if (this._semesterOrganizations) {
+						// We delay the opening of the menu until we have a response, so that the
+						// dropdown is sized correctly. Once we have the semesters and departments,
+						// we can just immediately open it on future clicks
+						this.$.filterDropdown.removeAttribute('no-auto-open', false);
+						this.$.filterDropdown.toggleOpen();
+					}
 				}
 			},
 			_onSemestersResponse: function(response) {
@@ -325,6 +346,14 @@
 					var parser = document.createElement('d2l-siren-parser');
 					var semesters = parser.parse(response.detail.xhr.response);
 					this._semesterOrganizations = semesters.entities;
+
+					if (this._departmentOrganizations) {
+						// We delay the opening of the menu until we have a response, so that the
+						// dropdown is sized correctly. Once we have the semesters and departments,
+						// we can just immediately open it on future clicks
+						this.$.filterDropdown.removeAttribute('no-auto-open', false);
+						this.$.filterDropdown.toggleOpen();
+					}
 				}
 			},
 			_selectSemesterList: function() {
@@ -343,13 +372,25 @@
 				this.$.semesterListButton.setAttribute('aria-pressed', false);
 				this.$.departmentListButton.setAttribute('aria-pressed', true);
 			},
-			_updateParentOrganizations: function(e) {
+			_updateFilter: function(e) {
 				if (e.target.checked) {
 					this.push('_parentOrganizationIds', e.target.value);
 				} else {
 					var index = this._parentOrganizationIds.indexOf(e.target.value);
 					this.splice('_parentOrganizationIds', index, 1);
 				}
+			},
+			_updateSortBy: function(e) {
+				this._sortField = e.target.value;
+
+				var buttons = Polymer.dom(this.root).querySelectorAll('#sortDropdown .sort-button');
+				buttons.forEach(function(button) {
+					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
+				}.bind(this));
+
+				this.$$('#sortDropdown button.d2l-dropdown-opener').innerHTML = "Sort: " + e.target.innerHTML;
+
+				this.$.sortDropdown.toggleOpen();
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,4 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
+<link rel="import" href="../d2l-dropdown/d2l-dropdown-button.html">
+<link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -21,6 +25,7 @@
 				margin: 20px 0 10px 0;
 				font-size: 20px;
 				/* end overrides */
+				clear: both;
 			}
 			d2l-alert {
 				margin-bottom: 20px;
@@ -28,12 +33,70 @@
 			d2l-search-widget {
 				margin-bottom: 60px;
 			}
+			.filter-button {
+				@apply(--d2l-small-text);
+ 				/* overrides to d2l-small-text */
+ 				font-size: 1rem;
+ 				color: var(--d2l-color-ferrite);
+ 				/* end overrides */
+ 				background: none;
+ 				border: none;
+ 				padding: 0;
+ 				cursor: pointer;
+			}
+			.filter-item {
+				display: block;
+				padding: 10px;
+			}
 		</style>
+
+		<d2l-ajax
+			id="semestersRequest"
+			url="[[_semestersUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onSemestersResponse">
+		</d2l-ajax>
+
+		<d2l-ajax
+			id="departmentsRequest"
+			url="[[_departmentsUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onDepartmentsResponse">
+		</d2l-ajax>
 
 		<d2l-search-widget
 			hidden$="[[_hasEnrollments]]"
-			organizations-url="/d2l/api/hm/organizations">
+			search-root-url="[[searchUrl]]"
+			parent-organization-ids="[[_parentOrganizationIds]]">
 		</d2l-search-widget>
+
+		<d2l-dropdown>
+			<div class="d2l-dropdown-opener">
+				<button class="d2l-dropdown-opener filter-button">Filter</button>
+			</div>
+			<d2l-dropdown-content>
+				Filter by
+				<template is="dom-repeat" items="[[_semesterOrganizations]]">
+					<div class="filter-item">
+						<input
+							type="checkbox"
+							value="[[item.properties.id]]"
+							on-click="_updateParentOrganizations"
+							>[[item.properties.name]]</input>
+					</div>
+				</template>
+				<template is="dom-repeat" items="[[_departmentOrganizations]]">
+					<div class="filter-item">
+						<input
+							type="checkbox"
+							value="[[item.properties.id]]"
+							on-click="_updateParentOrganizations"
+							>[[item.properties.name]]</input>
+					</div>
+				</template>
+			</d2l-dropdown-content>
+			</d2l-dropdown-button>
+		</d2l-dropdown>
 
 		<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 
@@ -71,6 +134,29 @@
 				delayCourseTileLoad: {
 					type: Boolean,
 					value: true
+				},
+				/*
+				* URL for search widget; should have search-my-enrollments Action
+				*/
+				searchUrl: {
+					type: String,
+					value: ''
+				},
+				_departmentOrganizations: Object,
+				_departmentsUrl: {
+					type: String,
+					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=203'
+				},
+				_semesterOrganizations: Object,
+				_semestersUrl: {
+					type: String,
+					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=5'
+				},
+				_parentOrganizationIds: {
+					type: Array,
+					value: function() {
+						return [];
+					}
 				}
 			},
 			behaviors: [
@@ -86,6 +172,12 @@
 				for (var i = 0; i < courseTileGrids.length; i++) {
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
+			},
+			attached: function() {
+				this.listen(this.$$('d2l-dropdown'), 'click', '_onFilterDropdownClick');
+			},
+			detached: function() {
+				this.unlisten(this.$$('d2l-dropdown'), 'click', '_onFilterDropdownClick');
 			},
 			/*
 			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
@@ -116,6 +208,34 @@
 			},
 			loadCourseTiles: function() {
 				this.delayCourseTileLoad = false;
+			},
+			_onFilterDropdownClick: function() {
+				if (!this._semesterOrganizations) {
+					this.$.semestersRequest.generateRequest();
+					this.$.departmentsRequest.generateRequest();
+				}
+			},
+			_onDepartmentsResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var departments = parser.parse(response.detail.xhr.response);
+					this._departmentOrganizations = departments.entities;
+				}
+			},
+			_onSemestersResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var semesters = parser.parse(response.detail.xhr.response);
+					this._semesterOrganizations = semesters.entities;
+				}
+			},
+			_updateParentOrganizations: function(e) {
+				if (e.target.checked) {
+					this.push('_parentOrganizationIds', e.target.value);
+				} else {
+					var index = this._parentOrganizationIds.indexOf(e.target.value);
+					this.splice('_parentOrganizationIds', index, 1);
+				}
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -56,6 +56,9 @@
 				margin-right: 12px;
 				padding: 0;
 			}
+			.selected {
+				color: var(--d2l-color-celestine);
+			}
 			.dropdown-button {
 				background: none;
 				border: none;
@@ -108,9 +111,6 @@
 				padding: 10px;
 				cursor: pointer;
 				display: inherit;
-			}
-			.dropdown-content-tab-button-selected {
-				color: var(--d2l-color-celestine);
 			}
 			.dropdown-content-tab-highlight {
 				background-color: var(--d2l-color-celestine);
@@ -203,7 +203,7 @@
 			<div>
 				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 				<d2l-dropdown id="filterDropdown">
-					<button class="d2l-dropdown-opener dropdown-button">
+					<button id="filterButton" class="d2l-dropdown-opener dropdown-button">
 						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content no-padding min-width="350">
@@ -219,7 +219,7 @@
 									<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
 									<button
 										id="semesterListButton"
-										class="dropdown-content-tab-button dropdown-content-tab-button-selected"
+										class="dropdown-content-tab-button selected"
 										on-tap="_selectSemesterList"
 										aria-pressed="true">
 										{{localize('filtering.semester')}}
@@ -268,7 +268,7 @@
 
 				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">{{localize('sorting.sortDatePinned')}}</span>
 				<d2l-dropdown id="sortDropdown">
-					<button class="d2l-dropdown-opener dropdown-button">
+					<button id="sortButton" class="d2l-dropdown-opener dropdown-button">
 						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content no-padding min-width="350">
@@ -385,6 +385,18 @@
 				this.$.semestersRequest.generateRequest();
 				this.$.departmentsRequest.generateRequest();
 			},
+			attached: function() {
+				this.listen(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownOpen');
+				this.listen(this.$.filterDropdown, 'd2l-dropdown-close', '_onFilterDropdownClose');
+				this.listen(this.$.sortDropdown, 'd2l-dropdown-open', '_onSortDropdownOpen');
+				this.listen(this.$.sortDropdown, 'd2l-dropdown-close', '_onSortDropdownClose');
+			},
+			detached: function() {
+				this.unlisten(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownOpen');
+				this.unlisten(this.$.filterDropdown, 'd2l-dropdown-open', '_onFilterDropdownClose');
+				this.unlisten(this.$.sortDropdown, 'd2l-dropdown-open', '_onSortDropdownOpen');
+				this.unlisten(this.$.sortDropdown, 'd2l-dropdown-close', '_onSortDropdownClose');
+			},
 			/*
 			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
 			*
@@ -450,6 +462,22 @@
 					this._semesterOrganizations = semesters.entities;
 				}
 			},
+			_onFilterDropdownOpen: function() {
+				this.toggleClass('selected', true, this.$.filterText);
+				this.toggleClass('selected', true, this.$.filterButton);
+			},
+			_onFilterDropdownClose: function() {
+				this.toggleClass('selected', false, this.$.filterText);
+				this.toggleClass('selected', false, this.$.filterButton);
+			},
+			_onSortDropdownOpen: function() {
+				this.toggleClass('selected', true, this.$.sortText);
+				this.toggleClass('selected', true, this.$.sortButton);
+			},
+			_onSortDropdownClose: function() {
+				this.toggleClass('selected', false, this.$.sortText);
+				this.toggleClass('selected', false, this.$.sortButton);
+			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
 				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
@@ -458,9 +486,9 @@
 				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
 			},
-			_toggleSelectedList(list, button, highlight, selected) {
+			_toggleSelectedList: function(list, button, highlight, selected) {
 				this.toggleClass('hidden', !selected, list);
-				this.toggleClass('dropdown-content-tab-button-selected', selected, button);
+				this.toggleClass('selected', selected, button);
 				this.toggleClass('invisible', !selected, highlight);
 				button.setAttribute('aria-pressed', selected);
 			},

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -417,6 +417,13 @@
 			},
 			_numSemesterFilters: 0,
 			_numDepartmentFilters: 0,
+			_sortTextOptions: {
+				'courseCode': 'sorting.sortCourseCode',
+				'courseName': 'sorting.sortCourseName',
+				'pinDate': 'sorting.sortDatePinned',
+				'department': 'sorting.sortDepartment',
+				'lastAccessed': 'sorting.sortLastAccessed'
+			},
 			_clearFilters: function() {
 				Polymer.dom(this.root).querySelectorAll('.dropdown-content-item input').forEach(function(checkbox) {
 					checkbox.checked = false;
@@ -505,24 +512,7 @@
 					this.toggleClass('dropdown-content-item-selected', button.value === e.target.value, button);
 				}.bind(this));
 
-				var sortText;
-				switch (this._sortField) {
-					case 'courseCode':
-						sortText = this.localize('sorting.sortCourseCode');
-						break;
-					case 'courseName':
-						sortText = this.localize('sorting.sortCourseName');
-						break;
-					case 'pinDate':
-						sortText = this.localize('sorting.sortDatePinned');
-						break;
-					case 'department':
-						sortText = this.localize('sorting.sortDepartment');
-						break;
-					case 'lastAccessed':
-						sortText = this.localize('sorting.sortLastAccessed');
-						break;
-				}
+				var sortText = this.localize(this._sortTextOptions[this._sortField] || '');
 
 				this.$.sortText.textContent = sortText;
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -131,16 +131,16 @@
 			</d2l-search-widget>
 
 			<div>
-				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">Filter</span>
+				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 				<d2l-dropdown id="filterDropdown">
 					<button class="d2l-dropdown-opener dropdown-button">
 						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content>
 						<div class="filter-and-clear">
-							<span>Filter by</span>
+							<span>{{localize('filtering.filterBy')}}</span>
 							<template is="dom-if" if="[[_isFiltered]]">
-								<button class="clear-button" on-tap="_clearFilters">Clear</button>
+								<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 							</template>
 						</div>
 						<div class="button-bar">
@@ -149,14 +149,14 @@
 								class="view-button view-button-selected"
 								on-tap="_selectSemesterList"
 								aria-pressed="true">
-								Semester
+								{{localize('filtering.semester')}}
 							</button>
 							<button
 								id="departmentListButton"
 								class="view-button"
 								on-tap="_selectDepartmentList"
 								aria-pressed="false">
-								Department
+								{{localize('filtering.department')}}
 							</button>
 						</div>
 						<div id="semesterList">
@@ -188,15 +188,15 @@
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
-				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">Sort: Date Pinned</span>
+				<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">{{localize('sorting.sortDatePinned')}}</span>
 				<d2l-dropdown id="sortDropdown">
 					<button class="d2l-dropdown-opener dropdown-button">
 						<iron-icon class="dropdown-icon" icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
 					<d2l-dropdown-content>
-						Sort by
-						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">Date Pinned</a>
-						<button class="sort-button" value="lastAccessed" on-tap="_updateSortBy">Last Accessed</a>
+						{{localize('sorting.sortBy')}}
+						<button class="sort-button sort-button-selected" value="pinDate" on-tap="_updateSortBy">{{localize('sorting.datePinned')}}</a>
+						<button class="sort-button" value="lastAccessed" on-tap="_updateSortBy">{{localize('sorting.lastAccessed')}}</a>
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 			</div>
@@ -321,7 +321,7 @@
 				});
 				this._isFiltered = false;
 				this._parentOrganizationIds = [];
-				this.$.filterText.textContent = 'Filter';
+				this.$.filterText.textContent = this.localize('filtering.filter');
 			},
 			_onDepartmentsResponse: function(response) {
 				if (response.detail.status === 200) {
@@ -369,11 +369,11 @@
 				}
 
 				if (this._parentOrganizationIds.length === 0) {
-					this.$.filterText.textContent = 'Filter';
+					this.$.filterText.textContent = this.localize('filtering.filter')
 				} else if (this._parentOrganizationIds.length === 1) {
-					this.$.filterText.textContent = 'Filter: 1 Filter';
+					this.$.filterText.textContent = this.localize('filtering.filterSingle')
 				} else {
-					this.$.filterText.textContent = 'Filter: ' + this._parentOrganizationIds.length + ' Filters';
+					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'numFilters', this._parentOrganizationIds.length);
 				}
 			},
 			_updateSortBy: function(e) {
@@ -384,9 +384,15 @@
 					this.toggleClass('sort-button-selected', button.value === e.target.value, button);
 				}.bind(this));
 
-				this.$.sortText.textContent = 'Sort: ' + e.target.textContent;
+				var sortText;
+				switch(this._sortField) {
+					case 'pinDate':
+						sortText = this.localize('sorting.sortDatePinned');
+					case 'lastAccessed':
+						sortText = this.localize('sorting.sortLastAccessed');
+				}
 
-				this.$.sortDropdown.toggleOpen();
+				this.$.sortText.textContent = sortText;
 			}
 		});
 	</script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -193,7 +193,17 @@
 				* Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
 				* @type Object
 				*/
-				_pinnedCoursesMap: Object
+				_pinnedCoursesMap: Object,
+				/*
+				* URL used by the search widget to fetch semester-type organizations
+				* @type {String}
+				*/
+				_semestersUrl: String,
+				/*
+				* URL used by the search widget to fetch department-type organizations
+				* @type {String}
+				*/
+				_departmentsUrl: String
 			},
 			behaviors: [
 				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -125,6 +125,9 @@
 			<d2l-all-courses
 				pinned-enrollments="{{pinnedEnrollments}}"
 				unpinned-enrollments="{{unpinnedEnrollments}}"
+				search-url="[[_enrollmentsSearchUrl]]"
+				semesters-url="[[_semestersUrl]]"
+				departments-url="[[_departmentsUrl]]"
 				locale="[[locale]]">
 			</d2l-all-courses>
 			<d2l-loading-spinner

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -200,6 +200,13 @@
 					}
 				},
 
+				_organizationRequests: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				},
+
 				/*
 				* The search string updated by the course search input
 				* @type {String}
@@ -317,6 +324,10 @@
 						this._searchAction,
 						queryParams
 					);
+
+					this._organizationRequests.forEach(function(req) {
+						req.abort();
+					});
 
 					this.$.searchRequest.generateRequest();
 				}
@@ -448,6 +459,7 @@
 						(function (index, self) {
 							var enrollment = enrollmentEntities[i];
 							var xhr = new XMLHttpRequest();
+							self.push('_organizationRequests', xhr);
 							xhr.open("GET", enrollment.getLinkByRel(/\/organization$/).href, true);
 							xhr.onload = function() {
 								if (xhr.readyState === 4) {

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -471,14 +471,14 @@
 					this._searchResults = [];
 					for (var i = 0; i < enrollmentEntities.length; i++) {
 						// Fetch each search result's organization's information
-						(function(enrollment, self, parser) {
+						(function(enrollment, index, self, parser) {
 							var ajax = document.createElement('d2l-ajax');
 							ajax.url = enrollment.getLinkByRel(/\/organization$/).href;
 							ajax.method = 'GET';
 							ajax.onResponse = function(response) {
 								if (response.detail.status === 200 || response.detail.status === 304) {
 									var organization = parser.parse(response.detail.response);
-									self.push('_searchResults', {
+									self.splice('_searchResults', index, 0, {
 										name: organization.properties.name,
 										href: organization.getLinkByRel(/\/organization-homepage$/).href
 									});
@@ -486,7 +486,7 @@
 							};
 							ajax.generateRequest();
 							self.push('_organizationRequests', ajax);
-						})(enrollmentEntities[i], this, parser);
+						})(enrollmentEntities[i], i, this, parser);
 					}
 				}
 			},

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -79,15 +79,11 @@
 				border: none;
 				margin: 0;
 				cursor: pointer;
-				opacity: 0.7;
-			}
-			.search-icon:focus,
-			.search-icon:hover {
-				opacity: 1.0;
+				height: 100%;
 			}
 			.search-icon iron-icon {
-				width: 30px;
-				height: 30px;
+				--iron-icon-height: 22px;
+				--iron-icon-width: 22px;
 				color: var(--d2l-color-tungsten);
 			}
 

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -330,8 +330,11 @@
 					);
 
 					this._organizationRequests.forEach(function(req) {
-						req.abort();
+						if (req.abort) {
+							req.abort();
+						}
 					});
+					this.set('_organizationRequests', []);
 
 					this.$.searchRequest.generateRequest();
 				}
@@ -457,29 +460,26 @@
 					var enrollmentEntities = searchResponse.entities;
 
 					this._searchResults = [];
+					var parser = document.createElement('d2l-siren-parser');
 					for (var i = 0; i < enrollmentEntities.length; i++) {
 						// Fetch each search result's organization's information
-						// Needs to be done in a closure since XHR is async
-						(function(index, self) {
-							var enrollment = enrollmentEntities[i];
-							var xhr = new XMLHttpRequest();
-							self.push('_organizationRequests', xhr);
-							xhr.open('GET', enrollment.getLinkByRel(/\/organization$/).href, true);
-							xhr.onload = function() {
-								if (xhr.readyState === 4) {
-									if (xhr.status === 200 || xhr.status === 304) {
-										var organizationParser = document.createElement('d2l-siren-parser');
-										var organization = organizationParser.parse(xhr.response);
-										self.push('_searchResults', {
-											name: organization.properties.name,
-											href: organization.getLinkByRel(/\/organization-homepage$/).href
-										});
-										self.$$('iron-pages').select(self._searchResults.length > 0 ? 'search-results-page' : 'no-results-page');
-									}
+						(function(enrollment, self, parser) {
+							var ajax = document.createElement('d2l-ajax');
+							ajax.url = enrollment.getLinkByRel(/\/organization$/).href;
+							ajax.method = 'GET';
+							ajax.onResponse = function(response) {
+								if (response.detail.status === 200 || response.detail.status === 304) {
+									var organization = parser.parse(response.detail.response);
+									self.push('_searchResults', {
+										name: organization.properties.name,
+										href: organization.getLinkByRel(/\/organization-homepage$/).href
+									});
+									self.$$('iron-pages').select(self._searchResults.length > 0 ? 'search-results-page' : 'no-results-page');
 								}
 							};
-							xhr.send(null);
-						})(i, this);
+							ajax.generateRequest();
+							self.push('_organizationRequests', ajax);
+						})(enrollmentEntities[i], this, parser);
 					}
 				}
 			},

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -190,12 +190,6 @@
 				},
 
 				/*
-				* Parameter to be sent as `sortField` parameter when searching
-				* @type {String}
-				*/
-				sortField: String,
-
-				/*
 				* Array of parent organization IDs by which to limit the search results
 				* @type {String}
 				*/
@@ -207,8 +201,8 @@
 				},
 
 				/*
-				* Outstanding /organizations XHRs, which are cancelled when a new search starts
-				* @Type {Array}
+ 				* Outstanding /organizations XHRs, which are cancelled when a new search starts
+ 				* @type {Array}
 				*/
 				_organizationRequests: {
 					type: Array,
@@ -327,8 +321,7 @@
 						search: this._searchString,
 						page: 1,
 						pageSize: 5,
-						parentOrganizationIds: this.parentOrganizationIds.join(','),
-						sortField: this.sortField
+						parentOrganizationIds: this.parentOrganizationIds.join(',')
 					};
 
 					this._searchUrl = this.createActionUrl(
@@ -467,11 +460,11 @@
 					for (var i = 0; i < enrollmentEntities.length; i++) {
 						// Fetch each search result's organization's information
 						// Needs to be done in a closure since XHR is async
-						(function (index, self) {
+						(function(index, self) {
 							var enrollment = enrollmentEntities[i];
 							var xhr = new XMLHttpRequest();
 							self.push('_organizationRequests', xhr);
-							xhr.open("GET", enrollment.getLinkByRel(/\/organization$/).href, true);
+							xhr.open('GET', enrollment.getLinkByRel(/\/organization$/).href, true);
 							xhr.onload = function() {
 								if (xhr.readyState === 4) {
 									if (xhr.status === 200 || xhr.status === 304) {

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -101,17 +101,17 @@
 		</style>
 
 		<d2l-ajax
-			id="organizationsSearchRootRequest"
-			url="[[organizationsUrl]]"
+			id="searchRootRequest"
+			url="[[searchRootUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onOrganizationsSearchRootResponse">
+			on-iron-ajax-response="_onSearchRootResponse">
 		</d2l-ajax>
 
 		<d2l-ajax
-			id="coursesSearchRequest"
-			url="[[_organizationsSearchUrl]]"
+			id="searchRequest"
+			url="[[_searchUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onCoursesSearchResponse">
+			on-iron-ajax-response="_onSearchResponse">
 		</d2l-ajax>
 
 		<d2l-dropdown no-auto-open>
@@ -155,7 +155,7 @@
 
 						<div class="search-results-listbox-page" data-page-name="search-results-page">
 							<d2l-search-listbox>
-								<template id="courseSearchResultsTemplate" is="dom-repeat" items="[[_courseSearchResults]]">
+								<template id="courseSearchResultsTemplate" is="dom-repeat" items="[[_searchResults]]">
 									<div selectable data-text$="[[item.name]]" data-href$="[[item.href]]" role="option">
 										[[item.name]]
 									</div>
@@ -180,8 +180,25 @@
 			is: 'd2l-search-widget',
 
 			properties: {
+				/*
+				* Root search URL, which should have the search Action in the response
+				* @type {String}
+				*/
+				searchRootUrl: {
+					type: String,
+					observer: '_onSearchRootUrlChanged'
+				},
 
-				organizationsUrl: String,
+				/*
+				* Array of parent organization IDs by which to limit the search results
+				* @type {String}
+				*/
+				parentOrganizationIds: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				},
 
 				/*
 				* The search string updated by the course search input
@@ -196,17 +213,17 @@
 				},
 
 				/*
-				* An array of objects containing the results of the search-course-collection action
+				* An array of objects containing the results of the search-my-enrollments action
 				* @type {Array<Object>}
 				*/
-				_courseSearchResults: {
+				_searchResults: {
 					type: Array,
 					value: function() {
 						return [];
 					}
 				},
 
-				_organizationsSearchUrl: String,
+				_searchUrl: String,
 
 				/*
 				* List of strings containing previously searched terms/selected courses
@@ -252,7 +269,6 @@
 				}
 
 				this._initializePreviousSearches();
-				this.$.organizationsSearchRootRequest.generateRequest();
 			},
 
 			detached: function() {
@@ -284,7 +300,7 @@
 			},
 
 			/*
-			* Calls the search-course-collection action, used to populate live search results in the listbox
+			* Calls the search-my-enrollments action, used to populate live search results in the listbox
 			*/
 			_liveSearch: function() {
 				if (this._searchString) {
@@ -293,16 +309,16 @@
 					var queryParams = {
 						search: this._searchString,
 						page: 1,
-						pageSize: 5
+						pageSize: 5,
+						parentOrganizationIds: this.parentOrganizationIds.join(',')
 					};
 
-					this._organizationsSearchUrl = this.createActionUrl(
-						this._organizationsSearchAction,
-						queryParams,
-						1
+					this._searchUrl = this.createActionUrl(
+						this._searchAction,
+						queryParams
 					);
 
-					this.$.coursesSearchRequest.generateRequest();
+					this.$.searchRequest.generateRequest();
 				}
 			},
 
@@ -325,7 +341,7 @@
 				this.cancelDebouncer('liveSearchJob');
 				this.$$('iron-pages').select('recent-searches-page');
 				this._searchString = '';
-				this.set('_courseSearchResults', []);
+				this.set('_searchResults', []);
 			},
 
 			_onSearchStringChanged: function(newString) {
@@ -400,38 +416,55 @@
 				return this._advancedSearchUrl + searchTerm;
 			},
 
-			_onOrganizationsSearchRootResponse: function(response) {
+			_onSearchRootUrlChanged: function(url) {
+				if (url) {
+					this.$.searchRootRequest.generateRequest();
+				}
+			},
+
+			_onSearchRootResponse: function(response) {
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
-					var organizationsResponse = parser.parse(response.detail.xhr.response);
+					var searchRootResponse = parser.parse(response.detail.xhr.response);
 
-					this._organizationsSearchAction = organizationsResponse.getActionByName('search-course-collection');
-
-					// Temporarily override action href as actions won't work with canonical API until routes fixed
-					this._organizationsSearchAction.href = '/d2l/api/hm/organizations';
+					this._searchAction = searchRootResponse.getActionByName('search-my-enrollments');
 				}
 			},
 
 			/*
-			* Called when search-course-collection response received
+			* Called when search-my-enrollments response received
 			* @param {Object}
 			*/
-			_onCoursesSearchResponse: function(response) {
+			_onSearchResponse: function(response) {
 				if (response.detail.status === 200 && this._searchString) {
 					var parser = document.createElement('d2l-siren-parser');
-					var organizationResponse = parser.parse(response.detail.xhr.response);
-					var organizationEntities = organizationResponse.entities;
-					var courseSearchResults = [];
+					var searchResponse = parser.parse(response.detail.xhr.response);
+					var enrollmentEntities = searchResponse.entities;
 
-					for (var i = 0; i < organizationEntities.length; i++) {
-						courseSearchResults.push({
-							name: organizationEntities[i].properties.name,
-							href: organizationEntities[i].getLinkByRel(/\/organization-homepage$/).href
-						});
+					this._searchResults = [];
+					for (var i = 0; i < enrollmentEntities.length; i++) {
+						// Fetch each search result's organization's information
+						// Needs to be done in a closure since XHR is async
+						(function (index, self) {
+							var enrollment = enrollmentEntities[i];
+							var xhr = new XMLHttpRequest();
+							xhr.open("GET", enrollment.getLinkByRel(/\/organization$/).href, true);
+							xhr.onload = function() {
+								if (xhr.readyState === 4) {
+									if (xhr.status === 200 || xhr.status === 304) {
+										var organizationParser = document.createElement('d2l-siren-parser');
+										var organization = organizationParser.parse(xhr.response);
+										self.push('_searchResults', {
+											name: organization.properties.name,
+											href: organization.getLinkByRel(/\/organization-homepage$/).href
+										});
+										self.$$('iron-pages').select(self._searchResults.length > 0 ? 'search-results-page' : 'no-results-page');
+									}
+								}
+							};
+							xhr.send(null);
+						})(i, this);
 					}
-
-					this.set('_courseSearchResults', courseSearchResults);
-					this.$$('iron-pages').select(courseSearchResults.length > 0 ? 'search-results-page' : 'no-results-page');
 				}
 			},
 
@@ -441,7 +474,7 @@
 			_onIronSelect: function(e) {
 				switch (e.target.nodeName) {
 					case 'IRON-PAGES':
-						// @TODO: Not a fan of any of this "current listbox" handling - necessary right now due to Iron Behavios regressions.
+						// @TODO: Not a fan of any of this "current listbox" handling - necessary right now due to Iron Behavior regressions.
 						// Should find a better way.
 						var ironPages = this.$$('iron-pages');
 						var pageIndex = ironPages.indexOf(ironPages.selectedItem);

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -190,6 +190,12 @@
 				},
 
 				/*
+				* Value to send for the `sortField` parameter in the search query
+				* @type {String}
+				*/
+				sortField: String,
+
+				/*
 				* Array of parent organization IDs by which to limit the search results
 				* @type {String}
 				*/
@@ -321,7 +327,8 @@
 						search: this._searchString,
 						page: 1,
 						pageSize: 5,
-						parentOrganizationIds: this.parentOrganizationIds.join(',')
+						parentOrganizationIds: this.parentOrganizationIds.join(','),
+						sortField: this.sortField
 					};
 
 					this._searchUrl = this.createActionUrl(
@@ -459,8 +466,9 @@
 					var searchResponse = parser.parse(response.detail.xhr.response);
 					var enrollmentEntities = searchResponse.entities;
 
+					this.$$('iron-pages').select(enrollmentEntities.length > 0 ? 'search-results-page' : 'no-results-page');
+
 					this._searchResults = [];
-					var parser = document.createElement('d2l-siren-parser');
 					for (var i = 0; i < enrollmentEntities.length; i++) {
 						// Fetch each search result's organization's information
 						(function(enrollment, self, parser) {
@@ -474,7 +482,6 @@
 										name: organization.properties.name,
 										href: organization.getLinkByRel(/\/organization-homepage$/).href
 									});
-									self.$$('iron-pages').select(self._searchResults.length > 0 ? 'search-results-page' : 'no-results-page');
 								}
 							};
 							ajax.generateRequest();

--- a/d2l-search-widget.html
+++ b/d2l-search-widget.html
@@ -190,6 +190,12 @@
 				},
 
 				/*
+				* Parameter to be sent as `sortField` parameter when searching
+				* @type {String}
+				*/
+				sortField: String,
+
+				/*
 				* Array of parent organization IDs by which to limit the search results
 				* @type {String}
 				*/
@@ -200,6 +206,10 @@
 					}
 				},
 
+				/*
+				* Outstanding /organizations XHRs, which are cancelled when a new search starts
+				* @Type {Array}
+				*/
 				_organizationRequests: {
 					type: Array,
 					value: function() {
@@ -317,7 +327,8 @@
 						search: this._searchString,
 						page: 1,
 						pageSize: 5,
-						parentOrganizationIds: this.parentOrganizationIds.join(',')
+						parentOrganizationIds: this.parentOrganizationIds.join(','),
+						sortField: this.sortField
 					};
 
 					this._searchUrl = this.createActionUrl(

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -72,7 +72,7 @@
 			-webkit-overflow-scrolling: touch;
 			border-top: 2px solid var(--d2l-color-gypsum);
 			background: linear-gradient(to top, var(--d2l-color-white), var(--d2l-color-regolith));
-			padding-top: 15px;
+			padding-top: 40px;
 			background-size: 100% 350px;
 			background-repeat: repeat-x;
 		}

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -19,9 +19,8 @@
 		* Creates a URL with a query from an Action and an object of required parameters
 		* @param {Action} action
 		* @param {Object} parameters Query parameters, as { parameterName: desiredValue, ... }
-		* @param {embedDepth} Embed depth of response entity
 		*/
-		createActionUrl: function(action, parameters, embedDepth) {
+		createActionUrl: function(action, parameters) {
 			parameters = parameters || {};
 			action.fields = action.fields || [];
 			var query = {};
@@ -33,11 +32,6 @@
 					query[field.name] = field.value;
 				}
 			});
-
-			// Temporary override, as some actions don't specify embedDepth as a parameter on the action. Could invert above logic or, well, fix in LMS
-			if (embedDepth) {
-				query['embedDepth'] = embedDepth;
-			}
 
 			var queryString = Object.keys(query).map(function(key) {
 				return key + '=' + query[key];

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -63,14 +63,22 @@
 							'filtering.filter': 'Filter',
 							'filtering.filterBy': 'Filter By',
 							'filtering.filterSingle': 'Filter: 1 Filter',
-							'filtering.filterMultiple': 'Filter: {numFilters} Filters',
+							'filtering.filterMultiple': 'Filter: {num} Filters',
 							'filtering.clear': 'Clear',
 							'filtering.semester': 'Semester',
 							'filtering.department': 'Department',
+							'filtering.semesterMultiple': 'Semester ({num})',
+							'filtering.departmentMultiple': 'Semester ({num})',
+							'sorting.sortCourseCode': 'Sort: Course Code',
+							'sorting.sortCourseName': 'Sort: Course Name',
 							'sorting.sortDatePinned': 'Sort: Date Pinned',
+							'sorting.sortDepartment': 'Sort: Department',
 							'sorting.sortLastAccessed': 'Sort: Last Accessed',
 							'sorting.sortBy': 'Sort By',
+							'sorting.courseCode': 'Course Code',
+							'sorting.courseName': 'Course Name',
 							'sorting.datePinned': 'Date Pinned',
+							'sorting.department': 'Department',
 							'sorting.lastAccessed': 'Last Accessed'
 						};
 

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -59,7 +59,19 @@
 							'recentSearches': 'Recent Searches',
 							'changeImage': 'Change Image',
 							'useThisImage': 'Use this image',
-							'courseSettings': '{course} course settings'
+							'courseSettings': '{course} course settings',
+							'filtering.filter': 'Filter',
+							'filtering.filterBy': 'Filter By',
+							'filtering.filterSingle': 'Filter: 1 Filter',
+							'filtering.filterMultiple': 'Filter: {numFilters} Filters',
+							'filtering.clear': 'Clear',
+							'filtering.semester': 'Semester',
+							'filtering.department': 'Department',
+							'sorting.sortDatePinned': 'Sort: Date Pinned',
+							'sorting.sortLastAccessed': 'Sort: Last Accessed',
+							'sorting.sortBy': 'Sort By',
+							'sorting.datePinned': 'Date Pinned',
+							'sorting.lastAccessed': 'Last Accessed'
 						};
 
 						return {

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -232,17 +232,14 @@ describe('d2l-my-courses', function() {
 			server.respondWith(
 				'GET',
 				new RegExp(searchHref),
-				function() {
-					var reqCount = 0;
-					return function(req) {
-						expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
-						if (reqCount++ === 0) {
-							req.respond(200, {}, JSON.stringify(enrollmentsSearchResponse));
-						} else {
-							req.respond(200, {}, JSON.stringify(enrollmentsNextPageSearchResponse));
-						}
-					};
-				}());
+				function(req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					if (widget.pinnedEnrollments.length === 0) {
+						req.respond(200, {}, JSON.stringify(enrollmentsSearchResponse));
+					} else {
+						req.respond(200, {}, JSON.stringify(enrollmentsNextPageSearchResponse));
+					}
+				});
 
 			var enrollmentsSearchSpy = sinon.spy(widget, '_onEnrollmentsSearchResponse');
 


### PR DESCRIPTION
The filtering and sorting here applies to the values that are shown in the live search dropdown - since we elected to move advanced searching to the existing advanced search page, the UI won't actually update when you select a new filter/sort. To check it out, apply filters/sort, then type in the search field. It's not intended to be like this permanently, but updating the course tiles with your search/filters/sorting is a future thing.

TODO:

- [x] Fix search when canonical namespace feature is enabled
- [x] Prevent dropdown menu from moving around when selecting/unselecting filters
- [x] Fix dropdowns to use buttons rather than icons
- [x] Localize
- [x] Match UI to designs

Things that were TODO but are no longer TODO because reasons:

- ~~Update search when filters/sort order change~~ - Doesn't work for live search approach, but this will have to be done when updating tiles
- ~~Display results as course tiles, not just in dropdown/live search box~~ Separate PR; this will be a fairly large piece of work
- ~~Add search box in filters when required~~ Separate PR; during the leap sprint I'm going to break out the search widget into its own repo, which will mucho-facilitate this (see TA104610)
- ~~Mobile view~~ Separate PR; pseudo-blocked on the breaking out of the search widget as well (see TA104609)
- ~~`box-shadow` above/below dropdown menu contents~~ See https://github.com/Brightspace/d2l-dropdown-ui/issues/76