### PR TITLE
US76123 - Dropdown search

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "d2l-loading-spinner": "^4.0.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#*",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.3",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-typography": "^4.0.0",
     "iron-a11y-keys": "^1.0.6",

--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "d2l-loading-spinner": "^4.0.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.8",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.9",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-typography": "^4.0.0",
     "iron-a11y-keys": "^1.0.6",

--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "d2l-loading-spinner": "^4.0.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.6",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.8",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-typography": "^4.0.0",
     "iron-a11y-keys": "^1.0.6",

--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,7 @@
     "d2l-loading-spinner": "^4.0.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#*",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-typography": "^4.0.0",
     "iron-a11y-keys": "^1.0.6",

--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "d2l-loading-spinner": "^4.0.0",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.3",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.6",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
     "d2l-typography": "^4.0.0",
     "iron-a11y-keys": "^1.0.6",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -336,10 +336,6 @@
 								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
 								{{localize('sorting.datePinned')}}
 							</button>
-							<button class="dropdown-content-item" value="department" on-tap="_updateSortBy">
-								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
-								{{localize('sorting.department')}}
-							</button>
 							<button class="dropdown-content-item" value="lastAccessed" on-tap="_updateSortBy">
 								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
 								{{localize('sorting.lastAccessed')}}
@@ -468,7 +464,7 @@
 			},
 			attached: function() {
 				this._onResize();
-				window.addEventListener('resize', this._onResize);
+				window.addEventListener('resize', this._onResize.bind(this));
 
 				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
@@ -478,7 +474,7 @@
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 			},
 			detached: function() {
-				window.removeEventListener('resize', this._onResize);
+				window.removeEventListener('resize', this._onResize.bind(this));
 
 				this.unlisten(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.unlisten(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
@@ -519,8 +515,11 @@
 				'courseCode': 'sorting.sortCourseCode',
 				'courseName': 'sorting.sortCourseName',
 				'pinDate': 'sorting.sortDatePinned',
-				'department': 'sorting.sortDepartment',
 				'lastAccessed': 'sorting.sortLastAccessed'
+			},
+			_changeTextFocus: function(element, focused) {
+				this.toggleClass('highlight', focused, element);
+				this.toggleClass('selected', focused, element);
 			},
 			_checkFilterEntities: function(entities) {
 				entities.forEach(function(entity) {
@@ -553,62 +552,48 @@
 				this.$.scrollThreshold.clearTriggers();
 			},
 			_onBlurFilterText: function() {
-				this.toggleClass('highlight', false, this.$.filterText);
-				this.toggleClass('selected', false, this.$.filterText);
+				this._changeTextFocus(this.$.filterText, false);
 			},
 			_onBlurSortText: function() {
-				this.toggleClass('highlight', false, this.$.sortText);
-				this.toggleClass('selected', false, this.$.sortText);
+				this._changeTextFocus(this.$.sortText, false);
 			},
 			_onFocusFilterText: function() {
-				this.toggleClass('highlight', true, this.$.filterText);
-				this.toggleClass('selected', true, this.$.filterText);
+				this._changeTextFocus(this.$.filterText, true);
 			},
 			_onFocusSortText: function() {
-				this.toggleClass('highlight', true, this.$.sortText);
-				this.toggleClass('selected', true, this.$.sortText);
+				this._changeTextFocus(this.$.sortText, true);
+			},
+			_updateMoreParameters: function(entity, moreUrlPath, hasMorePath) {
+				this._checkFilterEntities(entity.entities);
+
+				this.set(hasMorePath, entity.hasLinkByRel('next'));
+				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
 			},
 			_onDepartmentSearchResults: function(e) {
-				var entity = e.detail.value;
-
-				this._checkFilterEntities(entity.entities);
-				this.set('_departmentOrganizations', entity.entities);
-
-				this.set('_moreDepartmentsUrl', entity.hasLinkByRel('next') ? entity.getLinkByRel('next').href : '');
-				this.set('_hasMoreDepartments', this._moreDepartmentsUrl.length > 0);
+				this.set('_departmentOrganizations', e.detail.value.entities);
+				this._updateMoreParameters(e.detail.value, '_moreDepartmentsUrl', '_hasMoreDepartments');
 			},
 			_onSemesterSearchResults: function(e) {
-				var entity = e.detail.value;
+				this.set('_semesterOrganizations', e.detail.value.entities);
+				this._updateMoreParameters(e.detail.value, '_moreSemestersUrl', '_hasMoreSemesters');
+			},
+			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var parser = document.createElement('d2l-siren-parser');
+					var responseEntity = parser.parse(response.detail.xhr.response);
 
-				this._checkFilterEntities(entity.entities);
-				this.set('_semesterOrganizations', entity.entities);
+					responseEntity.entities.forEach(function(entity) {
+						this.push(organizationsPath, entity);
+					}.bind(this));
 
-				this.set('_moreSemestersUrl', entity.hasLinkByRel('next') ? entity.getLinkByRel('next').href : '');
-				this.set('_hasMoreSemesters', this._moreSemestersUrl.length > 0);
+					this._updateMoreParameters(responseEntity, moreUrlPath, hasMorePath);
+				}
 			},
 			_onMoreDepartmentsResponse: function(response) {
-				if (response.detail.status === 200 || response.detail.status === 304) {
-					var parser = document.createElement('d2l-siren-parser');
-					var moreDepartments = parser.parse(response.detail.xhr.response);
-					moreDepartments.entities.forEach(function(department) {
-						this.push('_departmentOrganizations', department);
-					}.bind(this));
-
-					this.set('_moreDepartmentsUrl', moreDepartments.hasLinkByRel('next') ? moreDepartments.getLinkByRel('next').href : '');
-					this.set('_hasMoreDepartments', this._moreDepartmentsUrl.length > 0);
-				}
+				this._onMoreResponse(response, '_departmentOrganizations', '_moreDepartmentsUrl', '_hasMoreDepartments');
 			},
 			_onMoreSemestersResponse: function(response) {
-				if (response.detail.status === 200 || response.detail.status === 304) {
-					var parser = document.createElement('d2l-siren-parser');
-					var moreSemesters = parser.parse(response.detail.xhr.response);
-					moreSemesters.entities.forEach(function(semester) {
-						this.push('_semesterOrganizations', semester);
-					}.bind(this));
-
-					this.set('_moreSemestersUrl', moreSemesters.hasLinkByRel('next') ? moreSemesters.getLinkByRel('next').href : '');
-					this.set('_hasMoreSemesters', this._moreSemestersUrl.length > 0);
-				}
+				this._onMoreResponse(response, '_semesterOrganizations', '_moreSemestersUrl', '_hasMoreSemesters');
 			},
 			_onResize: function() {
 				this.toggleClass('hidden', window.innerWidth < 768, this.$.filterAndSort);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
@@ -43,7 +44,7 @@
 				margin-bottom: 60px;
 			}
 			.search-and-filter > d2l-search-widget-custom {
-				width: 50%;
+				flex: 1
 			}
 			.dropdown-text {
 				@apply(--d2l-small-text);
@@ -203,6 +204,20 @@
 			}
 		</style>
 
+		<d2l-ajax
+			id="moreDepartmentsRequest"
+			url="[[_moreDepartmentsUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreDepartmentsResponse">
+		</d2l-ajax>
+
+		<d2l-ajax
+			id="moreSemestersRequest"
+			url="[[_moreSemestersUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreSemestersResponse">
+		</d2l-ajax>
+
 		<div class="search-and-filter">
 			<d2l-search-widget-custom
 				hidden$="[[_hasEnrollments]]"
@@ -211,7 +226,7 @@
 				sort-field="[[_sortField]]">
 			</d2l-search-widget-custom>
 
-			<div>
+			<div id="filterAndSort">
 				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 				<d2l-dropdown id="filterDropdown">
 					<button
@@ -221,7 +236,7 @@
 						class="d2l-dropdown-opener dropdown-button">
 						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
 					</button>
-					<d2l-dropdown-content no-padding min-width="350">
+					<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
 						<div class="dropdown-content-header">
 							<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
 							<template is="dom-if" if="[[_isFiltered]]">
@@ -288,6 +303,10 @@
 								</div>
 							</template>
 						</div>
+						<iron-scroll-threshold
+							id="scrollThreshold"
+							on-lower-threshold="_loadMore">
+						</iron-scroll-threshold>
 					</d2l-dropdown-content>
 				</d2l-dropdown>
 
@@ -380,6 +399,22 @@
 					type: Boolean,
 					value: false
 				},
+				_hasMoreDepartments: {
+					type: Boolean,
+					value: false
+				},
+				_hasMoreSemesters: {
+					type: Boolean,
+					value: false
+				},
+				_moreDepartmentsUrl: {
+					type: String,
+					value: ''
+				},
+				_moreSemestersUrl: {
+					type: String,
+					value: ''
+				},
 				_searchSemestersAction: {
 					type: Object,
 					value: {
@@ -432,12 +467,19 @@
 				}
 			},
 			attached: function() {
+				this._onResize();
+				window.addEventListener('resize', this._onResize);
+
 				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
 				this.$.semesterSearchWidget.search();
 				this.$.departmentSearchWidget.search();
+
+				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 			},
 			detached: function() {
+				window.removeEventListener('resize', this._onResize);
+
 				this.unlisten(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.unlisten(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
 			},
@@ -497,6 +539,19 @@
 				this._numSemesterFilters = 0;
 				this._numDepartmentFilters = 0;
 			},
+			_loadMore: function() {
+				// Generate the request based off of which tab is selected, and whether there are more to load or not
+				if (this.$.semesterList.classList.contains('hidden')) {
+					if (this._hasMoreDepartments) {
+						this.$.moreDepartmentsRequest.generateRequest();
+					}
+				} else {
+					if (this._hasMoreSemesters) {
+						this.$.moreSemesters.generateRequest();
+					}
+				}
+				this.$.scrollThreshold.clearTriggers();
+			},
 			_onBlurFilterText: function() {
 				this.toggleClass('highlight', false, this.$.filterText);
 				this.toggleClass('selected', false, this.$.filterText);
@@ -514,20 +569,61 @@
 				this.toggleClass('selected', true, this.$.sortText);
 			},
 			_onDepartmentSearchResults: function(e) {
-				this._checkFilterEntities(e.detail.value);
-				this.set('_departmentOrganizations', e.detail.value);
+				var entity = e.detail.value;
+
+				this._checkFilterEntities(entity.entities);
+				this.set('_departmentOrganizations', entity.entities);
+
+				this.set('_moreDepartmentsUrl', entity.hasLinkByRel('next') ? entity.getLinkByRel('next').href : '');
+				this.set('_hasMoreDepartments', this._moreDepartmentsUrl.length > 0);
 			},
 			_onSemesterSearchResults: function(e) {
-				this._checkFilterEntities(e.detail.value);
-				this.set('_semesterOrganizations', e.detail.value);
+				var entity = e.detail.value;
+
+				this._checkFilterEntities(entity.entities);
+				this.set('_semesterOrganizations', entity.entities);
+
+				this.set('_moreSemestersUrl', entity.hasLinkByRel('next') ? entity.getLinkByRel('next').href : '');
+				this.set('_hasMoreSemesters', this._moreSemestersUrl.length > 0);
+			},
+			_onMoreDepartmentsResponse: function(response) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var parser = document.createElement('d2l-siren-parser');
+					var moreDepartments = parser.parse(response.detail.xhr.response);
+					moreDepartments.entities.forEach(function(department) {
+						this.push('_departmentOrganizations', department);
+					}.bind(this));
+
+					this.set('_moreDepartmentsUrl', moreDepartments.hasLinkByRel('next') ? moreDepartments.getLinkByRel('next').href : '');
+					this.set('_hasMoreDepartments', this._moreDepartmentsUrl.length > 0);
+				}
+			},
+			_onMoreSemestersResponse: function(response) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var parser = document.createElement('d2l-siren-parser');
+					var moreSemesters = parser.parse(response.detail.xhr.response);
+					moreSemesters.entities.forEach(function(semester) {
+						this.push('_semesterOrganizations', semester);
+					}.bind(this));
+
+					this.set('_moreSemestersUrl', moreSemesters.hasLinkByRel('next') ? moreSemesters.getLinkByRel('next').href : '');
+					this.set('_hasMoreSemesters', this._moreSemestersUrl.length > 0);
+				}
+			},
+			_onResize: function() {
+				this.toggleClass('hidden', window.innerWidth < 768, this.$.filterAndSort);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
 				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
 			},
 			_selectDepartmentList: function() {
 				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
 			},
 			_toggleSelectedList: function(list, button, highlight, selected) {
 				this.toggleClass('hidden', !selected, list);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -3,8 +3,6 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-menu/d2l-menu.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -8,7 +8,7 @@
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-course-management-behavior.html">
-<link rel="import" href="d2l-search-widget.html">
+<link rel="import" href="d2l-search-widget-custom.html">
 
 <!--
 `<d2l-all-courses>` displays both pinned and unpinned courses
@@ -116,6 +116,12 @@
 			}
 			.dropdown-content-tab {
 				flex: 1;
+			}
+			d2l-search-widget {
+				margin-left: 20px;
+				margin-right: 20px;
+				margin-top: 10px;
+				margin-bottom: 10px;
 			}
 			.dropdown-content-tab-button {
 				@apply(--d2l-small-text);
@@ -261,28 +267,34 @@
 							</div>
 						</div>
 						<div id="semesterList">
-							<d2l-search-widget></d2l-search-widget>
+							<d2l-search-widget
+								id="semesterSearchWidget"
+								search-action="[[_searchSemestersAction]]"
+								search-field-name="search"></d2l-search-widget>
 							<template is="dom-repeat" items="[[_semesterOrganizations]]">
 								<div class="dropdown-content-item">
 									<label>
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
-											on-click="_updateFilter" />
+											on-tap="_updateFilter" />
 										[[item.properties.name]]
 									</label>
 								</div>
 							</template>
 						</div>
 						<div id="departmentList" class="hidden">
-							<d2l-search-widget></d2l-search-widget>
+							<d2l-search-widget
+								id="departmentSearchWidget"
+								search-action="[[_searchDepartmentsAction]]"
+								search-field-name="search"></d2l-search-widget>
 							<template is="dom-repeat" items="[[_departmentOrganizations]]">
 								<div class="dropdown-content-item">
 									<label>
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
-											on-click="_updateFilter" />
+											on-tap="_updateFilter" />
 										[[item.properties.name]]
 									</label>
 								</div>
@@ -414,6 +426,14 @@
 				this.$.semestersRequest.generateRequest();
 				this.$.departmentsRequest.generateRequest();
 			},
+			attached: function() {
+				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
+				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
+			},
+			detached: function() {
+				this.unlisten(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
+				this.unlisten(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
+			},
 			/*
 			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
 			*
@@ -485,15 +505,47 @@
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var departments = parser.parse(response.detail.xhr.response);
-					this._departmentOrganizations = departments.entities;
+					this.set('_departmentOrganizations', departments.entities);
+					this.set('_searchDepartmentsAction', departments.getActionByName('search-course-collection'));
 				}
 			},
 			_onSemestersResponse: function(response) {
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var semesters = parser.parse(response.detail.xhr.response);
-					this._semesterOrganizations = semesters.entities;
+					this.set('_semesterOrganizations', semesters.entities);
+					this.set('_searchSemestersAction', semesters.getActionByName('search-course-collection'));
 				}
+			},
+			_onDepartmentSearchResults: function(e) {
+				this.set('_departmentOrganizations', e.detail.value);
+
+				// There is a slight delay between this.set and the DOM being updated; we
+				// need this to run after the latter, so give it a bit of a delay
+				setTimeout(function() {
+					this.$.departmentList.querySelectorAll('input[type=checkbox]').forEach(function(checkbox) {
+						if (this._parentOrganizationIds.indexOf(checkbox.value) > -1) {
+							checkbox.checked = true;
+						} else {
+							checkbox.checked = false;
+						}
+					}.bind(this));
+				}.bind(this), 50);
+			},
+			_onSemesterSearchResults: function(e) {
+				this.set('_semesterOrganizations', e.detail.value);
+
+				// There is a slight delay between this.set and the DOM being updated; we
+				// need this to run after the latter, so give it a bit of a delay
+				setTimeout(function() {
+					this.$.semesterList.querySelectorAll('input[type=checkbox]').forEach(function(checkbox) {
+						if (this._parentOrganizationIds.indexOf(checkbox.value) > -1) {
+							checkbox.checked = true;
+						} else {
+							checkbox.checked = false;
+						}
+					}.bind(this));
+				}.bind(this), 50);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -390,7 +390,12 @@
 					type: String,
 					value: ''
 				},
-				_departmentOrganizations: Object,
+				_departmentOrganizations: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				},
 				_isFiltered: {
 					type: Boolean,
 					value: false
@@ -439,7 +444,12 @@
 							{'name':'organizationTypeIds', 'type':'hidden', 'value':'203'}]
 					}
 				},
-				_semesterOrganizations: Object,
+				_semesterOrganizations: {
+					type: Array,
+					value: function() {
+						return [];
+					}
+				},
 				_sortField: String,
 				_parentOrganizationIds: {
 					type: Array,

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -263,6 +263,7 @@
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
+											checked="[[item.properties.checked]]"
 											on-tap="_updateFilter" />
 										[[item.properties.name]]
 									</label>
@@ -280,6 +281,7 @@
 										<input
 											type="checkbox"
 											value="[[item.properties.id]]"
+											checked="[[item.properties.checked]]"
 											on-tap="_updateFilter" />
 										[[item.properties.name]]
 									</label>
@@ -478,6 +480,11 @@
 				'department': 'sorting.sortDepartment',
 				'lastAccessed': 'sorting.sortLastAccessed'
 			},
+			_checkFilterEntities: function(entities) {
+				entities.forEach(function(entity) {
+					entity.properties.checked = this._parentOrganizationIds.indexOf(entity.properties.id.toString()) > -1;
+				}.bind(this));
+			},
 			_clearFilters: function() {
 				Polymer.dom(this.root).querySelectorAll('.dropdown-content-item input').forEach(function(checkbox) {
 					checkbox.checked = false;
@@ -507,34 +514,12 @@
 				this.toggleClass('selected', true, this.$.sortText);
 			},
 			_onDepartmentSearchResults: function(e) {
+				this._checkFilterEntities(e.detail.value);
 				this.set('_departmentOrganizations', e.detail.value);
-
-				// There is a slight delay between this.set and the DOM being updated; we
-				// need this to run after the latter, so give it a bit of a delay
-				setTimeout(function() {
-					this.$.departmentList.querySelectorAll('input[type=checkbox]').forEach(function(checkbox) {
-						if (this._parentOrganizationIds.indexOf(checkbox.value) > -1) {
-							checkbox.checked = true;
-						} else {
-							checkbox.checked = false;
-						}
-					}.bind(this));
-				}.bind(this), 10);
 			},
 			_onSemesterSearchResults: function(e) {
+				this._checkFilterEntities(e.detail.value);
 				this.set('_semesterOrganizations', e.detail.value);
-
-				// There is a slight delay between this.set and the DOM being updated; we
-				// need this to run after the latter, so give it a bit of a delay
-				setTimeout(function() {
-					this.$.semesterList.querySelectorAll('input[type=checkbox]').forEach(function(checkbox) {
-						if (this._parentOrganizationIds.indexOf(checkbox.value) > -1) {
-							checkbox.checked = true;
-						} else {
-							checkbox.checked = false;
-						}
-					}.bind(this));
-				}.bind(this), 10);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -41,7 +42,7 @@
 				justify-content: space-between;
 				margin-bottom: 60px;
 			}
-			.search-and-filter > d2l-search-widget {
+			.search-and-filter > d2l-search-widget-custom {
 				width: 50%;
 			}
 			.dropdown-text {
@@ -211,12 +212,12 @@
 		</d2l-ajax>
 
 		<div class="search-and-filter">
-			<d2l-search-widget
+			<d2l-search-widget-custom
 				hidden$="[[_hasEnrollments]]"
 				search-root-url="[[searchUrl]]"
 				parent-organization-ids="[[_parentOrganizationIds]]"
 				sort-field="[[_sortField]]">
-			</d2l-search-widget>
+			</d2l-search-widget-custom>
 
 			<div>
 				<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
@@ -260,6 +261,7 @@
 							</div>
 						</div>
 						<div id="semesterList">
+							<d2l-search-widget></d2l-search-widget>
 							<template is="dom-repeat" items="[[_semesterOrganizations]]">
 								<div class="dropdown-content-item">
 									<label>
@@ -273,6 +275,7 @@
 							</template>
 						</div>
 						<div id="departmentList" class="hidden">
+							<d2l-search-widget></d2l-search-widget>
 							<template is="dom-repeat" items="[[_departmentOrganizations]]">
 								<div class="dropdown-content-item">
 									<label>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -203,20 +203,6 @@
 			}
 		</style>
 
-		<d2l-ajax
-			id="semestersRequest"
-			url="[[_semestersUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onSemestersResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="departmentsRequest"
-			url="[[_departmentsUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onDepartmentsResponse">
-		</d2l-ajax>
-
 		<div class="search-and-filter">
 			<d2l-search-widget-custom
 				hidden$="[[_hasEnrollments]]"
@@ -388,19 +374,39 @@
 					value: ''
 				},
 				_departmentOrganizations: Object,
-				_departmentsUrl: {
-					type: String,
-					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=203'
-				},
 				_isFiltered: {
 					type: Boolean,
 					value: false
 				},
-				_semesterOrganizations: Object,
-				_semestersUrl: {
-					type: String,
-					value: '/d2l/api/hm/organizations?embedDepth=1&organizationTypeIds=5'
+				_searchSemestersAction: {
+					type: Object,
+					value: {
+						'name':'search-course-collection',
+						'method':'GET',
+						'href':'/d2l/api/hm/organizations',
+						'fields':[
+							{'name':'search', 'type':'search', 'value':''},
+							{'name':'page', 'type':'number', 'value':'1'},
+							{'name':'pageSize', 'type':'number', 'value':'20'},
+							{'name':'embedDepth', 'type':'number', 'value':'1'},
+							{'name':'organizationTypeIds', 'type':'hidden', 'value':'5'}]
+					}
 				},
+				_searchDepartmentsAction: {
+					type: Object,
+					value: {
+						'name':'search-course-collection',
+						'method':'GET',
+						'href':'/d2l/api/hm/organizations',
+						'fields':[
+							{'name':'search', 'type':'search', 'value':''},
+							{'name':'page', 'type':'number', 'value':'1'},
+							{'name':'pageSize', 'type':'number', 'value':'20'},
+							{'name':'embedDepth', 'type':'number', 'value':'1'},
+							{'name':'organizationTypeIds', 'type':'hidden', 'value':'203'}]
+					}
+				},
+				_semesterOrganizations: Object,
 				_sortField: String,
 				_parentOrganizationIds: {
 					type: Array,
@@ -422,13 +428,12 @@
 				for (var i = 0; i < courseTileGrids.length; i++) {
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
-
-				this.$.semestersRequest.generateRequest();
-				this.$.departmentsRequest.generateRequest();
 			},
 			attached: function() {
 				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
+				this.$.semesterSearchWidget.search();
+				this.$.departmentSearchWidget.search();
 			},
 			detached: function() {
 				this.unlisten(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
@@ -501,22 +506,6 @@
 				this.toggleClass('highlight', true, this.$.sortText);
 				this.toggleClass('selected', true, this.$.sortText);
 			},
-			_onDepartmentsResponse: function(response) {
-				if (response.detail.status === 200) {
-					var parser = document.createElement('d2l-siren-parser');
-					var departments = parser.parse(response.detail.xhr.response);
-					this.set('_departmentOrganizations', departments.entities);
-					this.set('_searchDepartmentsAction', departments.getActionByName('search-course-collection'));
-				}
-			},
-			_onSemestersResponse: function(response) {
-				if (response.detail.status === 200) {
-					var parser = document.createElement('d2l-siren-parser');
-					var semesters = parser.parse(response.detail.xhr.response);
-					this.set('_semesterOrganizations', semesters.entities);
-					this.set('_searchSemestersAction', semesters.getActionByName('search-course-collection'));
-				}
-			},
 			_onDepartmentSearchResults: function(e) {
 				this.set('_departmentOrganizations', e.detail.value);
 
@@ -530,7 +519,7 @@
 							checkbox.checked = false;
 						}
 					}.bind(this));
-				}.bind(this), 50);
+				}.bind(this), 10);
 			},
 			_onSemesterSearchResults: function(e) {
 				this.set('_semesterOrganizations', e.detail.value);
@@ -545,7 +534,7 @@
 							checkbox.checked = false;
 						}
 					}.bind(this));
-				}.bind(this), 50);
+				}.bind(this), 10);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -126,8 +126,6 @@
 				pinned-enrollments="{{pinnedEnrollments}}"
 				unpinned-enrollments="{{unpinnedEnrollments}}"
 				search-url="[[_enrollmentsSearchUrl]]"
-				semesters-url="[[_semestersUrl]]"
-				departments-url="[[_departmentsUrl]]"
 				locale="[[locale]]">
 			</d2l-all-courses>
 			<d2l-loading-spinner

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -10,7 +10,7 @@
 <link rel="import" href="d2l-utility-behavior.html">
 <link rel="import" href="d2l-search-dropdown-content.html">
 
-<dom-module id="d2l-search-widget">
+<dom-module id="d2l-search-widget-custom">
 	<template>
 		<style>
 			:host {
@@ -173,7 +173,7 @@
 		'use strict';
 
 		Polymer({
-			is: 'd2l-search-widget',
+			is: 'd2l-search-widget-custom',
 
 			properties: {
 				/*

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -68,7 +68,7 @@
 							'filtering.semester': 'Semester',
 							'filtering.department': 'Department',
 							'filtering.semesterMultiple': 'Semester ({num})',
-							'filtering.departmentMultiple': 'Semester ({num})',
+							'filtering.departmentMultiple': 'Department ({num})',
 							'sorting.sortCourseCode': 'Sort: Course Code',
 							'sorting.sortCourseName': 'Sort: Course Name',
 							'sorting.sortDatePinned': 'Sort: Date Pinned',

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -64,6 +64,7 @@
 							'filtering.filterBy': 'Filter By',
 							'filtering.filterSingle': 'Filter: 1 Filter',
 							'filtering.filterMultiple': 'Filter: {num} Filters',
+							'filtering.loadMore': 'Load More',
 							'filtering.clear': 'Clear',
 							'filtering.semester': 'Semester',
 							'filtering.department': 'Department',


### PR DESCRIPTION
Eyyy, first follow-up PR to #116. For this, I broke out and modified the search bar that already existed, and used it in the dropdowns. Unfortunately, the existing search has a lot of complexity and "custom-ness" about it (mainly the live, drop-down search results stuff), so replacing that with the broken out component would have greatly increased the complexity of the broken out component. What I'm thinking is that, if we change this to update the entire tile view with the search results, then we may possibly be able to forego the dropdown, and instead just display search results (live or not) as course tiles. (At the very least, we do want to update the course tile view to be the full search results when you hit Enter - next thing I'm working on.)

Currently this is locked to a specific version of `d2l-search-widget` on purpose, as it hasn't hit 1.0.0 yet, and won't until I evaluate the above w.r.t. replacing the other search bar with it as well (meaning it may have to at least support live search).