### PR TITLE
Remove custom d2l-menu items

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "d2l-icons": "^2.11.1",
     "d2l-link": "^3.0.0",
     "d2l-loading-spinner": "^4.0.0",
-    "d2l-menu": "^0.2.2",
+    "d2l-menu": "^0.2.3",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.18",

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "d2l-icons": "^2.11.1",
     "d2l-link": "^3.0.0",
     "d2l-loading-spinner": "^4.0.0",
-    "d2l-menu": "^0.2.1",
+    "d2l-menu": "^0.2.2",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.18",

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "d2l-icons": "^2.4.0",
     "d2l-link": "^3.0.0",
     "d2l-loading-spinner": "^4.0.0",
-    "d2l-menu": "^0.2.0",
+    "d2l-menu": "^0.2.1",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.0.18",

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "d2l-ajax": "^2.0.1",
     "d2l-colors": "^2.0.0",
     "d2l-dropdown": "^3.0.0",
-    "d2l-icons": "^2.4.0",
+    "d2l-icons": "^2.11.1",
     "d2l-link": "^3.0.0",
     "d2l-loading-spinner": "^4.0.0",
     "d2l-menu": "^0.2.1",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,14 +1,14 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-styles.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-behavior.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-checkbox.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-radio.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-course-management-behavior.html">
@@ -16,6 +16,97 @@
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-search-widget-custom.html">
 <link rel="import" href="localize-behavior.html">
+
+<dom-module id="d2l-list-item-filter">
+	<template>
+		<style include="d2l-menu-item-selectable-style">
+			:host {
+				display: flex;
+				align-items: center;
+				padding: 0.5rem 1rem;
+				cursor: pointer;
+			}
+
+			:host > span {
+				font-size: 0.8rem;
+			}
+
+			:host(:hover) d2l-icon,
+			:host(:focus) d2l-icon {
+				color: var(--d2l-color-celestine);
+			}
+
+			:host d2l-icon {
+				visibility: hidden;
+				--d2l-icon-height: 0.7rem;
+				--d2l-icon-width: 0.7rem;
+				margin-left: 1px;
+			}
+
+			:host([aria-checked="true"]) d2l-icon {
+				visibility: visible;
+			}
+
+			.icon-border {
+				display: flex;
+				align-items: center;
+				border: 2px solid var(--d2l-color-titanius);
+				height: 1rem;
+				width: 1rem;
+				border: 2px solid var(--d2l-color-titanius);
+				border-radius: 0.3rem;
+				margin-right: 0.5rem;
+			}
+
+			:host(:hover) .icon-border,
+			:host(:focus) .icon-border {
+				border-color: var(--d2l-color-celestine);
+			}
+		</style>
+		<div class="icon-border">
+			<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
+		</div>
+		<span>[[text]]</span>
+	</template>
+	<script>
+		'use strict';
+		Polymer({
+			is: 'd2l-list-item-filter',
+			properties: {
+				selected: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				text: String,
+				value: String
+			},
+			behaviors: [
+				window.D2L.PolymerBehaviors.MenuItemBehavior
+			],
+			listeners: {
+				'tap': '_onTap',
+				'keydown': '_onKeydown'
+			},
+			_onKeydown: function(e) {
+				// Select on either Enter or Space
+				if (e.keyCode === 13 || e.keyCode === 32) {
+					this._onTap(e);
+				}
+			},
+			_onTap: function(e) {
+				e.preventDefault();
+				e.stopPropagation();
+				this.set('selected', !this.selected);
+				this.selected ? this.setAttribute('aria-checked', true) : this.removeAttribute('aria-checked');
+				this.fire('d2l-list-item-filter-changed', {
+					value: this.value,
+					selected: this.selected
+				});
+			}
+		});
+	</script>
+ -</dom-module>
 
 <!--
 `<d2l-all-courses>` displays both pinned and unpinned courses
@@ -245,11 +336,11 @@
 									search-field-name="search"></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.semester')}}">
 									<template is="dom-repeat" items="[[_semesterOrganizations]]">
-										<d2l-menu-item-checkbox
+										<d2l-list-item-filter
 											value="[[getEntityIdentifier(item)]]"
 											text="[[item.properties.name]]"
 											selected="[[item.properties.selected]]">
-										</d2l-menu-item-checkbox>
+										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
 							</div>
@@ -261,11 +352,11 @@
 									search-field-name="search"></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.department')}}">
 									<template is="dom-repeat" items="[[_departmentOrganizations]]">
-										<d2l-menu-item-checkbox
+										<d2l-list-item-filter
 											value="[[getEntityIdentifier(item)]]"
 											text="[[item.properties.name]]"
 											selected="[[item.properties.selected]]">
-										</d2l-menu-item-checkbox>
+										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
 							</div>
@@ -446,7 +537,7 @@
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.listen(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
+				this.listen(this.$.filterDropdown, 'd2l-list-item-filter-changed', '_updateFilter');
 
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
@@ -460,7 +551,7 @@
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.unlisten(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
+				this.unlisten(this.$.filterDropdown, 'd2l-list-item-filter-changed', '_updateFilter');
 
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -7,7 +7,8 @@
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-styles.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-behavior.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-checkbox.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-course-management-behavior.html">
@@ -15,159 +16,6 @@
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-search-widget-custom.html">
 <link rel="import" href="localize-behavior.html">
-
-<script>
-	'use strict';
-
-	(function() {
-		window.D2L = window.D2L || {};
-		window.D2L.MyCourses = window.D2L.MyCourses || {};
-
-		/** @polymerBehavior */
-		window.D2L.MyCourses.CustomMenuItemBehaviorImpl = {
-			/*
-			* Fired when the sliding animation of course tiles is finished
-			* @event menu-item-selected
-			* @param {String} value `value` property of the item
-			* @param {Boolean} selected True if item is selected
-			*/
-
-			properties: {
-				isToggle: {
-					type: Boolean,
-					value: false
-				},
-				selected: {
-					type: Boolean,
-					value: false,
-					observer: '_onSelectedChanged',
-					reflectToAttribute: true
-				},
-				value: String
-			},
-			listeners: {
-				'tap': '_onTap',
-				'keydown': '_onKeydown'
-			},
-			_onSelectedChanged: function(selected) {
-				this.toggleClass('hidden', !selected, this.$$('d2l-icon'));
-				selected ? this.setAttribute('aria-selected', true) : this.removeAttribute('aria-selected');
-			},
-			_onKeydown: function(e) {
-				// Select on either Enter or Space
-				if (e.keyCode === 13 || e.keyCode === 32) {
-					this._onTap(e);
-				}
-			},
-			_onTap: function(e) {
-				this.set('selected', this.isToggle ? !this.selected : true);
-				e.preventDefault();
-				this.fire('menu-item-selected', {
-					value: this.value,
-					selected: this.selected
-				});
-			}
-		};
-
-		/** @polymerBehavior */
-		window.D2L.MyCourses.CustomMenuItemBehavior = [
-			window.D2L.MyCourses.CustomMenuItemBehaviorImpl,
-			window.D2L.PolymerBehaviors.MenuItemBehavior
-		];
-	})();
-</script>
-
-<dom-module id="d2l-menu-item-sort">
-	<template>
-		<style include"d2l-menu-item-styles">
-			:host {
-				display: block;
-				padding: 0.9rem 1rem;
-				cursor: pointer;
-			}
-			:host span {
-				line-height: 1.2rem;
-			}
-			:host(:hover),
-			:host(:focus) {
-				color: var(--d2l-color-tungsten);
-			}
-			.hidden {
-				visibility: hidden;
-			}
-		</style>
-
-		<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
-		<span>[[text]]</span>
-	</template>
-	<script>
-		'use strict';
-		Polymer({
-			is: 'd2l-menu-item-sort',
-			behaviors: [
-				window.D2L.MyCourses.CustomMenuItemBehavior
-			]
-		});
-	</script>
-</dom-module>
-
-<dom-module id="d2l-menu-item-filter">
-	<template>
-		<style include="d2l-menu-item-styles">
-			:host {
-				display: block;
-				font-size: 0.8rem;
-				padding: 0.5rem 1rem;
-				overflow: hidden;
-				text-overflow: ellipsis;
-				white-space: nowrap;
-				border: none !important;
-			}
-			:host(:focus) > div,
-			:host(:hover) > div {
-				border-color: var(--d2l-color-celestine);
-			}
-			.hidden {
-				visibility: hidden;
-			}
-			.checkbox {
-				display: inline-block;
-				width: 1rem;
-				height: 1rem;
-				border: 2px solid var(--d2l-color-titanius);
-				border-radius: 0.3rem;
-				background-color: var(--d2l-color-woolonardo);
-				box-sizing: border-box;
-				margin-top: -0.2rem;
-				margin-right: 0.5rem;
-				vertical-align: middle;
-			}
-			d2l-icon {
-				margin-top: -0.4rem;
-				margin-left: 0.05rem;
-				--d2l-icon-height: 0.7rem;
-				--d2l-icon-width: 0.7rem;
-			}
-		</style>
-
-		<div class="checkbox">
-			<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
-		</div>
-		<span>[[text]]</span>
-	</template>
-	<script>
-		'use strict';
-		Polymer({
-			is: 'd2l-menu-item-filter',
-			behaviors: [
-				window.D2L.MyCourses.CustomMenuItemBehavior
-			],
-			ready: function() {
-				this.isToggle = true;
-			}
-		});
-	</script>
-</dom-module>
 
 <!--
 `<d2l-all-courses>` displays both pinned and unpinned courses
@@ -397,11 +245,11 @@
 									search-field-name="search"></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.semester')}}">
 									<template is="dom-repeat" items="[[_semesterOrganizations]]">
-										<d2l-menu-item-filter
+										<d2l-menu-item-checkbox
 											value="[[getEntityIdentifier(item)]]"
 											text="[[item.properties.name]]"
 											selected="[[item.properties.selected]]">
-										</d2l-menu-item-filter>
+										</d2l-menu-item-checkbox>
 									</template>
 								</d2l-menu>
 							</div>
@@ -413,11 +261,11 @@
 									search-field-name="search"></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.department')}}">
 									<template is="dom-repeat" items="[[_departmentOrganizations]]">
-										<d2l-menu-item-filter
+										<d2l-menu-item-checkbox
 											value="[[getEntityIdentifier(item)]]"
 											text="[[item.properties.name]]"
 											selected="[[item.properties.selected]]">
-										</d2l-menu-item-filter>
+										</d2l-menu-item-checkbox>
 									</template>
 								</d2l-menu>
 							</div>
@@ -441,10 +289,10 @@
 							<div class="dropdown-content-header">
 								<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
 							</div>
-							<d2l-menu-item-sort class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-sort>
-							<d2l-menu-item-sort value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-sort>
-							<d2l-menu-item-sort value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-sort>
-							<d2l-menu-item-sort value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-sort>
+							<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+							<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+							<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+							<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
 						</d2l-menu>
 					</d2l-dropdown-menu>
 				</d2l-dropdown>
@@ -597,8 +445,8 @@
 				this._updateTileSizes();
 			},
 			attached: function() {
-				this.listen(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
-				this.listen(this.$.filterDropdown, 'menu-item-selected', '_updateFilter');
+				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.listen(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
 
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
@@ -611,8 +459,8 @@
 				window.addEventListener('resize', this._onResize.bind(this));
 			},
 			detached: function() {
-				this.unlisten(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
-				this.unlisten(this.$.filterDropdown, 'menu-item-selected', '_updateFilter');
+				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.unlisten(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
 
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
@@ -652,7 +500,7 @@
 				}.bind(this));
 			},
 			_clearFilters: function() {
-				Polymer.dom(this.$.filterDropdown).querySelectorAll('d2l-menu-item-filter').forEach(function(item) {
+				Polymer.dom(this.$.filterDropdown).querySelectorAll('d2l-menu-item-checkbox').forEach(function(item) {
 					item.selected = false;
 				});
 				this._isFiltered = false;
@@ -808,6 +656,7 @@
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},
 			_updateFilter: function(e) {
+				console.log(e.detail);
 				var isSemester = this.$.semesterList.contains(e.target);
 
 				if (e.detail.selected) {
@@ -836,14 +685,8 @@
 					: this.localize('filtering.department');
 			},
 			_updateSortBy: function(e) {
+				console.log(e.detail);
 				this.set('_sortField', e.detail.value);
-
-				var menuItems = Polymer.dom(this.$.sortDropdown).querySelectorAll('d2l-menu-item-sort');
-				menuItems.forEach(function(item) {
-					if (item.value !== this._sortField) {
-						item.selected = false;
-					}
-				}.bind(this));
 
 				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -55,7 +55,7 @@
 			}
 		});
 	</script>
- -</dom-module>
+</dom-module>
 
 <!--
 `<d2l-all-courses>` displays both pinned and unpinned courses

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -42,9 +42,6 @@
 		'use strict';
 		Polymer({
 			is: 'd2l-list-item-filter',
-			properties: {
-				text: String
-			},
 			behaviors: [
 				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
 			],

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -6,7 +6,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-behavior.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-behavior.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
@@ -19,53 +19,23 @@
 
 <dom-module id="d2l-list-item-filter">
 	<template>
-		<style include="d2l-menu-item-selectable-style">
+		<style include="d2l-menu-item-selectable-styles">
 			:host {
-				display: flex;
-				align-items: center;
 				padding: 0.5rem 1rem;
-				cursor: pointer;
 			}
 
 			:host > span {
 				font-size: 0.8rem;
 			}
 
-			:host(:hover) d2l-icon,
-			:host(:focus) d2l-icon {
-				color: var(--d2l-color-celestine);
-			}
-
 			:host d2l-icon {
-				visibility: hidden;
-				--d2l-icon-height: 0.7rem;
-				--d2l-icon-width: 0.7rem;
-				margin-left: 1px;
-			}
-
-			:host([aria-checked="true"]) d2l-icon {
+				--d2l-icon-height: 1rem;
+				--d2l-icon-width: 1rem;
 				visibility: visible;
-			}
-
-			.icon-border {
-				display: flex;
-				align-items: center;
-				border: 2px solid var(--d2l-color-titanius);
-				height: 1rem;
-				width: 1rem;
-				border: 2px solid var(--d2l-color-titanius);
-				border-radius: 0.3rem;
 				margin-right: 0.5rem;
 			}
-
-			:host(:hover) .icon-border,
-			:host(:focus) .icon-border {
-				border-color: var(--d2l-color-celestine);
-			}
 		</style>
-		<div class="icon-border">
-			<d2l-icon icon="d2l-tier1:check" aria-hidden="true"></d2l-icon>
-		</div>
+		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
 	</template>
 	<script>
@@ -73,36 +43,18 @@
 		Polymer({
 			is: 'd2l-list-item-filter',
 			properties: {
-				selected: {
-					type: Boolean,
-					value: false,
-					reflectToAttribute: true
-				},
-				text: String,
-				value: String
+				text: String
 			},
 			behaviors: [
-				window.D2L.PolymerBehaviors.MenuItemBehavior
+				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
 			],
 			listeners: {
-				'tap': '_onTap',
-				'keydown': '_onKeydown'
+				'd2l-menu-item-select': '_onSelect'
 			},
-			_onKeydown: function(e) {
-				// Select on either Enter or Space
-				if (e.keyCode === 13 || e.keyCode === 32) {
-					this._onTap(e);
-				}
-			},
-			_onTap: function(e) {
-				e.preventDefault();
-				e.stopPropagation();
+			_onSelect: function(e) {
 				this.set('selected', !this.selected);
-				this.selected ? this.setAttribute('aria-checked', true) : this.removeAttribute('aria-checked');
-				this.fire('d2l-list-item-filter-changed', {
-					value: this.value,
-					selected: this.selected
-				});
+				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
+				this.__onSelect(e);
 			}
 		});
 	</script>
@@ -537,7 +489,7 @@
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.listen(this.$.filterDropdown, 'd2l-list-item-filter-changed', '_updateFilter');
+				this.listen(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
 
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
@@ -551,7 +503,7 @@
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.unlisten(this.$.filterDropdown, 'd2l-list-item-filter-changed', '_updateFilter');
+				this.unlisten(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
 
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -656,7 +656,6 @@
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},
 			_updateFilter: function(e) {
-				console.log(e.detail);
 				var isSemester = this.$.semesterList.contains(e.target);
 
 				if (e.detail.selected) {
@@ -685,7 +684,6 @@
 					: this.localize('filtering.department');
 			},
 			_updateSortBy: function(e) {
-				console.log(e.detail);
 				this.set('_sortField', e.detail.value);
 
 				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');


### PR DESCRIPTION
Removing the custom menu item for the sorting menu, and applying `d2l-menu-item-selectable-styles` to the custom item for the filter menu.

After some discussion in https://github.com/Brightspace/d2l-menu-ui/pull/17 and offline, it was decided that the filter menu checkboxes aren't really _menu items_ per se, so they're remaining as custom items. However, their use is limited to the all courses overlay, hence keeping them there for now. If there is a use case to use them elsewhere, they should probably be broken out into their own repo.
