### PR TITLE
Update focusable override stuff

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -46,7 +46,7 @@
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
     "iron-input": "^1.0.10",
     "iron-menu-behavior": "^1.1.9",
-    "iron-overlay-behavior": "https://github.com/PolymerElements/iron-overlay-behavior.git#42a0843af78d5a8e384f0643b9b02fc522d2a2e5",
+    "iron-overlay-behavior": "https://github.com/PolymerElements/iron-overlay-behavior.git#^1.9.0",
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -619,24 +619,6 @@
 				this.unlisten(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
 			},
 			/*
-			* Fetches set of focusable elements (all `<d2l-course-tile>`s)
-			*
-			* Required for accessibility, this specifies which elements within the element are intended to be
-			* keyboard-focusable. This is because we're using `<iron-overlay with-backdrop>`. See
-			* [those docs](https://github.com/PolymerElements/iron-overlay-behavior#backdrop) for more information.
-			*
-			* @return {Array<HTMLElement>} `<d2l-course-tile` HTMLElements
-			*/
-			focusableNodesOverride: function() {
-				var courseTileFocusables = [];
-
-				Polymer.dom(this.root).querySelectorAll('d2l-course-tile').forEach(function(courseTile) {
-					Array.prototype.push.apply(courseTileFocusables, Polymer.dom(courseTile.root).querySelectorAll('a'));
-				});
-
-				return courseTileFocusables;
-			},
-			/*
 			* Fetches the max value between the pinned and unpinned enrollments
 			* @return {Number} Max(number of pinned enrollments, number of unpinned enrollments)
 			*/

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -225,10 +225,6 @@
 
 				this.toggleClass('hidden', true, this.$.courseTiles);
 				this.toggleClass('hidden', true, this.$.courseList);
-
-				var allCoursesOverlay = this.$$('#all-courses');
-				var allCourses = this.$$('d2l-all-courses');
-				allCoursesOverlay.focusableNodesOverride = allCourses.focusableNodesOverride.bind(allCourses);
 			},
 			attached: function() {
 				if (!this.delayLoad) {
@@ -323,13 +319,9 @@
 				this._showContent();
 			},
 			_openChangeImageView: function(e) {
-				var changeImageOverlay = this.$$('#basic-image-selector-overlay');
-				var basicImageSelector = this.$$('d2l-basic-image-selector');
 				if (e.detail.organization) {
 					this._setImageOrg = e.detail.organization;
 				}
-
-				changeImageOverlay.focusableNodesOverride = basicImageSelector.focusableNodesOverride.bind(basicImageSelector);
 
 				this.$$('#basic-image-selector-overlay').open();
 			},

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -101,17 +101,6 @@ The overlay supports using different animations and transitions for desktop and 
 						};
 					}
 				},
-				/*
-				* Focusable element override for `iron-overlay`
-				*
-				* Required for accessibility, this specifies which elements within the element are intended to be
-				* keyboard-focusable. This is because we're using `<iron-overlay with-backdrop>`. See
-				* [those docs](https://github.com/PolymerElements/iron-overlay-behavior#backdrop) for more information.
-				*/
-				focusableNodesOverride: {
-					type: Object,
-					value: null
-				},
 				/* TODO: No longer required? */
 				_viewportContent: {
 					type: String

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -99,14 +99,6 @@
 				_showGrid: Boolean,
 			},
 			behaviors: [ window.D2L.MyCourses.LocalizeBehavior ],
-			focusableNodesOverride: function() {
-				var imageTileFocusables = [];
-				var grid = this.$$('d2l-image-tile-grid');
-				[].forEach.call(grid.querySelectorAll('d2l-image-selector-tile'), function(imageTile) {
-					Array.prototype.push.apply(imageTileFocusables, Polymer.dom(imageTile.root).querySelectorAll('button'));
-				});
-				return imageTileFocusables;
-			},
 			_sirenParser: document.createElement('d2l-siren-parser'),
 			_searchImages: [],
 			_defaultImages: [],


### PR DESCRIPTION
No story, just removes some dead code I noticed (`focusableNodesOverride` is never called as `_focusableNodes` does the same thing in a much simpler and more generic way directly). Also updates the `iron-overlay-behavior` dependency to the release with the updates in the pinned commit we're currently using.