### PR TITLE
Use d2l-icon

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,8 +42,6 @@
     "iron-a11y-keys": "^1.0.6",
     "iron-ajax": "PolymerElements/iron-ajax#^1.2.0",
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
-    "iron-icon": "PolymerElements/iron-icon#^1.0.8",
-    "iron-iconset-svg": "PolymerElements/iron-iconset-svg#^1.0.9",
     "iron-input": "^1.0.10",
     "iron-menu-behavior": "^1.1.9",
     "iron-overlay-behavior": "https://github.com/PolymerElements/iron-overlay-behavior.git#42a0843af78d5a8e384f0643b9b02fc522d2a2e5",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -79,9 +79,9 @@
 				padding: 0;
 				color: var(--d2l-color-tungsten);
 			}
-			iron-icon {
-				--iron-icon-height: 15px;
-				--iron-icon-width: 15px;
+			d2l-icon {
+				--d2l-icon-height: 15px;
+				--d2l-icon-width: 15px;
 				margin-top: -0.35rem;
 			}
 			.clear-button {
@@ -183,12 +183,12 @@
 				background-repeat: no-repeat;
 				background-size: 13px;
 			}
-			.dropdown-content-item > iron-icon {
+			.dropdown-content-item > d2l-icon {
 				visibility: hidden;
 				margin-right: 20px;
 				margin-top: -5px;
-				--iron-icon-height: 20px;
-				--iron-icon-width: 20px;
+				--d2l-icon-height: 20px;
+				--d2l-icon-width: 20px;
 			}
 			#sortDropdown d2l-dropdown-content button {
 				border-bottom: 1px solid var(--d2l-color-gypsum);
@@ -197,7 +197,7 @@
 			.selected {
 				color: var(--d2l-color-celestine);
 			}
-			.selected > iron-icon {
+			.selected > d2l-icon {
 				visibility: visible;
 			}
 			.highlight {
@@ -235,7 +235,7 @@
 						on-mouseenter="_onFocusFilterText"
 						on-mouseout="_onBlurFilterText"
 						class="d2l-dropdown-opener dropdown-button">
-						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+						<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 					</button>
 					<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
 						<div class="dropdown-content-header">
@@ -318,7 +318,7 @@
 						on-mouseenter="_onFocusSortText"
 						on-mouseout="_onBlurSortText"
 						class="d2l-dropdown-opener dropdown-button">
-						<iron-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></iron-icon>
+						<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 					</button>
 					<d2l-dropdown-content no-padding min-width="350">
 						<div class="dropdown-content-header">
@@ -326,19 +326,19 @@
 						</div>
 						<div class="dropdown-content-gradient">
 							<button class="dropdown-content-item" value="courseCode" on-tap="_updateSortBy">
-								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
 								{{localize('sorting.courseCode')}}
 							</button>
 							<button class="dropdown-content-item" value="courseName" on-tap="_updateSortBy">
-								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
 								{{localize('sorting.courseName')}}
 							</button>
 							<button class="dropdown-content-item selected" value="pinDate" on-tap="_updateSortBy">
-								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
 								{{localize('sorting.datePinned')}}
 							</button>
 							<button class="dropdown-content-item" value="lastAccessed" on-tap="_updateSortBy">
-								<iron-icon icon="d2l-tier1:check" aria-hidden="true"></iron-icon>
+								<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
 								{{localize('sorting.lastAccessed')}}
 							</button>
 						</div>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -64,8 +64,8 @@
 				color: var(--d2l-color-celestine);
 				text-decoration: underline;
 			}
-			.dropdown-text:hover + d2l-dropdown button,
-			.dropdown-text:focus + d2l-dropdown button {
+			.dropdown-text:hover + d2l-dropdown button d2l-icon,
+			.dropdown-text:focus + d2l-dropdown button d2l-icon {
 				color: var(--d2l-color-celestine);
 			}
 			d2l-dropdown > button:hover,

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -146,9 +146,10 @@
 			opacity: 1;
 			margin-top: 10px;
 		}
-		.menu-icon {
-			width: 18px;
-			height: 18px;
+		d2l-icon {
+			color: white;
+			--d2l-icon-width: 18px;
+			--d2l-icon-height: 18px;
 		}
 		.menu-item {
 			color: rgba(255,255,255,1);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -59,7 +59,7 @@ in that organization - student, teacher, TA, etc.
 			<div class="hover-menu no-tap-interaction">
 				<d2l-dropdown>
 					<button	class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[_courseSettingsLabel]]">
-						<d2l-icon class="menu-icon" icon="d2l-tier1:more"></d2l-icon>
+						<d2l-icon icon="d2l-tier1:more"></d2l-icon>
 					</button>
 					<d2l-dropdown-menu id="overflow-dropdown">
 						<d2l-menu label$="[[_courseSettingsLabel]]">

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
@@ -60,7 +59,7 @@ in that organization - student, teacher, TA, etc.
 			<div class="hover-menu no-tap-interaction">
 				<d2l-dropdown>
 					<button	class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[_courseSettingsLabel]]">
-						<iron-icon class="menu-icon" icon="d2l-tier1:more"></iron-icon>
+						<d2l-icon class="menu-icon" icon="d2l-tier1:more"></d2l-icon>
 					</button>
 					<d2l-dropdown-menu id="overflow-dropdown">
 						<d2l-menu label$="[[_courseSettingsLabel]]">

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../iron-pages/iron-pages.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="localize-behavior.html">
@@ -82,9 +83,9 @@
 				cursor: pointer;
 				height: 100%;
 			}
-			.search-icon iron-icon {
-				--iron-icon-height: 22px;
-				--iron-icon-width: 22px;
+			.search-icon d2l-icon {
+				--d2l-icon-height: 22px;
+				--d2l-icon-width: 22px;
 				color: var(--d2l-color-tungsten);
 			}
 
@@ -114,7 +115,7 @@
 		<d2l-dropdown no-auto-open>
 			<div class="search-bar d2l-dropdown-opener" id="opener">
 				<button type="button" on-tap="_onSearchButtonClick" class="search-icon search-button">
-					<iron-icon icon="d2l-tier1:search"></iron-icon>
+					<d2l-icon icon="d2l-tier1:search"></d2l-icon>
 				</button>
 
 				<input
@@ -127,7 +128,7 @@
 				</input>
 
 				<button type="button" on-tap="_clearSearchResults" class="search-icon clear-search-button">
-					<iron-icon icon="d2l-tier1:close-default"></iron-icon>
+					<d2l-icon icon="d2l-tier1:close-default"></d2l-icon>
 				</button>
 			</div>
 			<d2l-search-dropdown-content

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
 
 <dom-module id="d2l-simple-overlay-styles">
 	<template>
@@ -32,12 +33,12 @@
 			cursor: pointer;
 		}
 
-		.close-button iron-icon {
+		.close-button d2l-icon {
 			border: 1px solid transparent;
 			padding: 8px;
 		}
 
-		.close-button:focus iron-icon, .close-button:hover iron-icon {
+		.close-button:focus d2l-icon, .close-button:hover d2l-icon {
 			border-radius: 0.3rem;
 			border-color: var(--d2l-color-pressicus);
 			color: var(--d2l-color-celestuba);
@@ -54,7 +55,7 @@
 			float: left;
 		}
 
-		iron-icon {
+		d2l-icon {
 			width: 12px;
 			height: 12px;
 		}

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -6,7 +6,6 @@
 <link rel="import" href="../neon-animation/animations/transform-animation.html">
 <link rel="import" href="../neon-animation/animations/fade-in-animation.html">
 <link rel="import" href="../neon-animation/animations/fade-out-animation.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-simple-overlay-styles.html">
 <link rel="import" href="localize-behavior.html">
@@ -26,7 +25,7 @@ The overlay supports using different animations and transitions for desktop and 
 				on-tap="_handleClose"
 				aria-label$="{{localize('closeSimpleOverlayAltText')}}"
 				alt$="{{localize('closeSimpleOverlayAltText')}}">
-				<iron-icon icon="d2l-tier1:close-large-thick"></iron-icon>
+				<d2l-icon icon="d2l-tier1:close-large-thick"></d2l-icon>
 			</button>
 			<h1 class="d2l-heading-2">{{title}}</h1>
 		</div>

--- a/d2l-touch-menu-item-styles.html
+++ b/d2l-touch-menu-item-styles.html
@@ -55,8 +55,8 @@
 		}
 
 		.longpress-menu-item-image {
-			--iron-icon-width: 0.58em;
-			--iron-icon-height: 0.58em;
+			--d2l-icon-width: 0.58em;
+			--d2l-icon-height: 0.58em;
 			fill: var(--d2l-color-ferrite);
 			-webkit-backface-visibility: hidden;
 			-webkit-transition: fill 0.3s ease-in-out;

--- a/d2l-touch-menu-item.html
+++ b/d2l-touch-menu-item.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-icon/iron-icon.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="d2l-touch-menu-item-styles.html">
@@ -15,7 +14,7 @@
 			<div class="longpress-menu-item-text">{{_displayText}}</div>
 
 			<div class="longpress-menu-item-image-background">
-				<iron-icon class="longpress-menu-item-image" icon="{{_displayBackgroundImage}}" aria-hidden="true"></iron-icon>
+				<d2l-icon class="longpress-menu-item-image" icon="{{_displayBackgroundImage}}" aria-hidden="true"></d2l-icon>
 			</div>
 		</div>
 

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -19,7 +19,7 @@
 			<div class="d2l-image-tile-overlay">
 				<button class="overlay-button" on-tap="_selectImage" on-focus="_toggleOverlayOn" on-blur="_toggleOverlayOff">
 					<div class="overlay-button-inner">
-						<iron-icon class="camera-icon" icon="d2l-tier1:pic" aria-hidden="true"></iron-icon>
+						<d2l-icon class="camera-icon" icon="d2l-tier1:pic" aria-hidden="true"></d2l-icon>
 						<span class="overlay-button-text">{{localize('useThisImage')}}</span>
 					</div>
 				</button>


### PR DESCRIPTION
[`d2l-icon`](https://github.com/Brightspace/d2l-icons-ui) wraps `iron-icon` and gives us some delicious extra stuff, so for D2L WC stuff, the idea is to use the former rather than directly using the latter now.