### PR TITLE
Reset search/image tiles when opening image selector

### DIFF
--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -48,6 +48,16 @@ The overlay supports using different animations and transitions for desktop and 
 			* @event recalculate-columns
 			*/
 
+			/*
+			* Fired on distributed children when overlay is about to open
+			* @event d2l-simple-overlay-opening
+			*/
+
+			/*
+			* Fired on distributed children when overlay has finished closing
+			* @event d2l-simple-overlay-closed
+			*/
+
 			behaviors: [
 				Polymer.IronOverlayBehavior,
 				Polymer.NeonAnimationRunnerBehavior,

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -144,6 +144,7 @@ The overlay supports using different animations and transitions for desktop and 
 				if (this.opened) {
 					this._finishRenderOpened();
 				} else {
+					this._notifyDistributedChildren('d2l-simple-overlay-closed');
 					this._finishRenderClosed();
 				}
 			},
@@ -163,6 +164,7 @@ The overlay supports using different animations and transitions for desktop and 
 
 				this._onNodesChange();
 				Polymer.dom(this.root).querySelector('.scrollable').scrollTop = 0;
+				this._notifyDistributedChildren('d2l-simple-overlay-opening');
 
 				if (this._isMobile()) {
 					this.playAnimation('mobileOpen');
@@ -185,6 +187,20 @@ The overlay supports using different animations and transitions for desktop and 
 			},
 			get scrollRegion() {
 				return this.$$('.scrollable');
+			},
+			_notifyDistributedChildren: function(eventName) {
+				Polymer.dom(this.$$('content'))
+					.getDistributedNodes()
+					.forEach(function(childNode) {
+						this.fire(
+							eventName,
+							null,
+							{
+								bubbles: false,
+								node: childNode
+							}
+						);
+					}.bind(this));
 			}
 		});
 	</script>

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -147,7 +147,7 @@
 			_clear: function() {
 				this._searchString = '';
 				this._images = [];
-			}
+			},
 			_getSearchAction: function() {
 				return {
 					name: 'search-catalog-image',

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -83,10 +83,7 @@
 			},
 			properties: {
 				imageCatalogLocation: String,
-				organization: {
-					type: Object,
-					observer: '_updateOrganization'
-				},
+				organization: Object,
 				_searchString: String,
 				_images: Array,
 				_searchAction: String,
@@ -96,6 +93,10 @@
 				_showGrid: Boolean,
 			},
 			behaviors: [ window.D2L.MyCourses.LocalizeBehavior ],
+			listeners: {
+				'd2l-simple-overlay-opening': '_initialize',
+				'd2l-simple-overlay-closed': '_clear'
+			},
 			_sirenParser: document.createElement('d2l-siren-parser'),
 			_searchImages: [],
 			_defaultImages: [],
@@ -126,14 +127,14 @@
 
 				this._updateImages();
 			},
-			_updateOrganization: function(organization) {
+			_initialize: function() {
 				this._searchAction = JSON.stringify(this._getSearchAction());
 				this._showGrid = true;
 				this.$$('d2l-search-widget').clear();
 
 				// TODO: Add 'department' to the organization HM entity and use that information here
-				if (organization && (organization.properties || {}).name) {
-					this._searchString = this._getSearchStringValue(organization.properties.name, true);
+				if (this.organization && (this.organization.properties || {}).name) {
+					this._searchString = this._getSearchStringValue(this.organization.properties.name, true);
 				} else {
 					// This is better than 'default' because we get random defaults rather than starting at 0
 					this._searchString = this._getSearchStringValue('THIS_WILL_RETURN_NOTHING', true);
@@ -143,6 +144,10 @@
 					this.$.imagesRequest.generateRequest();
 				}
 			},
+			_clear: function() {
+				this._searchString = '';
+				this._images = [];
+			}
 			_getSearchAction: function() {
 				return {
 					name: 'search-catalog-image',


### PR DESCRIPTION
Re-opening the image selector won't clear the search if the same course is selected twice in succession due to how Polymer property observers work. Changed observer to a public setter that's called when the overlay is opened, as the organization should only change while the overlay is closed.