### PR TITLE
US76123 UI fixes

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -83,6 +83,7 @@
 			:host {
 				display: block;
 				padding: 0.9rem 1rem;
+				cursor: pointer;
 			}
 			:host span {
 				line-height: 1.2rem;

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -338,14 +338,15 @@
 			<div id="filterAndSort">
 				<div id="filterSection">
 					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
-					<d2l-dropdown id="filterDropdown">
+					<d2l-dropdown id="filterDropdown" no-auto-open>
 						<button
 							class="d2l-dropdown-opener dropdown-button"
 							on-focus="_focusFilterText"
 							on-blur="_blurFilterText"
 							on-mouseenter="_focusFilterText"
 							on-mouseleave="_blurFilterText"
-							aria-labelledby="filterText">
+							aria-labelledby="filterText"
+							on-tap="_toggleFilterDropdown">
 							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 						</button>
 						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
@@ -619,6 +620,7 @@
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
+			_filterDropdownOpen: false,
 			_numSemesterFilters: 0,
 			_numDepartmentFilters: 0,
 			_sortTextOptions: {
@@ -763,9 +765,15 @@
 				button.setAttribute('aria-pressed', selected);
 			},
 			_toggleFilterDropdown: function() {
-				this.$.filterDropdown.toggleOpen();
-				this.$.departmentList.querySelector('d2l-menu').resize();
-				this.$.semesterList.querySelector('d2l-menu').resize();
+				// This is somewhat gross, but is a side effect of using the filter text span as a secondary opener
+				if (this._filterDropdownOpen) {
+					this.$.filterDropdownContent.close();
+				} else {
+					this.$.filterDropdownContent.open();
+					this.$.departmentList.querySelector('d2l-menu').resize();
+					this.$.semesterList.querySelector('d2l-menu').resize();
+				}
+				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},
 			_updateFilter: function(e) {
 				var isSemester = this.$.semesterList.contains(e.target);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -593,8 +593,6 @@
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 
-				this.$.organizationsRequest.generateRequest();
-
 				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -559,7 +559,7 @@
 					type: String,
 					value: 'pinDate'
 				},
-				_parentOrganizationIds: {
+				_parentOrganizations: {
 					type: Array,
 					value: function() {
 						return [];

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -298,7 +298,9 @@
 			button:focus > span,
 			button:hover > span,
 			#filterText:hover,
+			#filterText:focus,
 			#filterText:hover + d2l-dropdown button d2l-icon,
+			#filterText:focus + d2l-dropdown button d2l-icon,
 			d2l-dropdown-content button:hover,
 			d2l-dropdown-content button:focus,
 			.focus {
@@ -338,15 +340,15 @@
 			<div id="filterAndSort">
 				<div id="filterSection">
 					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
-					<d2l-dropdown id="filterDropdown" no-auto-open>
+					<d2l-dropdown id="filterDropdown">
 						<button
+							id="filterDropdownOpener"
 							class="d2l-dropdown-opener dropdown-button"
 							on-focus="_focusFilterText"
 							on-blur="_blurFilterText"
 							on-mouseenter="_focusFilterText"
 							on-mouseleave="_blurFilterText"
-							aria-labelledby="filterText"
-							on-tap="_toggleFilterDropdown">
+							aria-labelledby="filterText">
 							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 						</button>
 						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
@@ -588,6 +590,9 @@
 				this.listen(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
 				this.listen(this.$.filterDropdown, 'menu-item-selected', '_updateFilter');
 
+				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
+				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
+
 				this.$.organizationsRequest.generateRequest();
 
 				this.listen(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
@@ -600,6 +605,9 @@
 
 				this.unlisten(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
 				this.unlisten(this.$.filterDropdown, 'menu-item-selected', '_updateFilter');
+
+				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
+				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 
 				this.unlisten(this.$.semesterSearchWidget, 'search-results-changed', '_onSemesterSearchResults');
 				this.unlisten(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
@@ -663,7 +671,11 @@
 				this.$.scrollThreshold.clearTriggers();
 			},
 			_blurFilterText: function() {
-				this.toggleClass('focus', false, this.$.filterText);
+				// Only de-highlight text if focus has moved AND we're not hovering over the opener button anymore
+				// Without this check, the text de-highlights once the dropdown is opened as focus moves to the tabs
+				if (this.$$('#filterDropdownOpener:focus') === null && this.$$('#filterDropdownOpener:hover') === null) {
+					this.toggleClass('focus', false, this.$.filterText);
+				}
 			},
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);
@@ -674,15 +686,24 @@
 				this.set(hasMorePath, entity.hasLinkByRel('next'));
 				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
 			},
+			_onFilterDropdownClose: function() {
+				// If the dropdown is closed by clicking elsewhere, we need to manually update _filterDropdownOpen
+				// since _toggleFilterDropdown doesn't run.
+				// Timeout is to ensure this runs after _toggleFilterDropdown when it's clicked closed
+				setTimeout(function() {
+					this.set('_filterDropdownOpen', false);
+				}.bind(this), 100);
+			},
+			_onFilterDropdownOpen: function() {
+				this._selectSemesterList();
+			},
 			_onDepartmentSearchResults: function(e) {
 				this.set('_departmentOrganizations', e.detail.entities);
 				this._updateMoreParameters(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
-				this.$.departmentList.querySelector('d2l-menu').resize();
 			},
 			_onSemesterSearchResults: function(e) {
 				this.set('_semesterOrganizations', e.detail.entities);
 				this._updateMoreParameters(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
-				this.$.semesterList.querySelector('d2l-menu').resize();
 			},
 			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
@@ -768,10 +789,9 @@
 				// This is somewhat gross, but is a side effect of using the filter text span as a secondary opener
 				if (this._filterDropdownOpen) {
 					this.$.filterDropdownContent.close();
+					this.$.filterDropdownOpener.focus();
 				} else {
 					this.$.filterDropdownContent.open();
-					this.$.departmentList.querySelector('d2l-menu').resize();
-					this.$.semesterList.querySelector('d2l-menu').resize();
 				}
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -188,6 +188,11 @@
 			d2l-alert {
 				margin-bottom: 20px;
 			}
+			d2l-icon {
+				--d2l-icon-height: 15px;
+				--d2l-icon-width: 15px;
+				margin-top: -0.35rem;
+			}
 			.hidden {
 				display: none;
 			}
@@ -203,46 +208,20 @@
 			.search-and-filter > d2l-search-widget-custom {
 				flex: calc(5 / 12);
 			}
-			#filterAndSort {
+			.search-and-filter > div {
 				flex: calc(7 / 12);
+				display: flex;
+				justify-content: flex-end;
 			}
-			.dropdown-text {
+			.dropdown-opener-text {
 				@apply(--d2l-body-small-text);
 				/* overrides to d2l-body-small-text */
 				font-size: 1rem;
-				font-weight: 300;
 				color: var(--d2l-color-tungsten);
 				/* end overrides */
 				cursor: pointer;
 				padding: 0;
 				margin-left: 1rem;
-			}
-			#filterAndSort {
-				margin-left: auto;
-			}
-			#filterAndSort > div {
-				float: right;
-			}
-			#filterSection,
-			#sortSection {
-				float: left;
-			}
-			#filterSection:hover > span,
-			#filterSection:hover d2l-dropdown button d2l-icon,
-			#sortSection:hover > span,
-			#sortSection:hover d2l-dropdown button d2l-icon,
-			#filterSection d2l-dropdown button:focus d2l-icon,
-			#sortSection d2l-dropdown button:focus d2l-icon,
-			.focus {
-				text-decoration: underline;
-				color: var(--d2l-color-celestine);
-			}
-			#filterSection > * {
-				float: left;
-			}
-			d2l-dropdown > button:hover,
-			d2l-dropdown > button:focus {
-				color: var(--d2l-color-celestine);
 			}
 			.dropdown-button {
 				background: none;
@@ -250,11 +229,6 @@
 				cursor: pointer;
 				padding: 0;
 				color: var(--d2l-color-tungsten);
-			}
-			d2l-icon {
-				--d2l-icon-height: 15px;
-				--d2l-icon-width: 15px;
-				margin-top: -0.35rem;
 			}
 			.clear-button {
 				@apply(--d2l-body-small-text);
@@ -289,13 +263,6 @@
 			.dropdown-content-tab {
 				flex: 1;
 			}
-			d2l-search-widget {
-				--d2l-search-widget-height: 45px;
-				margin-left: 20px;
-				margin-right: 20px;
-				margin-top: 10px;
-				margin-bottom: 10px;
-			}
 			.dropdown-content-tab-button {
 				@apply(--d2l-body-small-text);
 				color: var(--d2l-color-ferrite);
@@ -313,16 +280,24 @@
 				width: 80%;
 				margin: auto;
 			}
-			button:focus,
-			button:hover,
-			.highlight {
-				text-decoration: underline;
+			d2l-dropdown-content d2l-search-widget {
+				--d2l-search-widget-height: 45px;
+				margin: 10px 20px;
 			}
-			.selected {
+			button[aria-pressed="true"] {
 				color: var(--d2l-color-celestine);
 			}
-			.selected > d2l-icon {
-				visibility: visible;
+			button:focus > d2l-icon,
+			button:hover > d2l-icon,
+			button:focus > span,
+			button:hover > span,
+			#filterText:hover,
+			#filterText:hover + d2l-dropdown button d2l-icon,
+			d2l-dropdown-content button:hover,
+			d2l-dropdown-content button:focus,
+			.focus {
+				text-decoration: underline;
+				color: var(--d2l-color-celestine);
 			}
 		</style>
 
@@ -356,111 +331,105 @@
 
 			<div id="filterAndSort">
 				<div>
-					<div id="filterSection">
-						<span id="filterText" class="dropdown-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
-						<d2l-dropdown id="filterDropdown" no-auto-open>
-							<button
-								class="d2l-dropdown-opener dropdown-button"
-								on-focus="_focusFilterText"
-								on-blur="_blurFilterText"
-								aria-labelledby="filterText"
-								on-tap="_toggleFilterDropdown">
-								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-							</button>
-							<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
-								<div class="dropdown-content-header">
-									<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
-									<template is="dom-if" if="[[_isFiltered]]">
-										<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
+					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
+					<d2l-dropdown id="filterDropdown">
+						<button
+							class="d2l-dropdown-opener dropdown-button"
+							on-focus="_focusFilterText"
+							on-blur="_blurFilterText"
+							on-mouseenter="_focusFilterText"
+							on-mouseleave="_blurFilterText"
+							aria-labelledby="filterText">
+							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+						</button>
+						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
+							<div class="dropdown-content-header">
+								<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
+								<template is="dom-if" if="[[_isFiltered]]">
+									<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
+								</template>
+							</div>
+							<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
+								<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
+									<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
+									<button
+										id="semesterListButton"
+										class="dropdown-content-tab-button"
+										on-tap="_selectSemesterList"
+										aria-pressed="true">
+										{{localize('filtering.semester')}}
+									</button>
+								</div>
+								<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
+									<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
+									<button
+										id="departmentListButton"
+										class="dropdown-content-tab-button"
+										on-tap="_selectDepartmentList"
+										aria-pressed="false">
+										{{localize('filtering.department')}}
+									</button>
+								</div>
+							</div>
+							<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
+								<d2l-search-widget
+									id="semesterSearchWidget"
+									placeholder-text="{{localize('filtering.searchSemesters')}}"
+									search-action="[[_searchSemestersAction]]"
+									search-field-name="search"></d2l-search-widget>
+								<d2l-menu label="{{localize('filtering.semester')}}">
+									<template is="dom-repeat" items="[[_semesterOrganizations]]">
+										<d2l-menu-item-filter
+											value="[[getEntityIdentifier(item)]]"
+											text="[[item.properties.name]]"
+											selected="[[item.properties.selected]]">
+										</d2l-menu-item-filter>
 									</template>
-								</div>
-								<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
-									<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
-										<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
-										<button
-											id="semesterListButton"
-											class="dropdown-content-tab-button"
-											on-tap="_selectSemesterList"
-											aria-pressed="true">
-											{{localize('filtering.semester')}}
-										</button>
-									</div>
-									<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
-										<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
-										<button
-											id="departmentListButton"
-											class="dropdown-content-tab-button"
-											on-tap="_selectDepartmentList"
-											aria-pressed="false">
-											{{localize('filtering.department')}}
-										</button>
-									</div>
-								</div>
-								<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
-									<d2l-search-widget
-										id="semesterSearchWidget"
-										placeholder-text="{{localize('filtering.searchSemesters')}}"
-										search-action="[[_searchSemestersAction]]"
-										search-field-name="search"></d2l-search-widget>
-									<d2l-menu label="{{localize('filtering.semester')}}">
-										<template is="dom-repeat" items="[[_semesterOrganizations]]">
-											<d2l-menu-item-filter
-												value="[[getEntityIdentifier(item)]]"
-												text="[[item.properties.name]]"
-												selected="[[item.properties.selected]]">
-											</d2l-menu-item-filter>
-										</template>
-									</d2l-menu>
-								</div>
-								<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
-									<d2l-search-widget
-										id="departmentSearchWidget"
-										placeholder-text="{{localize('filtering.searchDepartments')}}"
-										search-action="[[_searchDepartmentsAction]]"
-										search-field-name="search"></d2l-search-widget>
-									<d2l-menu label="{{localize('filtering.department')}}">
-										<template is="dom-repeat" items="[[_departmentOrganizations]]">
-											<d2l-menu-item-filter
-												value="[[getEntityIdentifier(item)]]"
-												text="[[item.properties.name]]"
-												selected="[[item.properties.selected]]">
-											</d2l-menu-item-filter>
-										</template>
-									</d2l-menu>
-								</div>
-								<iron-scroll-threshold
-									id="scrollThreshold"
-									on-lower-threshold="_loadMore">
-								</iron-scroll-threshold>
-							</d2l-dropdown-content>
-						</d2l-dropdown>
-					</div>
-
-					<div id="sortSection">
-						<span id="sortText" class="dropdown-text" on-tap="_toggleSortDropdown">{{localize('sorting.sortDatePinned')}}</span>
-						<d2l-dropdown id="sortDropdown" no-auto-open>
-							<button
-								class="d2l-dropdown-opener dropdown-button"
-								on-focus="_focusSortText"
-								on-blur="_blurSortText"
-								aria-labelledby="sortText"
-								on-tap="_toggleSortDropdown">
-								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-							</button>
-							<d2l-dropdown-menu no-padding min-width="350">
-								<d2l-menu label="{{localize('sorting.sortBy')}}">
-									<div class="dropdown-content-header">
-										<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
-									</div>
-									<d2l-menu-item-sort class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-sort>
-									<d2l-menu-item-sort value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-sort>
-									<d2l-menu-item-sort value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-sort>
-									<d2l-menu-item-sort value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-sort>
 								</d2l-menu>
-							</d2l-dropdown-menu>
-						</d2l-dropdown>
-					</div>
+							</div>
+							<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
+								<d2l-search-widget
+									id="departmentSearchWidget"
+									placeholder-text="{{localize('filtering.searchDepartments')}}"
+									search-action="[[_searchDepartmentsAction]]"
+									search-field-name="search"></d2l-search-widget>
+								<d2l-menu label="{{localize('filtering.department')}}">
+									<template is="dom-repeat" items="[[_departmentOrganizations]]">
+										<d2l-menu-item-filter
+											value="[[getEntityIdentifier(item)]]"
+											text="[[item.properties.name]]"
+											selected="[[item.properties.selected]]">
+										</d2l-menu-item-filter>
+									</template>
+								</d2l-menu>
+							</div>
+							<iron-scroll-threshold
+								id="scrollThreshold"
+								on-lower-threshold="_loadMore">
+							</iron-scroll-threshold>
+						</d2l-dropdown-content>
+					</d2l-dropdown>
 				</div>
+
+				<d2l-dropdown id="sortDropdown">
+					<button
+						class="d2l-dropdown-opener dropdown-button"
+						aria-labelledby="sortText">
+						<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
+						<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+					</button>
+					<d2l-dropdown-menu no-padding min-width="350">
+						<d2l-menu label="{{localize('sorting.sortBy')}}">
+							<div class="dropdown-content-header">
+								<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+							</div>
+							<d2l-menu-item-sort class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-sort>
+							<d2l-menu-item-sort value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-sort>
+							<d2l-menu-item-sort value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-sort>
+							<d2l-menu-item-sort value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-sort>
+						</d2l-menu>
+					</d2l-dropdown-menu>
+				</d2l-dropdown>
 			</div>
 		</div>
 
@@ -579,8 +548,11 @@
 						return [];
 					}
 				},
-				_sortField: String,
-				_parentOrganizations: {
+				_sortField: {
+					type: String,
+					value: 'pinDate'
+				},
+				_parentOrganizationIds: {
 					type: Array,
 					value: function() {
 						return [];
@@ -685,14 +657,8 @@
 			_blurFilterText: function() {
 				this.toggleClass('focus', false, this.$.filterText);
 			},
-			_blurSortText: function() {
-				this.toggleClass('focus', false, this.$.sortText);
-			},
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);
-			},
-			_focusSortText: function() {
-				this.toggleClass('focus', true, this.$.sortText);
 			},
 			_updateMoreParameters: function(entity, moreUrlPath, hasMorePath) {
 				this._checkFilterEntities(entity.entities);
@@ -769,8 +735,7 @@
 				}
 			},
 			_onResize: function() {
-				this.toggleClass('hidden', window.innerWidth < 768, this.$.filterSection);
-				this.toggleClass('hidden', window.innerWidth < 768, this.$.sortSection);
+				this.toggleClass('hidden', window.innerWidth < 768, this.$.filterAndSort);
 			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
@@ -788,7 +753,6 @@
 			},
 			_toggleSelectedList: function(list, button, highlight, selected) {
 				this.toggleClass('hidden', !selected, list);
-				this.toggleClass('selected', selected, button);
 				this.toggleClass('invisible', !selected, highlight);
 				button.setAttribute('aria-pressed', selected);
 			},
@@ -796,9 +760,6 @@
 				this.$.filterDropdown.toggleOpen();
 				this.$.departmentList.querySelector('d2l-menu').resize();
 				this.$.semesterList.querySelector('d2l-menu').resize();
-			},
-			_toggleSortDropdown: function() {
-				this.$.sortDropdown.toggleOpen();
 			},
 			_updateFilter: function(e) {
 				var isSemester = this.$.semesterList.contains(e.target);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -198,10 +198,13 @@
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
-				margin-bottom: 60px;
+				margin-bottom: 50px;
 			}
-			.search-and-filter > * {
-				flex: 1
+			.search-and-filter > d2l-search-widget-custom {
+				flex: calc(5 / 12);
+			}
+			#filterAndSort {
+				flex: calc(7 / 12);
 			}
 			.dropdown-text {
 				@apply(--d2l-body-small-text);
@@ -233,6 +236,9 @@
 			.focus {
 				text-decoration: underline;
 				color: var(--d2l-color-celestine);
+			}
+			#filterSection > * {
+				float: left;
 			}
 			d2l-dropdown > button:hover,
 			d2l-dropdown > button:focus {
@@ -284,6 +290,7 @@
 				flex: 1;
 			}
 			d2l-search-widget {
+				--d2l-search-widget-height: 45px;
 				margin-left: 20px;
 				margin-right: 20px;
 				margin-top: 10px;
@@ -832,6 +839,8 @@
 				}.bind(this));
 
 				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');
+
+				this.$.sortDropdown.toggleOpen();
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -230,6 +230,12 @@
 				padding: 0;
 				color: var(--d2l-color-tungsten);
 			}
+			#filterSection {
+				display: flex;
+			}
+			#filterText {
+				padding-right: 5px;
+			}
 			.clear-button {
 				@apply(--d2l-body-small-text);
 				/* overrides to d2l-body-small-text */
@@ -330,7 +336,7 @@
 			</d2l-search-widget-custom>
 
 			<div id="filterAndSort">
-				<div>
+				<div id="filterSection">
 					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 					<d2l-dropdown id="filterDropdown">
 						<button

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -337,6 +337,7 @@
 				e.stopPropagation();
 				this.$$('#all-courses').open();
 				this.$$('d2l-all-courses').loadCourseTiles();
+				this.$$('d2l-all-courses').$.organizationsRequest.generateRequest();
 
 				setTimeout(function() {
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -384,9 +384,14 @@
 
 			_clearSearchResults: function() {
 				this.cancelDebouncer('liveSearchJob');
-				this.$$('iron-pages').select('recent-searches-page');
 				this._searchString = '';
 				this.set('_searchResults', []);
+
+				if (this._previousSearches.length > 0) {
+					this.$$('iron-pages').select('recent-searches-page');
+				} else {
+					this.$.dropdown.close();
+				}
 			},
 
 			_onSearchStringChanged: function(newString) {
@@ -487,6 +492,9 @@
 					var enrollmentEntities = searchResponse.entities;
 
 					this.$$('iron-pages').select(enrollmentEntities.length > 0 ? 'search-results-page' : 'no-results-page');
+					if (!this.$.dropdown.opened) {
+						this.$.dropdown.open();
+					}
 
 					this._searchResults = [];
 					for (var i = 0; i < enrollmentEntities.length; i++) {
@@ -563,12 +571,25 @@
 			_advancedSearchUrl: 'le/manageCourses/search/6606?searchTerm=',
 
 			/*
-			 * Called when an element within the search bar gains focus, to open the dropdown.
+			 * Called when an element within the search bar gains focus, to open the dropdown if required
 			 */
 			_onElementFocus: function() {
-				if (!this.$.dropdown.opened) {
-					this.$.dropdown.open();
+				if (this.$.dropdown.opened) {
+					return;
 				}
+
+				// If the search field is blank, we want to open the previous searches, but only if there are some
+				if (!this._searchString) {
+					if (this._previousSearches.length > 0) {
+						this.$$('iron-pages').select('recent-searches-page');
+						this.$.dropdown.open();
+						return;
+					}
+				}
+
+				// If there is a search value, just re-open the dropdown (either results or no-results will show,
+				// depending on what was last selected).
+				this.$.dropdown.open();
 			},
 
 			/*

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -583,8 +583,8 @@
 					if (this._previousSearches.length > 0) {
 						this.$$('iron-pages').select('recent-searches-page');
 						this.$.dropdown.open();
-						return;
 					}
+					return;
 				}
 
 				// If there is a search value, just re-open the dropdown (either results or no-results will show,


### PR DESCRIPTION
This addresses Bob's UI feedback in US76123, namely:

- Remove space between menu caret and text
- Vertically align checkbox and text
- Search input too wide - should be 5/12 width
- Don't show recent searches dropdown if there are none
- Space between search and "Pinned" should be 50px
- Smaller search in dropdowns (45px tall)
- Clicking a checkbox's label doesn't click the checkbox
- Selecting a value in the sort dropdown should apply it and close the dropdown
- Clicking dropdown text should toggle dropdown, not always open it

Some of these were likely already addressed by the switch to using "proper" `d2l-menu` custom components in #129. (Which will be even further improved by #151.)

There is also a note about weird scrolling in the dropdowns, but I cannot reproduce this. I suspect it was a Mac/Safari thing, and is likely fixed now with the new `d2l-menu` components.