### PR TITLE
Responsive image resolutions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,3 +7,4 @@ globals:
   Polymer: false
   WCT: false
   D2L: false
+  picturefill: false

--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
     "polymer": "Polymer/polymer#^1.4.0",
-    "picturefill": "https://github.com/scottjehl/picturefill.git#3.0"
+    "picturefill": "https://github.com/scottjehl/picturefill.git#^3.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/bower.json
+++ b/bower.json
@@ -50,7 +50,8 @@
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
-    "polymer": "Polymer/polymer#^1.4.0"
+    "polymer": "Polymer/polymer#^1.4.0",
+    "picturefill": "https://github.com/scottjehl/picturefill.git#master"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/bower.json
+++ b/bower.json
@@ -51,7 +51,7 @@
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
     "polymer": "Polymer/polymer#^1.4.0",
-    "picturefill": "https://github.com/scottjehl/picturefill.git#master"
+    "picturefill": "https://github.com/scottjehl/picturefill.git#3.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -463,7 +463,8 @@
 			id="all-courses-pinned"
 			enrollments="{{pinnedEnrollments}}"
 			enrollments-queue="{{pinnedEnrollmentsQueue}}"
-			delay-course-tile-load="[[delayCourseTileLoad]]">
+			delay-course-tile-load="[[delayCourseTileLoad]]"
+			all-courses=true>
 		</d2l-course-tile-grid>
 
 		<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
@@ -472,7 +473,8 @@
 			id="all-courses-unpinned"
 			enrollments="{{unpinnedEnrollments}}"
 			enrollments-queue="{{unpinnedEnrollmentsQueue}}"
-			delay-course-tile-load="[[delayCourseTileLoad]]">
+			delay-course-tile-load="[[delayCourseTileLoad]]"
+			all-courses=true>
 		</d2l-course-tile-grid>
 	</template>
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -464,7 +464,7 @@
 			enrollments="{{pinnedEnrollments}}"
 			enrollments-queue="{{pinnedEnrollmentsQueue}}"
 			delay-course-tile-load="[[delayCourseTileLoad]]"
-			all-courses=true>
+			tile-sizes="[[_tileSizes]]">
 		</d2l-course-tile-grid>
 
 		<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
@@ -474,7 +474,7 @@
 			enrollments="{{unpinnedEnrollments}}"
 			enrollments-queue="{{unpinnedEnrollmentsQueue}}"
 			delay-course-tile-load="[[delayCourseTileLoad]]"
-			all-courses=true>
+			tile-sizes="[[_tileSizes]]">
 		</d2l-course-tile-grid>
 	</template>
 
@@ -572,6 +572,7 @@
 					type: String,
 					value: 'pinDate'
 				},
+				_tileSizes: String,
 				_parentOrganizations: {
 					type: Array,
 					value: function() {
@@ -593,6 +594,7 @@
 				for (var i = 0; i < courseTileGrids.length; i++) {
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
+				this._updateTileSizes();
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
@@ -605,6 +607,8 @@
 				this.listen(this.$.departmentSearchWidget, 'search-results-changed', '_onDepartmentSearchResults');
 
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
+
+				window.addEventListener('resize', this._onResize.bind(this));
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'menu-item-selected', '_updateSortBy');
@@ -767,6 +771,9 @@
 					this._selectSemesterList();
 				}
 			},
+			_onResize: function() {
+				this._updateTileSizes();
+			},
 			_selectSemesterList: function() {
 				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
 				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
@@ -780,6 +787,10 @@
 				this.$.semesterSearchWidget.clear();
 				this.$.departmentSearchWidget.clear();
 				this.$.departmentList.querySelector('d2l-menu').resize();
+			},
+			_updateTileSizes: function() {
+				this._rescaleCourseTileRegions();
+				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			},
 			_toggleSelectedList: function(list, button, highlight, selected) {
 				this.toggleClass('hidden', !selected, list);

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -24,8 +24,7 @@
 					class="grid-child"
 					enrollment-id="[[getEntityIdentifier(item)]]"
 					delay-load="[[delayCourseTileLoad]]"
-					all-courses="[[allCourses]]"
-					num-cols="[[_numCols]]">
+					tile-sizes="[[tileSizes]]">
 				</d2l-course-tile>
 			</template>
 		</div>
@@ -56,11 +55,6 @@
 				* Specifies whether or not the tile grid is for the all courses overlay
 				* @type {Boolean}
 				*/
-				allCourses: Boolean,
-				/*
-				* Sets the delay-load property on the course tiles
-				* @type {Boolean}
-				*/
 				delayCourseTileLoad: Boolean,
 				/*
 				* Set of enrollment entities for which to display course tiles
@@ -83,7 +77,12 @@
 					value: function() {
 						return [];
 					}
-				}
+				},
+				/*
+				* Size the tile should render with respect to vw
+				* @type {String}
+				*/
+				tileSizes: String
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -23,7 +23,9 @@
 					animate-insertion="[[_removeEnrollmentFromTransitionList(item)]]"
 					class="grid-child"
 					enrollment-id="[[getEntityIdentifier(item)]]"
-					delay-load="[[delayCourseTileLoad]]">
+					delay-load="[[delayCourseTileLoad]]"
+					all-courses="[[allCourses]]"
+					num-cols="[[_numCols]]">
 				</d2l-course-tile>
 			</template>
 		</div>
@@ -50,6 +52,11 @@
 			*/
 
 			properties: {
+				/*
+				* Specifies whether or not the tile grid is for the all courses overlay
+				* @type {Boolean}
+				*/
+				allCourses: Boolean,
 				/*
 				* Sets the delay-load property on the course tiles
 				* @type {Boolean}

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -52,7 +52,7 @@
 
 			properties: {
 				/*
-				* Specifies whether or not the tile grid is for the all courses overlay
+				* Sets the delay-load property on the course tiles
 				* @type {Boolean}
 				*/
 				delayCourseTileLoad: Boolean,

--- a/d2l-course-tile-responsive-grid-behavior.html
+++ b/d2l-course-tile-responsive-grid-behavior.html
@@ -37,6 +37,11 @@
 				throw 'Must implement getCourseTileItemCount in behavior consumer';
 			},
 			_numCols: 0,
+			/*
+			* Tile in the course overlay will render at 100% width
+			* @type {Number}
+			*/
+			_numColsOverlay: 0,
 			_calcNumColumns: function(width, itemCount) {
 				var numCols = 1;
 
@@ -95,6 +100,7 @@
 					});
 					return foundClass;
 				};
+				this._numColsOverlay = this._calcNumColumns(window.innerWidth, itemCount);
 
 				containers.forEach(function(container) {
 					var width = this._getAvailableWidth(container);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -347,7 +347,8 @@ in that organization - student, teacher, TA, etc.
 			setCourseImage: function(details) {
 				details = details || {};
 				var tileContainer = this.$$('.tile-container');
-				var newImageHref = this.getDefaultImageLink(details.image);
+				var newImageHref = this.getDefaultImageLink(details.image),
+					newSrcset = this.getImageSrcset(details.image, 'tile');
 
 				switch (details.status) {
 					case 'set':
@@ -356,16 +357,18 @@ in that organization - student, teacher, TA, etc.
 						// NOTE: if this needs optimization, we can wait for the image's onload to play the success animation
 						var imagePreloader = document.createElement('img');
 						imagePreloader.setAttribute('src', newImageHref);
+						imagePreloader.setAttribute('srcset', newSrcset);
+						imagePreloader.setAttribute('sizes', this._sizes);
 						break;
 					case 'success':
-						this._displaySetImageResult(true, newImageHref);
+						this._displaySetImageResult(true, newImageHref, newSrcset);
 						break;
 					case 'failure':
 						this._displaySetImageResult(false);
 						break;
 				}
 			},
-			_displaySetImageResult: function(success, newImageHref) {
+			_displaySetImageResult: function(success, newImageHref, newSrcset) {
 				var tileContainer = this.$$('.tile-container');
 				var courseImage = this.$$('.course-image img');
 
@@ -386,7 +389,7 @@ in that organization - student, teacher, TA, etc.
 						if (success) {
 							this.toggleClass('hidden', false, courseImage);
 							Polymer.dom(courseImage).setAttribute('src', newImageHref);
-							Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(details.image, 'tile'));
+							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -368,7 +368,9 @@ in that organization - student, teacher, TA, etc.
 					setTimeout(function() {
 						if (success) {
 							this.toggleClass('hidden', false, courseImage);
+							var newSrcset = this.getImageSrcset(details.image) || '';
 							Polymer.dom(courseImage).setAttribute('src', newImageHref);
+							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -535,21 +535,8 @@ in that organization - student, teacher, TA, etc.
 				}
 			},
 			setSizes: function() {
-				if (this.allCourses) {
-					switch(this.numCols) {
-						case 2:
-							this._sizes = "50vw"
-							break;
-						case 3:
-							this._sizes = "33vw"
-							break;
-						default:
-							this._sizes = "25vw"
-							break;
-					}
-				} else {
-					this._sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw"
-				}
+				this._sizes = this.allCourses ? Math.floor(100 / this.numCols) + 'vw'
+					: "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw";
 			}
 		});
 	</script>

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -285,8 +285,8 @@ in that organization - student, teacher, TA, etc.
 
 				Polymer.IronA11yAnnouncer.requestAvailability();
 
-				this.setSizes();
-				window.addEventListener('resize', this.setSizes.bind(this));
+				this._setSizes();
+				window.addEventListener('resize', this._setSizes.bind(this));
 
 				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
@@ -534,7 +534,7 @@ in that organization - student, teacher, TA, etc.
 					this._setCourseTileHovered(false);
 				}
 			},
-			setSizes: function() {
+			_setSizes: function() {
 				this._sizes = this.allCourses ? Math.floor(100 / this.numCols) + 'vw'
 					: '(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw';
 			}

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -11,6 +11,7 @@
 <link rel="import" href="d2l-course-tile-styles.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-utility-behavior.html">
+<script src="bower_components/picturefill/src/picturefill.js"></script>
 
 <!--
 `<d2l-course-tile>` is a clickable, interactable tile that represents a course
@@ -286,6 +287,8 @@ in that organization - student, teacher, TA, etc.
 
 				this.setSizes();
 				window.addEventListener('resize', this.setSizes.bind(this));
+
+				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
 			/*
 			* Handler that triggers the API call to change an enrollment's pin state when the user says DO IT
@@ -359,6 +362,7 @@ in that organization - student, teacher, TA, etc.
 						imagePreloader.setAttribute('src', newImageHref);
 						imagePreloader.setAttribute('srcset', newSrcset);
 						imagePreloader.setAttribute('sizes', this._sizes);
+						picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 						break;
 					case 'success':
 						this._displaySetImageResult(true, newImageHref, newSrcset);
@@ -390,6 +394,7 @@ in that organization - student, teacher, TA, etc.
 							this.toggleClass('hidden', false, courseImage);
 							Polymer.dom(courseImage).setAttribute('src', newImageHref);
 							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
+							picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);
@@ -508,6 +513,7 @@ in that organization - student, teacher, TA, etc.
 				this.toggleClass('hidden', href === '', courseImage);
 				Polymer.dom(courseImage).setAttribute('src', href);
 				Polymer.dom(courseImage).setAttribute('srcset', srcset);
+				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */
@@ -542,7 +548,7 @@ in that organization - student, teacher, TA, etc.
 							break;
 					}
 				} else {
-					this._sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 20vw"
+					this._sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw"
 				}
 			}
 		});

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -330,6 +330,7 @@ in that organization - student, teacher, TA, etc.
 				details = details || {};
 				var tileContainer = this.$$('.tile-container');
 				var newImageHref = this.getDefaultImageLink(details.image);
+				console.log(this.getImageSrcset(details.image))
 
 				switch (details.status) {
 					case 'set':
@@ -475,16 +476,19 @@ in that organization - student, teacher, TA, etc.
 				return organization && organization.getLinkByRel(rel);
 			},
 			_setCourseImageSrc: function() {
-				var href = '';
+				var href = '', srcset = '', sizes = '';
 
 				var courseImageEntity = this._organization.getSubEntityByClass('course-image');
 				if (courseImageEntity) {
 					href = this.getDefaultImageLink(courseImageEntity) || '';
+					srcset = this.getImageSrcset(courseImageEntity) || '';
 				}
-
+				sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 20vw";
 				var courseImage = this.$$('.course-image img');
 				this.toggleClass('hidden', href === '', courseImage);
 				Polymer.dom(courseImage).setAttribute('src', href);
+				Polymer.dom(courseImage).setAttribute('srcset', srcset);
+				Polymer.dom(courseImage).setAttribute('sizes', sizes);
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -224,11 +224,6 @@ in that organization - student, teacher, TA, etc.
 				_courseSettingsLabel: String,
 				_canChangeCourseImage: Boolean,
 				/*
-				* Size property to be used for srcset responsive images
-				* @type {String}
-				*/
-				_sizes: String,
-				/*
 				* The icon we want to show when you select an image
 				* @type {Object}
 				*/

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -11,7 +11,7 @@
 <link rel="import" href="d2l-course-tile-styles.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-utility-behavior.html">
-<script src="bower_components/picturefill/src/picturefill.js"></script>
+<script src="bower_components/picturefill/src/picturefill.js" async></script>
 
 <!--
 `<d2l-course-tile>` is a clickable, interactable tile that represents a course
@@ -536,7 +536,7 @@ in that organization - student, teacher, TA, etc.
 			},
 			setSizes: function() {
 				this._sizes = this.allCourses ? Math.floor(100 / this.numCols) + 'vw'
-					: "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw";
+					: '(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw';
 			}
 		});
 	</script>

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -57,7 +57,7 @@ in that organization - student, teacher, TA, etc.
 								<d2l-icon class$="[[_iconDetails.className]]" icon="[[_iconDetails.iconName]]"></d2l-icon>
 							</div>
 						</div>
-						<img aria-hidden="true" />
+						<img aria-hidden="true" sizes="[[_sizes]]"/>
 					</div>
 				</div>
 				<div class="course-text d2l-heading-4">{{_organization.properties.name}}</div>
@@ -119,6 +119,11 @@ in that organization - student, teacher, TA, etc.
 
 			properties: {
 				/*
+				* Specifies whether or not the tile grid is for the all courses overlay
+				* @type {Boolean}
+				*/
+				allCourses: Boolean,
+				/*
 				* TODO: Figure out what this is... Friday night brain isn't allowing me to understand this.
 				* @type {Boolean}
 				*/
@@ -155,6 +160,11 @@ in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					value: true
 				},
+				/*
+				* Number of columns in the courses tile grid
+				* @type {Number}
+				*/
+				numCols: Number,
 				/*
 				* Whether the enrollment represented by this course tile is pinned or not
 				* @type {Boolean}
@@ -218,6 +228,11 @@ in that organization - student, teacher, TA, etc.
 				_courseSettingsLabel: String,
 				_canChangeCourseImage: Boolean,
 				/*
+				* Size property to be used for srcset responsive images
+				* @type {String}
+				*/
+				_sizes: String,
+				/*
 				* The icon we want to show when you select an image
 				* @type {Object}
 				*/
@@ -268,6 +283,9 @@ in that organization - student, teacher, TA, etc.
 				this._hoverCourseTile = this._hoverCourseTile.bind(this);
 
 				Polymer.IronA11yAnnouncer.requestAvailability();
+
+				this.setSizes();
+				window.addEventListener('resize', this.setSizes.bind(this));
 			},
 			/*
 			* Handler that triggers the API call to change an enrollment's pin state when the user says DO IT
@@ -330,7 +348,6 @@ in that organization - student, teacher, TA, etc.
 				details = details || {};
 				var tileContainer = this.$$('.tile-container');
 				var newImageHref = this.getDefaultImageLink(details.image);
-				console.log(this.getImageSrcset(details.image))
 
 				switch (details.status) {
 					case 'set':
@@ -368,9 +385,8 @@ in that organization - student, teacher, TA, etc.
 					setTimeout(function() {
 						if (success) {
 							this.toggleClass('hidden', false, courseImage);
-							var newSrcset = this.getImageSrcset(details.image) || '';
 							Polymer.dom(courseImage).setAttribute('src', newImageHref);
-							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
+							Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(details.image, 'tile'));
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);
@@ -478,19 +494,17 @@ in that organization - student, teacher, TA, etc.
 				return organization && organization.getLinkByRel(rel);
 			},
 			_setCourseImageSrc: function() {
-				var href = '', srcset = '', sizes = '';
+				var href = '', srcset = '';
 
 				var courseImageEntity = this._organization.getSubEntityByClass('course-image');
 				if (courseImageEntity) {
 					href = this.getDefaultImageLink(courseImageEntity) || '';
-					srcset = this.getImageSrcset(courseImageEntity) || '';
+					srcset = this.getImageSrcset(courseImageEntity, 'tile') || '';
 				}
-				sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 20vw";
 				var courseImage = this.$$('.course-image img');
 				this.toggleClass('hidden', href === '', courseImage);
 				Polymer.dom(courseImage).setAttribute('src', href);
 				Polymer.dom(courseImage).setAttribute('srcset', srcset);
-				Polymer.dom(courseImage).setAttribute('sizes', sizes);
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */
@@ -509,6 +523,23 @@ in that organization - student, teacher, TA, etc.
 					var dropdown = this.$$('#overflow-dropdown');
 					dropdown.close();
 					this._setCourseTileHovered(false);
+				}
+			},
+			setSizes: function() {
+				if (this.allCourses) {
+					switch(this.numCols) {
+						case 2:
+							this._sizes = "50vw"
+							break;
+						case 3:
+							this._sizes = "33vw"
+							break;
+						default:
+							this._sizes = "25vw"
+							break;
+					}
+				} else {
+					this._sizes = "(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 20vw"
 				}
 			}
 		});

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -58,7 +58,7 @@ in that organization - student, teacher, TA, etc.
 								<d2l-icon class$="[[_iconDetails.className]]" icon="[[_iconDetails.iconName]]"></d2l-icon>
 							</div>
 						</div>
-						<img aria-hidden="true" sizes="[[_sizes]]"/>
+						<img aria-hidden="true" sizes="[[tileSizes]]"/>
 					</div>
 				</div>
 				<div class="course-text d2l-heading-4">{{_organization.properties.name}}</div>
@@ -120,11 +120,6 @@ in that organization - student, teacher, TA, etc.
 
 			properties: {
 				/*
-				* Specifies whether or not the tile grid is for the all courses overlay
-				* @type {Boolean}
-				*/
-				allCourses: Boolean,
-				/*
 				* TODO: Figure out what this is... Friday night brain isn't allowing me to understand this.
 				* @type {Boolean}
 				*/
@@ -162,11 +157,6 @@ in that organization - student, teacher, TA, etc.
 					value: true
 				},
 				/*
-				* Number of columns in the courses tile grid
-				* @type {Number}
-				*/
-				numCols: Number,
-				/*
 				* Whether the enrollment represented by this course tile is pinned or not
 				* @type {Boolean}
 				*/
@@ -174,6 +164,11 @@ in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					observer: '_pinnedChanged'
 				},
+				/*
+				* Size the tile should render with respect to vw
+				* @type {String}
+				*/
+				tileSizes: String,
 				/*
 				* Specifies whether the (mobile) touch menu is enabled on the course tile
 				* @type {Boolean}
@@ -285,9 +280,6 @@ in that organization - student, teacher, TA, etc.
 
 				Polymer.IronA11yAnnouncer.requestAvailability();
 
-				this._setSizes();
-				window.addEventListener('resize', this._setSizes.bind(this));
-
 				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
 			/*
@@ -361,7 +353,7 @@ in that organization - student, teacher, TA, etc.
 						var imagePreloader = document.createElement('img');
 						imagePreloader.setAttribute('src', newImageHref);
 						imagePreloader.setAttribute('srcset', newSrcset);
-						imagePreloader.setAttribute('sizes', this._sizes);
+						imagePreloader.setAttribute('sizes', this.sizes);
 						picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 						break;
 					case 'success':
@@ -533,10 +525,6 @@ in that organization - student, teacher, TA, etc.
 					dropdown.close();
 					this._setCourseTileHovered(false);
 				}
-			},
-			_setSizes: function() {
-				this._sizes = this.allCourses ? Math.floor(100 / this.numCols) + 'vw'
-					: '(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw';
 			}
 		});
 	</script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -97,7 +97,7 @@
 			</d2l-alert>
 			<d2l-course-tile-grid
 				enrollments="{{pinnedEnrollments}}"
-				tile-sizes="(max-width: 767px) 100vw, (max-width: 1243px) and (min-width: 768px) 67vw, 20vw">
+				tile-sizes="[[_tileSizes]]">
 			</d2l-course-tile-grid>
 			<button
 				class="all-courses-button"
@@ -213,7 +213,12 @@
 				* URL used by the search widget to fetch department-type organizations
 				* @type {String}
 				*/
-				_departmentsUrl: String
+				_departmentsUrl: String,
+				/*
+				* Size the tile should render with respect to vw
+				* @type {String}
+				*/
+				_tileSizes: String
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -314,6 +319,10 @@
 
 					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
 					this._hasEnrollments = this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0;
+
+					this._tileSizes = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length) === 2 ?
+						'(max-width: 767px) 50vw, (max-width: 1243px) and (min-width: 768px) 33vw, 20vw'
+						: '(max-width: 767px) 100vw, (max-width: 1243px) and (min-width: 768px) 67vw, 25vw';
 
 					if (this._hasEnrollments) {
 						this._alertMessage = this.localize('noPinnedCoursesMessage');

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -97,7 +97,7 @@
 			</d2l-alert>
 			<d2l-course-tile-grid
 				enrollments="{{pinnedEnrollments}}"
-				tile-sizes="(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw">
+				tile-sizes="(max-width: 767px) 100vw, (max-width: 1243px) and (min-width: 768px) 67vw, 20vw">
 			</d2l-course-tile-grid>
 			<button
 				class="all-courses-button"

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -96,7 +96,8 @@
 					on-tap="_refreshPage">{{localize('refresh')}}</a>
 			</d2l-alert>
 			<d2l-course-tile-grid
-				enrollments="{{pinnedEnrollments}}">
+				enrollments="{{pinnedEnrollments}}"
+				tile-sizes="(max-width: 767px) 100vw, (max-width: 1211px) and (min-width: 768px) 67vw, 33vw">
 			</d2l-course-tile-grid>
 			<button
 				class="all-courses-button"

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -39,6 +39,19 @@
 
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
+		getImageSrcset: function(image) {
+			var imageLinks = image.getLinksByClass('tile'),
+				srcset = '';
+			imageLinks.forEach(function(link) {
+				srcset += link.hasClass('min') && !link.hasClass('high-density') ? link.href + ' 145w, ' : '';
+				srcset += link.hasClass('min') && link.hasClass('high-density') ? link.href + ' 290w, ' : '';
+				srcset += link.hasClass('mid') && !link.hasClass('high-density') ? link.href + ' 220w, ' : '';
+				srcset += link.hasClass('mid') && link.hasClass('high-density') ? link.href + ' 440w, ' : '';
+				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 540w, ' : '';
+				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1080w, ' : '';
+			});
+			return srcset.trimRight().replace(/,\s*$/, "");
+		},
 		/*
 		* Returns the best available image to use as a default
 		* @param {Entity} image

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,7 +40,7 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image) {
-			var test = true;
+			var test = false;
 			var imageLinks = image.getLinksByClass('tile'),
 				srcset = '';
 			imageLinks.forEach(function(link) {
@@ -57,7 +57,7 @@
 			return srcset.replace(/,\s*$/, "");
 		},
 		getImageSrcsetBanner: function(image) {
-			var test = true;
+			var test = false;
 			var imageLinks = image.getLinksByClass('narrow'),
 				srcset = '';
 				console.log(imageLinks);

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,34 +40,22 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image, imageClass) {
-			var test = true;
-			if (!image) {
-				return '';
-			}
+			if (!image) {	return ''; }
 			var srcset = '',
-				sizes = this._getImageLinks(image, imageClass);
-			if (imageClass === 'tile') {
-				if (test) {
-					return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
-				}
-				srcset += sizes.lowMin ? sizes.lowMin + ' 145w, ' : '';
-				srcset += sizes.highMin ? sizes.highMin + ' 290w, ' : '';
-				srcset += sizes.lowMid ? sizes.lowMid + ' 220w, ' : '';
-				srcset += sizes.highMid ? sizes.highMid + ' 440w, ' : '';
-				srcset += sizes.lowMax ? sizes.lowMax + ' 540w, ' : '';
-				srcset += sizes.highMax ? sizes.highMax + ' 1080w, ' : '';
-			}
-			if (imageClass === 'narrow') {
-				if (test) {
-					return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
-				}
-				srcset += sizes.lowMin ? sizes.lowMin + ' 320w, ' : '';
-				srcset += sizes.highMin ? sizes.highMin + ' 640w, ' : '';
-				srcset += sizes.lowMid ? sizes.lowMid + ' 375w, ' : '';
-				srcset += sizes.highMid ? sizes.highMid + ' 750w, ' : '';
-				srcset += sizes.lowMax ? sizes.lowMax + ' 767w, ' : '';
-				srcset += sizes.highMax ? sizes.highMax + ' 1534w, ' : '';
-			}
+				sizes = this._getImageLinks(image, imageClass),
+				imageWidths = {
+					tile: {
+						lowMin: 145, lowMid: 220, lowMax: 540,
+						highMin: 290, highMid: 440, highMax: 1080
+					},
+					narrow: {
+						lowMin: 320, lowMid: 375, lowMax: 767,
+						highMin: 640, highMid: 750, highMax: 1534
+					}
+				};
+			['lowMin', 'lowMid', 'lowMax', 'highMin', 'highMid', 'highMax'].forEach(function(size) {
+				srcset += sizes[size] ? sizes[size] + ' ' + imageWidths[imageClass][size] + 'w, ' : '';
+			});
 			return srcset.replace(/,\s*$/, '');
 		},
 		/*

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -56,7 +56,7 @@
 				srcset += sizes.lowMax ? sizes.lowMax + ' 540w, ' : '';
 				srcset += sizes.highMax ? sizes.highMax + ' 1080w, ' : '';
 			}
-			if (imageClass === 'banner') {
+			if (imageClass === 'narrow') {
 				srcset += sizes.lowMin ? sizes.lowMin + ' 320w, ' : '';
 				srcset += sizes.highMin ? sizes.highMin + ' 640w, ' : '';
 				srcset += sizes.lowMid ? sizes.lowMid + ' 375w, ' : '';

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -45,7 +45,7 @@
 				sizes = {};
 			imageLinks.forEach(function(link) {
 				var size = link.hasClass('min') && 'Min' || link.hasClass('mid') && 'Mid' || link.hasClass('max') && 'Max',
-				density = link.hasClass('high-density') ? 'high' : 'low';
+					density = link.hasClass('high-density') ? 'high' : 'low';
 				sizes[density + size] = link.href;
 			});
 			if (imageClass === 'tile') {
@@ -64,7 +64,7 @@
 				srcset += sizes.lowMax ? sizes.lowMax + ' 767w, ' : '';
 				srcset += sizes.highMax ? sizes.highMax + ' 1534w, ' : '';
 			}
-			return srcset.replace(/,\s*$/, "");
+			return srcset.replace(/,\s*$/, '');
 		},
 		/*
 		* Returns the best available image to use as a default

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,7 +40,7 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image, imageClass) {
-			if (!image) {	return ''; }
+			if (!image) { return ''; }
 			var srcset = '',
 				sizes = this._getImageLinks(image, imageClass),
 				imageWidths = {

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -44,13 +44,7 @@
 				return '';
 			}
 			var srcset = '',
-				imageLinks = image.getLinksByClass(imageClass || 'tile'),
-				sizes = {};
-			imageLinks.forEach(function(link) {
-				var size = link.hasClass('min') && 'Min' || link.hasClass('mid') && 'Mid' || link.hasClass('max') && 'Max',
-					density = link.hasClass('high-density') ? 'high' : 'low';
-				sizes[density + size] = link.href;
-			});
+				sizes = this._getImageLinks(image, imageClass);
 			if (imageClass === 'tile') {
 				srcset += sizes.lowMin ? sizes.lowMin + ' 145w, ' : '';
 				srcset += sizes.highMin ? sizes.highMin + ' 290w, ' : '';
@@ -75,13 +69,7 @@
 		* @return {String}
 		*/
 		getDefaultImageLink: function(image, imageClass) {
-			var imageLinks = image.getLinksByClass(imageClass || 'tile'),
-				sizes = {};
-			imageLinks.forEach(function(link) {
-				var size = link.hasClass('min') && 'Min' || link.hasClass('mid') && 'Mid' || link.hasClass('max') && 'Max',
-					density = link.hasClass('high-density') ? 'high' : 'low';
-				sizes[density + size] = link.href;
-			});
+			var sizes = this._getImageLinks(image, imageClass);
 			return sizes.highMax || sizes.lowMax || sizes.highMid || sizes.lowMid || sizes.highMin || sizes.lowMin;
 		},
 		/*
@@ -93,6 +81,16 @@
 			// An entity's self href should be unique, so use it as an identifier
 			var selfLink = entity.getLinkByRel('self');
 			return selfLink.href;
+		},
+		_getImageLinks: function(image, imageClass) {
+			var imageLinks = image.getLinksByClass(imageClass || 'tile'),
+				sizes = {};
+			imageLinks.forEach(function(link) {
+				var size = link.hasClass('min') && 'Min' || link.hasClass('mid') && 'Mid' || link.hasClass('max') && 'Max',
+					density = link.hasClass('high-density') ? 'high' : 'low';
+				sizes[density + size] = link.href;
+			});
+			return sizes;
 		}
 	};
 </script>

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,6 +40,9 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image, imageClass) {
+			if (!image) {
+				return '';
+			}
 			var srcset = '',
 				imageLinks = image.getLinksByClass(imageClass || 'tile'),
 				sizes = {};

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,12 +40,16 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image, imageClass) {
+			var test = true;
 			if (!image) {
 				return '';
 			}
 			var srcset = '',
 				sizes = this._getImageLinks(image, imageClass);
 			if (imageClass === 'tile') {
+				if (test) {
+					return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
+				}
 				srcset += sizes.lowMin ? sizes.lowMin + ' 145w, ' : '';
 				srcset += sizes.highMin ? sizes.highMin + ' 290w, ' : '';
 				srcset += sizes.lowMid ? sizes.lowMid + ' 220w, ' : '';
@@ -54,6 +58,9 @@
 				srcset += sizes.highMax ? sizes.highMax + ' 1080w, ' : '';
 			}
 			if (imageClass === 'narrow') {
+				if (test) {
+					return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
+				}
 				srcset += sizes.lowMin ? sizes.lowMin + ' 320w, ' : '';
 				srcset += sizes.highMin ? sizes.highMin + ' 640w, ' : '';
 				srcset += sizes.lowMid ? sizes.lowMid + ' 375w, ' : '';

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -39,38 +39,37 @@
 
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
-		getImageSrcset: function(image) {
-			var test = false;
-			var imageLinks = image.getLinksByClass('tile'),
-				srcset = '';
+		getImageSrcset: function(image, imageClass) {
+			var test = true;
+			var srcset = '',
+				imageLinks = image.getLinksByClass(imageClass || 'tile'),
+				sizes = {};
 			imageLinks.forEach(function(link) {
-				srcset += link.hasClass('min') && !link.hasClass('high-density') ? link.href + ' 145w, ' : '';
-				srcset += link.hasClass('min') && link.hasClass('high-density') ? link.href + ' 290w, ' : '';
-				srcset += link.hasClass('mid') && !link.hasClass('high-density') ? link.href + ' 220w, ' : '';
-				srcset += link.hasClass('mid') && link.hasClass('high-density') ? link.href + ' 440w, ' : '';
-				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 540w, ' : '';
-				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1080w, ' : '';
+				var size = link.hasClass('min') && 'Min' || link.hasClass('mid') && 'Mid' || link.hasClass('max') && 'Max',
+				density = link.hasClass('high-density') ? 'high' : 'low';
+				sizes[density + size] = link.href;
 			});
-			if (test) {
-				return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
+			if (imageClass === 'tile') {
+				srcset += sizes.lowMin ? sizes.lowMin + ' 145w, ' : '';
+				srcset += sizes.highMin ? sizes.highMin + ' 290w, ' : '';
+				srcset += sizes.lowMid ? sizes.lowMid + ' 220w, ' : '';
+				srcset += sizes.highMid ? sizes.highMid + ' 440w, ' : '';
+				srcset += sizes.lowMax ? sizes.lowMax + ' 540w, ' : '';
+				srcset += sizes.highMax ? sizes.highMax + ' 1080w, ' : '';
+				if (test) {
+					return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
+				}
 			}
-			return srcset.replace(/,\s*$/, "");
-		},
-		getImageSrcsetBanner: function(image) {
-			var test = false;
-			var imageLinks = image.getLinksByClass('narrow'),
-				srcset = '';
-				console.log(imageLinks);
-			imageLinks.forEach(function(link) {
-				srcset += link.hasClass('min') && !link.hasClass('high-density') ? link.href + ' 320w, ' : '';
-				srcset += link.hasClass('min') && link.hasClass('high-density') ? link.href + ' 640w, ' : '';
-				srcset += link.hasClass('mid') && !link.hasClass('high-density') ? link.href + ' 375w, ' : '';
-				srcset += link.hasClass('mid') && link.hasClass('high-density') ? link.href + ' 750w, ' : '';
-				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 767w, ' : '';
-				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1534w, ' : '';
-			});
-			if (test) {
-				return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
+			if (imageClass === 'banner') {
+				srcset += sizes.lowMin ? sizes.lowMin + ' 320w, ' : '';
+				srcset += sizes.highMin ? sizes.highMin + ' 640w, ' : '';
+				srcset += sizes.lowMid ? sizes.lowMid + ' 375w, ' : '';
+				srcset += sizes.highMid ? sizes.highMid + ' 750w, ' : '';
+				srcset += sizes.lowMax ? sizes.lowMax + ' 767w, ' : '';
+				srcset += sizes.highMax ? sizes.highMax + ' 1534w, ' : '';
+				if (test) {
+					return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
+				}
 			}
 			return srcset.replace(/,\s*$/, "");
 		},

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,6 +40,7 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image) {
+			var test = true;
 			var imageLinks = image.getLinksByClass('tile'),
 				srcset = '';
 			imageLinks.forEach(function(link) {
@@ -50,9 +51,13 @@
 				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 540w, ' : '';
 				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1080w, ' : '';
 			});
+			if (test) {
+				return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
+			}
 			return srcset.replace(/,\s*$/, "");
 		},
 		getImageSrcsetBanner: function(image) {
+			var test = true;
 			var imageLinks = image.getLinksByClass('narrow'),
 				srcset = '';
 				console.log(imageLinks);
@@ -64,6 +69,9 @@
 				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 767w, ' : '';
 				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1534w, ' : '';
 			});
+			if (test) {
+				return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
+			}
 			return srcset.replace(/,\s*$/, "");
 		},
 		/*

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -50,7 +50,21 @@
 				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 540w, ' : '';
 				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1080w, ' : '';
 			});
-			return srcset.trimRight().replace(/,\s*$/, "");
+			return srcset.replace(/,\s*$/, "");
+		},
+		getImageSrcsetBanner: function(image) {
+			var imageLinks = image.getLinksByClass('narrow'),
+				srcset = '';
+				console.log(imageLinks);
+			imageLinks.forEach(function(link) {
+				srcset += link.hasClass('min') && !link.hasClass('high-density') ? link.href + ' 320w, ' : '';
+				srcset += link.hasClass('min') && link.hasClass('high-density') ? link.href + ' 640w, ' : '';
+				srcset += link.hasClass('mid') && !link.hasClass('high-density') ? link.href + ' 375w, ' : '';
+				srcset += link.hasClass('mid') && link.hasClass('high-density') ? link.href + ' 750w, ' : '';
+				srcset += link.hasClass('max') && !link.hasClass('high-density') ? link.href + ' 767w, ' : '';
+				srcset += link.hasClass('max') && link.hasClass('high-density') ? link.href + ' 1534w, ' : '';
+			});
+			return srcset.replace(/,\s*$/, "");
 		},
 		/*
 		* Returns the best available image to use as a default

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -40,7 +40,6 @@
 			return queryString ? action.href + '?' + queryString : action.href;
 		},
 		getImageSrcset: function(image, imageClass) {
-			var test = true;
 			var srcset = '',
 				imageLinks = image.getLinksByClass(imageClass || 'tile'),
 				sizes = {};
@@ -56,9 +55,6 @@
 				srcset += sizes.highMid ? sizes.highMid + ' 440w, ' : '';
 				srcset += sizes.lowMax ? sizes.lowMax + ' 540w, ' : '';
 				srcset += sizes.highMax ? sizes.highMax + ' 1080w, ' : '';
-				if (test) {
-					return "http://i.imgur.com/BHOB11o.png 1080w, http://i.imgur.com/mKnXE1f.png 440w, http://i.imgur.com/FQ2Hetx.png 290w, http://i.imgur.com/ch60eDr.png 540w, http://i.imgur.com/OMpdPM8.png 220w, http://i.imgur.com/UKSwTZv.png 145w";
-				}
 			}
 			if (imageClass === 'banner') {
 				srcset += sizes.lowMin ? sizes.lowMin + ' 320w, ' : '';
@@ -67,9 +63,6 @@
 				srcset += sizes.highMid ? sizes.highMid + ' 750w, ' : '';
 				srcset += sizes.lowMax ? sizes.lowMax + ' 767w, ' : '';
 				srcset += sizes.highMax ? sizes.highMax + ' 1534w, ' : '';
-				if (test) {
-					return "http://i.imgur.com/6zywPmF.png 1534w, http://i.imgur.com/uZhwOny.png 750w, http://i.imgur.com/MIzy0Zd.png 640w, http://i.imgur.com/M4oDn2l.png 767w, http://i.imgur.com/YtOLque.png 375w, http://i.imgur.com/XXyf8GK.png 320w";
-				}
 			}
 			return srcset.replace(/,\s*$/, "");
 		},

--- a/image-selector/d2l-image-selector-tile-styles.html
+++ b/image-selector/d2l-image-selector-tile-styles.html
@@ -45,7 +45,7 @@
 			}
 
 			.d2l-image-tile-content img {
-				max-height: 100%;
+				height: 100%;
 			}
 
 			.d2l-image-tile:hover .d2l-image-tile-content,

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -106,7 +106,6 @@
 				this.fire('close-simple-overlay');
 			},
 			_updateImageSource: function() {
-				console.log('update');
 				var courseImage = Polymer.dom(this.root).querySelector('img');
 				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
 				Polymer.dom(courseImage).setAttribute('sizes', "(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw");

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -27,7 +27,10 @@
 				</button>
 			</div>
 			<div class="d2l-image-tile-content">
-				<img src="[[getDefaultImageLink(image, 'banner')]]"></img>
+				<img
+					src="[[getDefaultImageLink(image, 'banner')]]"
+					srcset="[[getImageSrcsetBanner(image)]]"
+					sizes="(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw"></img>
 			</div>
 
 			<d2l-ajax

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -6,7 +6,7 @@
 <link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-image-selector-tile-styles.html">
-<script src="../bower_components/picturefill/src/picturefill.js"></script>
+<script src="../bower_components/picturefill/src/picturefill.js" async></script>
 
 <dom-module id="d2l-image-selector-tile">
 	<template>

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-image-selector-tile-styles.html">
+<script src="../bower_components/picturefill/src/picturefill.js"></script>
 
 <dom-module id="d2l-image-selector-tile">
 	<template>
@@ -27,10 +28,7 @@
 				</button>
 			</div>
 			<div class="d2l-image-tile-content">
-				<img
-					src="[[getDefaultImageLink(image, 'banner')]]"
-					srcset="[[getImageSrcset(image, 'banner')]]"
-					sizes="(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw"></img>
+				<img src="[[getDefaultImageLink(image, 'narrow')]]"></img>
 			</div>
 
 			<d2l-ajax
@@ -51,7 +49,10 @@
 		Polymer({
 			is: 'd2l-image-selector-tile',
 			properties: {
-				image: Object,
+				image: {
+					type: Object,
+					observer: '_updateImageSource'
+				},
 				organization: Object,
 				_setImageUrl: String
 			},
@@ -59,6 +60,9 @@
 				window.D2L.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.UtilityBehavior
 			],
+			ready: function() {
+				this._updateImageSource();
+			},
 			_toggleOverlayOn: function() {
 				this.toggleClass('mobile-selected', true, this.$$('.d2l-image-tile'));
 			},
@@ -100,6 +104,13 @@
 				this.$.setImageRequest.generateRequest();
 				this._fireCourseImageMessage('set');
 				this.fire('close-simple-overlay');
+			},
+			_updateImageSource: function() {
+				console.log('update');
+				var courseImage = Polymer.dom(this.root).querySelector('img');
+				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
+				Polymer.dom(courseImage).setAttribute('sizes', "(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw");
+				picturefill({ reevaluate: true, elements: [ courseImage ] });
 			}
 		});
 	</script>

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -29,7 +29,7 @@
 			<div class="d2l-image-tile-content">
 				<img
 					src="[[getDefaultImageLink(image, 'banner')]]"
-					srcset="[[getImageSrcsetBanner(image)]]"
+					srcset="[[getImageSrcset(image, 'banner')]]"
 					sizes="(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw"></img>
 			</div>
 

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.min.js"></script>
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>
 	<body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.min.js" async></script>
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>
 	<body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
-		<script src="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.min.js"></script>
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>
 	<body>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
 		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="https://cdn.rawgit.com/scottjehl/picturefill/3.0.2/dist/picturefill.min.js" async></script>
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>
 	<body>

--- a/test/d2l-utility-behavior/d2l-utility-behavior.js
+++ b/test/d2l-utility-behavior/d2l-utility-behavior.js
@@ -26,11 +26,69 @@ describe('d2l-utility-behavior', function() {
 				href: '/enrollments/users/169/organizations/1'
 			}]
 		},
-		enrollmentEntity;
+		image = {
+			class: ['course-image'],
+			properties: {
+				name: 'image1'
+			},
+			rel: ['https://api.brightspace.com/rels/organization-image'],
+			links: [
+				{
+					class: ['tile', 'low-density', 'max'],
+					href: 'http://image.com/tile-low-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				},
+				{
+					class: ['tile', 'high-density', 'max'],
+					href: 'http://image.com/tile-high-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				},
+				{
+					class: ['banner', 'low-density', 'max', 'narrow'],
+					href: 'http://image.com/banner-narrow-low-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				},
+				{
+					class: ['banner', 'high-density', 'max', 'narrow'],
+					href: 'http://image.com/banner-narrow-high-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				}
+			]
+		},
+		imageLowd = {
+			class: ['course-image'],
+			properties: {
+				name: 'image2'
+			},
+			rel: ['https://api.brightspace.com/rels/organization-image'],
+			links: [
+				{
+					class: ['tile', 'low-density', 'max'],
+					href: 'http://image.com/tile-low-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				},
+				{
+					class: ['banner', 'low-density', 'max', 'narrow'],
+					href: 'http://image.com/banner-narrow-low-density-max',
+					rel: ['alternate'],
+					type: 'image/jpeg'
+				}
+			]
+		},
+		enrollmentEntity,
+		imageEntity,
+		imageLowdEntity;
 
 	before(function() {
 		var parser = document.createElement('d2l-siren-parser');
 		enrollmentEntity = parser.parse(enrollment);
+		imageEntity = parser.parse(image);
+		imageLowdEntity = parser.parse(imageLowd);
 	});
 
 	beforeEach(function() {
@@ -68,6 +126,32 @@ describe('d2l-utility-behavior', function() {
 			var id = component.getEntityIdentifier(enrollmentEntity);
 
 			expect(id).to.equal(enrollment.links[1].href);
+		});
+	});
+
+	describe('getDefaultImageLink', function() {
+		it('should return high-density max image as a default image', function() {
+			var link = component.getDefaultImageLink(imageEntity, 'tile');
+			expect(link).to.equal(image.links[1].href);
+		});
+		it('should return low-density max image as a backup default image', function() {
+			var link = component.getDefaultImageLink(imageLowdEntity, 'tile');
+			expect(link).to.equal(imageLowd.links[0].href);
+		});
+		it('should get the appropiate image links from the class', function() {
+			var link = component.getDefaultImageLink(imageEntity, 'narrow');
+			expect(link).to.equal(image.links[3].href);
+		});
+	});
+
+	describe.only('getImageSrcset', function() {
+		it('should return a tile srcset based on the links available', function() {
+			var link = component.getImageSrcset(imageEntity, 'tile');
+			expect(link).to.equal('http://image.com/tile-low-density-max 540w, http://image.com/tile-high-density-max 1080w');
+		});
+		it('should return a banner srcset on the links available', function() {
+			var link = component.getImageSrcset(imageEntity, 'narrow');
+			expect(link).to.equal('http://image.com/banner-narrow-low-density-max 767w, http://image.com/banner-narrow-high-density-max 1534w');
 		});
 	});
 });


### PR DESCRIPTION
TODO:
- [x] Fix tests
- [x] Write tests
- [x] Picturefill

Use `srcset` to set the best image based on the image width, approximate width of the image container and the density of the screen. Each browser incorporates `srcset` a little different by how they determine the best image to display - chrome seem so optimize it better for network calls (with cache and lower quality images), but from my testing images will never be distorted (lower resolution than the container).

`srcset` is kind of tricky in how it's implemented with `sizes` being in units of `vw` - I did my best to approximate this based on the media query breakpoints and number of columns in the all courses overlay. The approximations are more accurate on mobile, where I feel the image resolution is a greater concern (mobile data impact), where as on desktop it becomes a bit more approximated (over approximated rather than under).

`srcset` isn't support by IE, in which case it will use the default image instead (note the default image could be reconfigured to default to low-max rather than high-max if that would make sense). Here is the support of it as a whole
![image](https://cloud.githubusercontent.com/assets/8656538/19705776/5bab887a-9adc-11e6-8a5b-b0f35d6955c3.png)
