### PR TITLE
sortDescending = true when sorting by course name

### DIFF
--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -326,7 +326,9 @@
 						page: 1,
 						pageSize: 5,
 						parentOrganizationIds: this.parentOrganizationIds.join(','),
-						sortField: this.sortField
+						sortField: this.sortField,
+						// Need to reverse the order for sorting by name
+						sortDescending: this.sortField !== 'courseName'
 					};
 
 					this._searchUrl = this.createActionUrl(


### PR DESCRIPTION
Because comparators, if we're searching the API and want it to be ordered by course name, then we need to actually sort it descending, so that A is at the top. Fixes #136.