### PR TITLE
Move behaviour namespace to window.D2L.MyCourses

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -20,11 +20,11 @@
 	'use strict';
 
 	(function() {
-		Polymer.D2L = Polymer.D2L || {};
-		Polymer.D2L.MyCourse = Polymer.D2L.MyCourses || {};
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 		/** @polymerBehavior */
-		Polymer.D2L.MyCourses.CustomMenuItemBehaviorImpl = {
+		window.D2L.MyCourses.CustomMenuItemBehaviorImpl = {
 			/*
 			* Fired when the sliding animation of course tiles is finished
 			* @event menu-item-selected
@@ -70,8 +70,8 @@
 		};
 
 		/** @polymerBehavior */
-		Polymer.D2L.MyCourses.CustomMenuItemBehavior = [
-			Polymer.D2L.MyCourses.CustomMenuItemBehaviorImpl,
+		window.D2L.MyCourses.CustomMenuItemBehavior = [
+			window.D2L.MyCourses.CustomMenuItemBehaviorImpl,
 			window.D2L.PolymerBehaviors.MenuItemBehavior
 		];
 	})();
@@ -104,7 +104,7 @@
 		Polymer({
 			is: 'd2l-menu-item-sort',
 			behaviors: [
-				Polymer.D2L.MyCourses.CustomMenuItemBehavior
+				window.D2L.MyCourses.CustomMenuItemBehavior
 			]
 		});
 	</script>
@@ -159,7 +159,7 @@
 		Polymer({
 			is: 'd2l-menu-item-filter',
 			behaviors: [
-				Polymer.D2L.MyCourses.CustomMenuItemBehavior
+				window.D2L.MyCourses.CustomMenuItemBehavior
 			],
 			ready: function() {
 				this.isToggle = true;
@@ -580,9 +580,9 @@
 				}
 			},
 			behaviors: [
-				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.CourseManagementBehavior
+				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.CourseManagementBehavior
 			],
 			ready: function() {
 				this.usePendingLists = true;

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -6,8 +6,8 @@
 	'use strict';
 
 	(function() {
-		Polymer.D2L = Polymer.D2L || {};
-		Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 		/*
 		* Behavior that allows for course management
@@ -15,9 +15,9 @@
 		* "Management" in this case means having a pinned and unpinned list, and supporting switching an enrollment between the
 		* two.
 		*
-		* @polymerBehavior Polymer.D2L.MyCourses.CourseManagementBehavior
+		* @polymerBehavior window.D2L.MyCourses.CourseManagementBehavior
 		*/
-		Polymer.D2L.MyCourses.CourseManagementBehaviorImpl = {
+		window.D2L.MyCourses.CourseManagementBehaviorImpl = {
 			properties: {
 				/*
 				* Set of pinned enrollment entities
@@ -185,9 +185,9 @@
 			}
 		};
 
-		Polymer.D2L.MyCourses.CourseManagementBehavior = [
-			Polymer.D2L.MyCourses.CourseManagementBehaviorImpl,
-			Polymer.D2L.MyCourses.UtilityBehavior
+		window.D2L.MyCourses.CourseManagementBehavior = [
+			window.D2L.MyCourses.CourseManagementBehaviorImpl,
+			window.D2L.MyCourses.UtilityBehavior
 		];
 	})();
 </script>

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -79,10 +79,10 @@
 				}
 			},
 			behaviors: [
-				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
-				Polymer.D2L.MyCourses.InteractionDetectionBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
+				window.D2L.MyCourses.InteractionDetectionBehavior,
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 			listeners: {
 				'tile-insert-complete': '_onTileInsertionComplete',

--- a/d2l-course-tile-responsive-grid-behavior.html
+++ b/d2l-course-tile-responsive-grid-behavior.html
@@ -4,8 +4,8 @@
 	'use strict';
 
 	(function() {
-		Polymer.D2L = Polymer.D2L || {};
-		Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 		/*
 		* Behavior for responsive course tile grids
@@ -15,7 +15,7 @@
 		*
 		* @polymerBehavior
 		*/
-		Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior = {
+		window.D2L.MyCourses.CourseTileResponsiveGridBehavior = {
 			attached: function() {
 				window.addEventListener('recalculate-columns', this._rescaleCourseTileRegions.bind(this));
 

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -229,8 +229,8 @@ in that organization - student, teacher, TA, etc.
 				}
 			},
 			behaviors: [
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 			listeners: {
 				'animationend': '_onAnimationComplete'

--- a/d2l-interaction-detection-behavior.html
+++ b/d2l-interaction-detection-behavior.html
@@ -4,17 +4,14 @@
 	'use strict';
 
 	(function() {
-		Polymer.D2L = Polymer.D2L || {};
-		Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 		/*
 		* Behavior that detects whether an interaction occurs via touch or hover
-		*
-		* Requires switch to be set to "more magic".
-		*
 		* @polymerBehavior
 		*/
-		Polymer.D2L.MyCourses.InteractionDetectionBehavior = {
+		window.D2L.MyCourses.InteractionDetectionBehavior = {
 			properties: {
 				/*
 				* True if hover (desktop) interaction is enabled

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -210,10 +210,10 @@
 				_departmentsUrl: String
 			},
 			behaviors: [
-				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.InteractionDetectionBehavior,
-				Polymer.D2L.MyCourses.CourseManagementBehavior
+				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.InteractionDetectionBehavior,
+				window.D2L.MyCourses.CourseManagementBehavior
 			],
 			listeners: {
 				'open-change-image-view': '_openChangeImageView',

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -275,8 +275,8 @@
 			},
 
 			behaviors: [
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 
 			ready: function() {

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -49,7 +49,7 @@ The overlay supports using different animations and transitions for desktop and 
 			behaviors: [
 				Polymer.IronOverlayBehavior,
 				Polymer.NeonAnimationRunnerBehavior,
-				Polymer.D2L.MyCourses.LocalizeBehavior
+				window.D2L.MyCourses.LocalizeBehavior
 			],
 			listeners: {
 				'neon-animation-finish': '_onNeonAnimationFinish',

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -4,8 +4,8 @@
 <script>
 	'use strict';
 
-	Polymer.D2L = Polymer.D2L || {};
-	Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+	window.D2L = window.D2L || {};
+	window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 	/*
 	* General utility functions that can be used in many places.
@@ -14,7 +14,7 @@
 	*
 	* @polymerBehavior
 	*/
-	Polymer.D2L.MyCourses.UtilityBehavior = {
+	window.D2L.MyCourses.UtilityBehavior = {
 		/*
 		* Creates a URL with a query from an Action and an object of required parameters
 		* @param {Action} action

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -98,7 +98,7 @@
 				_noResultsTextEnd: String,
 				_showGrid: Boolean,
 			},
-			behaviors: [ Polymer.D2L.MyCourses.LocalizeBehavior ],
+			behaviors: [ window.D2L.MyCourses.LocalizeBehavior ],
 			focusableNodesOverride: function() {
 				var imageTileFocusables = [];
 				var grid = this.$$('d2l-image-tile-grid');

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -53,8 +53,8 @@
 				_setImageUrl: String
 			},
 			behaviors: [
-				Polymer.D2L.MyCourses.LocalizeBehavior,
-				Polymer.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 			_toggleOverlayOn: function() {
 				this.toggleClass('mobile-selected', true, this.$$('.d2l-image-tile'));

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -4,15 +4,15 @@
 	'use strict';
 
 	(function() {
-		Polymer.D2L = Polymer.D2L || {};
-		Polymer.D2L.MyCourses = Polymer.D2L.MyCourses || {};
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
 		/*
 		* Behavior for elements that require localization, based on `app-localize-behavior`
 		*
-		* @polymerBehavior Polymer.D2L.MyCourses.LocalizeBehavior
+		* @polymerBehavior window.D2L.MyCourses.LocalizeBehavior
 		*/
-		Polymer.D2L.MyCourses.LocalizeBehaviorImpl = {
+		window.D2L.MyCourses.LocalizeBehaviorImpl = {
 			properties: {
 				/*
 				* Language string
@@ -114,9 +114,9 @@
 		};
 
 		/* @polymerBehavior */
-		Polymer.D2L.MyCourses.LocalizeBehavior = [
+		window.D2L.MyCourses.LocalizeBehavior = [
 			Polymer.AppLocalizeBehavior,
-			Polymer.D2L.MyCourses.LocalizeBehaviorImpl
+			window.D2L.MyCourses.LocalizeBehaviorImpl
 		];
 	})();
 </script>

--- a/test/d2l-course-tile-responsive-grid-behavior/consumer-element.html
+++ b/test/d2l-course-tile-responsive-grid-behavior/consumer-element.html
@@ -10,7 +10,7 @@
 		Polymer({
 			is: 'consumer-element',
 			behaviors: [
-				Polymer.D2L.MyCourses.CourseTileResponsiveGridBehavior
+				window.D2L.MyCourses.CourseTileResponsiveGridBehavior
 			]
 		});
 	</script>

--- a/test/d2l-utility-behavior/consumer-element.html
+++ b/test/d2l-utility-behavior/consumer-element.html
@@ -7,7 +7,7 @@
 		Polymer({
 			is: 'consumer-element',
 			behaviors: [
-				Polymer.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.UtilityBehavior
 			]
 		});
 	</script>

--- a/test/localize-behavior/consumer-element.html
+++ b/test/localize-behavior/consumer-element.html
@@ -7,7 +7,7 @@
 		Polymer({
 			is: 'consumer-element',
 			behaviors: [
-				Polymer.D2L.MyCourses.LocalizeBehavior
+				window.D2L.MyCourses.LocalizeBehavior
 			]
 		});
 	</script>


### PR DESCRIPTION
While using Polymer.X.Y is recommended in some Polymer documentation, other D2L projects are using window.D2L.X.Y. This includes d2l-polymer-behaviors, which includes shared behaviours.

Just a straight-up replacement, so a cursory check is all that's really needed here.