### PR TITLE
Don't use orgunitid

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -342,7 +342,7 @@
 			<d2l-search-widget-custom
 				hidden$="[[_hasEnrollments]]"
 				search-root-url="[[searchUrl]]"
-				parent-organization-ids="[[_parentOrganizationIds]]"
+				parent-organizations="[[_parentOrganizations]]"
 				sort-field="[[_sortField]]">
 			</d2l-search-widget-custom>
 
@@ -397,7 +397,7 @@
 									<d2l-menu label="{{localize('filtering.semester')}}">
 										<template is="dom-repeat" items="[[_semesterOrganizations]]">
 											<d2l-menu-item-filter
-												value="[[item.properties.id]]"
+												value="[[getEntityIdentifier(item)]]"
 												text="[[item.properties.name]]"
 												selected="[[item.properties.selected]]">
 											</d2l-menu-item-filter>
@@ -413,7 +413,7 @@
 									<d2l-menu label="{{localize('filtering.department')}}">
 										<template is="dom-repeat" items="[[_departmentOrganizations]]">
 											<d2l-menu-item-filter
-												value="[[item.properties.id]]"
+												value="[[getEntityIdentifier(item)]]"
 												text="[[item.properties.name]]"
 												selected="[[item.properties.selected]]">
 											</d2l-menu-item-filter>
@@ -572,7 +572,7 @@
 					}
 				},
 				_sortField: String,
-				_parentOrganizationIds: {
+				_parentOrganizations: {
 					type: Array,
 					value: function() {
 						return [];
@@ -661,7 +661,8 @@
 			},
 			_checkFilterEntities: function(entities) {
 				entities.forEach(function(entity) {
-					entity.properties.selected = this._parentOrganizationIds.indexOf(entity.properties.id) > -1;
+					var id = this.getEntityIdentifier(entity);
+					entity.properties.selected = this._parentOrganizations.indexOf(id) > -1;
 				}.bind(this));
 			},
 			_clearFilters: function() {
@@ -671,7 +672,7 @@
 				this._isFiltered = false;
 				// Clear button is removed via dom-if, so need to manually set focus to next element
 				this.$.semesterListButton.focus();
-				this._parentOrganizationIds = [];
+				this._parentOrganizations = [];
 				this.$.filterText.textContent = this.localize('filtering.filter');
 				this.$.semesterListButton.textContent = this.localize('filtering.semester');
 				this.$.departmentListButton.textContent = this.localize('filtering.department');
@@ -813,23 +814,23 @@
 				var isSemester = this.$.semesterList.contains(e.target);
 
 				if (e.detail.selected) {
-					this.push('_parentOrganizationIds', e.detail.value);
+					this.push('_parentOrganizations', e.detail.value);
 					isSemester ? this._numSemesterFilters++ : this._numDepartmentFilters++;
 				} else {
-					var index = this._parentOrganizationIds.indexOf(e.detail.value);
-					this.splice('_parentOrganizationIds', index, 1);
+					var index = this._parentOrganizations.indexOf(e.detail.value);
+					this.splice('_parentOrganizations', index, 1);
 					isSemester ? this._numSemesterFilters-- : this._numDepartmentFilters--;
 				}
 
-				if (this._parentOrganizationIds.length === 0) {
+				if (this._parentOrganizations.length === 0) {
 					this.$.filterText.textContent = this.localize('filtering.filter');
-				} else if (this._parentOrganizationIds.length === 1) {
+				} else if (this._parentOrganizations.length === 1) {
 					this.$.filterText.textContent = this.localize('filtering.filterSingle');
 				} else {
-					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'num', this._parentOrganizationIds.length);
+					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'num', this._parentOrganizations.length);
 				}
 
-				this._isFiltered = this._parentOrganizationIds.length > 0;
+				this._isFiltered = this._parentOrganizations.length > 0;
 				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
 					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
 					: this.localize('filtering.semester');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -582,7 +582,8 @@
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				window.D2L.MyCourses.LocalizeBehavior,
-				window.D2L.MyCourses.CourseManagementBehavior
+				window.D2L.MyCourses.CourseManagementBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 			ready: function() {
 				this.usePendingLists = true;

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -110,10 +110,10 @@
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				// Remove enrollment from unpinned list, add to pinned
-				var enrollmentId = this.getEnrollmentIdentifier(enrollment);
+				var enrollmentId = this.getEntityIdentifier(enrollment);
 
 				for (var index = 0; index < this.unpinnedEnrollments.length; index++) {
-					var pinnedEnrollmentId = this.getEnrollmentIdentifier(this.unpinnedEnrollments[index]);
+					var pinnedEnrollmentId = this.getEntityIdentifier(this.unpinnedEnrollments[index]);
 					if (pinnedEnrollmentId === enrollmentId) {
 						var foundEnrollment = this.unpinnedEnrollments[index];
 						this._setEnrollmentPinData(foundEnrollment, true);
@@ -133,10 +133,10 @@
 			},
 			_moveEnrollmentToUnpinnedList: function(enrollment) {
 				// Remove enrollment from pinned list, add to unpinned
-				var enrollmentId = this.getEnrollmentIdentifier(enrollment);
+				var enrollmentId = this.getEntityIdentifier(enrollment);
 
 				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
-					var unpinnedEnrollmentId = this.getEnrollmentIdentifier(this.pinnedEnrollments[index]);
+					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
 					if (unpinnedEnrollmentId === enrollmentId) {
 						var foundEnrollment = this.pinnedEnrollments[index];
 						this._setEnrollmentPinData(foundEnrollment, false);

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -22,7 +22,7 @@
 					hover-enabled="[[_hoverInteractionEnabled]]"
 					animate-insertion="[[_removeEnrollmentFromTransitionList(item)]]"
 					class="grid-child"
-					enrollment-id="[[getEnrollmentIdentifier(item)]]"
+					enrollment-id="[[getEntityIdentifier(item)]]"
 					delay-load="[[delayCourseTileLoad]]">
 				</d2l-course-tile>
 			</template>
@@ -188,7 +188,7 @@
 				this._animationState.isInsertion = isInsertion;
 
 				if (this.enrollments.length > 0) {
-					this._animationState.lastAnimatedCourseTileId = this.getEnrollmentIdentifier(this.enrollments[lastAnimatedCourseIndex]);
+					this._animationState.lastAnimatedCourseTileId = this.getEntityIdentifier(this.enrollments[lastAnimatedCourseIndex]);
 				} else {
 					this._animationState.slideAnimationComplete = true;
 				}
@@ -197,7 +197,7 @@
 
 				if (isInsertion) {
 					// If inserting, set tile as in transition, and listen for DOM change to know when new course tile is added and tiles can be animated
-					this._tilesInPinStateTransition.push(this.getEnrollmentIdentifier(enrollment));
+					this._tilesInPinStateTransition.push(this.getEntityIdentifier(enrollment));
 					this.unshift('enrollments', enrollment);
 
 					var gridTemplate = this.$.enrollmentsTemplate;
@@ -352,11 +352,11 @@
 			_onEnrollmentPinAction: function(e) {
 				// If an enrollment was (un)pinned from this grid (ie. a course tile had a pin action invoked on it, such that it (should) leave
 				// this grid), then we need to slide other tiles in to fill its place
-				var modifiedEnrollmentId = this.getEnrollmentIdentifier(e.detail.enrollment);
+				var modifiedEnrollmentId = this.getEntityIdentifier(e.detail.enrollment);
 
 				var enrollmentId;
 				for (var i = 0; i < this.enrollments.length; i++) {
-					enrollmentId = this.getEnrollmentIdentifier(this.enrollments[i]);
+					enrollmentId = this.getEntityIdentifier(this.enrollments[i]);
 					if (enrollmentId === modifiedEnrollmentId) {
 						this._animateTileSlide(false, i);
 						break;
@@ -366,7 +366,7 @@
 				// When a tile is pinned/unpinned, set focus to the next (or previous, if last) course tile
 				var courseTiles = Polymer.dom(this.root).querySelectorAll('d2l-course-tile');
 				for (i = 0; i < courseTiles.length; i++) {
-					enrollmentId = this.getEnrollmentIdentifier(courseTiles[i].enrollment);
+					enrollmentId = this.getEntityIdentifier(courseTiles[i].enrollment);
 					if (enrollmentId === modifiedEnrollmentId) {
 						if (i < courseTiles.length - 1) {
 							courseTiles[i + 1].querySelector('a').focus();
@@ -431,7 +431,7 @@
 				e.detail.element._onUnpinHover(e);
 			},
 			_removeEnrollmentFromTransitionList: function(enrollment) {
-				var enrollmentId = this.getEnrollmentIdentifier(enrollment);
+				var enrollmentId = this.getEntityIdentifier(enrollment);
 				var index = this._tilesInPinStateTransition.indexOf(enrollmentId);
 
 				if (index !== -1) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -277,7 +277,7 @@
 
 					enrollmentEntities.forEach(function(enrollment) {
 						if (enrollment.hasClass('pinned')) {
-							var enrollmentId = this.getEnrollmentIdentifier(enrollment);
+							var enrollmentId = this.getEntityIdentifier(enrollment);
 							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
 								newPinnedEnrollments.push(enrollment);
 								this._pinnedCoursesMap[enrollmentId] = true;

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -212,10 +212,10 @@
 				sortField: String,
 
 				/*
-				* Array of parent organization IDs by which to limit the search results
-				* @type {String}
+				* Array of parent organization IDs (self links) by which to limit the search results
+				* @type {Array} Array of self links of parent organizations
 				*/
-				parentOrganizationIds: {
+				parentOrganizations: {
 					type: Array,
 					value: function() {
 						return [];
@@ -345,7 +345,7 @@
 						search: this._searchString,
 						page: 1,
 						pageSize: this._pageSize,
-						parentOrganizationIds: this.parentOrganizationIds.join(','),
+						parentOrganizations: this.parentOrganizations.join(','),
 						sortField: this.sortField,
 						// Need to reverse the order for sorting by name
 						sortDescending: this.sortField !== 'courseName'

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -55,14 +55,23 @@
 			return sizes.highMax || sizes.lowMax || sizes.highMid || sizes.lowMid || sizes.highMin || sizes.lowMin;
 		},
 		/*
-		* Creates a unique identifier for an enrollment (really just the self Link href)
-		* @param {Entity} enrollment
+		* Creates a unique identifier for a Siren Entity (really just the self Link href)
+		* @param {Entity}
 		* @return {String}
 		*/
-		getEnrollmentIdentifier: function(enrollment) {
-			// An enrollment's self href should be unique, so use it as an identifier
-			var selfLink = enrollment.getLinkByRel('self');
-			return selfLink.href;
+		getEntityIdentifier: function(entity) {
+			// An entity's self href should be unique, so use it as an identifier
+			if (entity.getLinkByRel) {
+				var selfLink = entity.getLinkByRel('self');
+				return selfLink.href;
+			} else {
+				var links = entity.links || [];
+				links.forEach(function(link) {
+					if (link.rel.indexOf('self') > -1) {
+						return link.href;
+					}
+				});
+			}
 		}
 	};
 </script>

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -61,17 +61,8 @@
 		*/
 		getEntityIdentifier: function(entity) {
 			// An entity's self href should be unique, so use it as an identifier
-			if (entity.getLinkByRel) {
-				var selfLink = entity.getLinkByRel('self');
-				return selfLink.href;
-			} else {
-				var links = entity.links || [];
-				links.forEach(function(link) {
-					if (link.rel.indexOf('self') > -1) {
-						return link.href;
-					}
-				});
-			}
+			var selfLink = entity.getLinkByRel('self');
+			return selfLink.href;
 		}
 	};
 </script>

--- a/test/d2l-utility-behavior/d2l-utility-behavior.js
+++ b/test/d2l-utility-behavior/d2l-utility-behavior.js
@@ -63,9 +63,9 @@ describe('d2l-utility-behavior', function() {
 		});
 	});
 
-	describe('getEnrollmentIdentifier', function() {
+	describe('getEntityIdentifier', function() {
 		it('should get the unique enrollment ID based off the self link', function() {
-			var id = component.getEnrollmentIdentifier(enrollmentEntity);
+			var id = component.getEntityIdentifier(enrollmentEntity);
 
 			expect(id).to.equal(enrollment.links[1].href);
 		});


### PR DESCRIPTION
This might require some explanation -

The _/organizations_ HM API right now has a property, `id`, that is the org unit ID. This shouldn't be there, since IDs in Hypermedia _should_ really be the self link for the entity, since that is unique. I added the ID since it was available from the `IOrgUnit`, and wasn't thinking, basically.

I've added the `parentOrganization` query parameter to the HM API ([dis](https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/3467/overview)), which is equivalent to `parentOrganizationIds` except that it takes comma-separated URIs rather than comma-separated ints.

This is the only usage of this query parameter (Pulse almost used it, but Eduardo asked about it, and @jopnick noticed that it shouldn't be there and let me know), so once this is merged then there will be another `lp` PR to remove `parentOrganizationIds` and the `id` property entirely.

This isn't... strictly a _bug_, but I'm tagging it as such because it is an incorrect behaviour.