### PR TITLE
The overlay shouldn't glitch out if there is no title provided

### DIFF
--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -28,9 +28,14 @@
 			margin: 0;
 			padding: 0 0 0.2rem 0;
 			color: var(--d2l-color-tungsten);
-			width: 24px;
-			height: 24px;
 			cursor: pointer;
+		}
+
+		.container {
+			display: flex;
+			justify-content: space-between;
+			align-items: center;
+			min-height: 105px;
 		}
 
 		.close-button d2l-icon {
@@ -46,13 +51,6 @@
 
 		.close-button * {
 			box-sizing: content-box;
-		}
-
-		.pull-right {
-			float: right;
-		}
-		:host-context([dir='rtl']) .pull-right {
-			float: left;
 		}
 
 		d2l-icon {
@@ -85,8 +83,6 @@
 			/* overrides to d2l-heading-2 (h1 styled with d2l-heading-2 class) */
 			font-weight: 400;
 			font-size: 30px;
-			margin-top: 30px;
-			margin-bottom: 30px;
 			/* end overrides */
 		}
 		</style>

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -19,15 +19,15 @@ The overlay supports using different animations and transitions for desktop and 
 <dom-module id="d2l-simple-overlay">
 	<style include="d2l-simple-overlay-styles"></style>
 	<template>
-		<div class="max-width">
+		<div class="max-width container">
+			<h1 class="d2l-heading-2">{{title}}</h1>
 			<button
-				class="close-button pull-right"
+				class="close-button"
 				on-tap="_handleClose"
 				aria-label$="{{localize('closeSimpleOverlayAltText')}}"
 				alt$="{{localize('closeSimpleOverlayAltText')}}">
 				<d2l-icon icon="d2l-tier1:close-large-thick"></d2l-icon>
 			</button>
-			<h1 class="d2l-heading-2">{{title}}</h1>
 		</div>
 		<div class="scrollable">
 			<div class="max-width">


### PR DESCRIPTION
This helps solve some of the strange behaviour we were seeing with overlays on @CodeBaboon's computer (Turns out that something was leaving his overlay without a title)