### PR TITLE
Remove picturefill

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,4 +7,3 @@ globals:
   Polymer: false
   WCT: false
   D2L: false
-  picturefill: false

--- a/bower.json
+++ b/bower.json
@@ -50,8 +50,7 @@
     "iron-pages": "^1.0.8",
     "neon-animation": "PolymerElements/neon-animation#^1.2.2",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
-    "polymer": "Polymer/polymer#^1.4.0",
-    "picturefill": "https://github.com/scottjehl/picturefill.git#^3.0.0"
+    "polymer": "Polymer/polymer#^1.4.0"
   },
   "devDependencies": {
     "web-component-tester": "^4.2.2"

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -11,7 +11,6 @@
 <link rel="import" href="d2l-course-tile-styles.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-utility-behavior.html">
-<script src="bower_components/picturefill/src/picturefill.js" async></script>
 
 <!--
 `<d2l-course-tile>` is a clickable, interactable tile that represents a course
@@ -274,8 +273,6 @@ in that organization - student, teacher, TA, etc.
 				this._hoverCourseTile = this._hoverCourseTile.bind(this);
 
 				Polymer.IronA11yAnnouncer.requestAvailability();
-
-				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
 			/*
 			* Handler that triggers the API call to change an enrollment's pin state when the user says DO IT
@@ -349,7 +346,6 @@ in that organization - student, teacher, TA, etc.
 						imagePreloader.setAttribute('src', newImageHref);
 						imagePreloader.setAttribute('srcset', newSrcset);
 						imagePreloader.setAttribute('sizes', this.sizes);
-						picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 						break;
 					case 'success':
 						this._displaySetImageResult(true, newImageHref, newSrcset);
@@ -381,7 +377,6 @@ in that organization - student, teacher, TA, etc.
 							this.toggleClass('hidden', false, courseImage);
 							Polymer.dom(courseImage).setAttribute('src', newImageHref);
 							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
-							picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);
@@ -500,7 +495,6 @@ in that organization - student, teacher, TA, etc.
 				this.toggleClass('hidden', href === '', courseImage);
 				Polymer.dom(courseImage).setAttribute('src', href);
 				Polymer.dom(courseImage).setAttribute('srcset', srcset);
-				picturefill({ reevaluate: true, elements: Polymer.dom(this.root).querySelectorAll('img')});
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -6,7 +6,6 @@
 <link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-image-selector-tile-styles.html">
-<script src="../bower_components/picturefill/src/picturefill.js" async></script>
 
 <dom-module id="d2l-image-selector-tile">
 	<template>
@@ -112,7 +111,6 @@
 				var courseImage = Polymer.dom(this.root).querySelector('img');
 				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
 				Polymer.dom(courseImage).setAttribute('sizes', "(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw");
-				picturefill({ reevaluate: true, elements: [ courseImage ] });
 			}
 		});
 	</script>


### PR DESCRIPTION
This was causing some BSI build errors, and the performance benefit only really applies to IE11 - and only on small screens, at that. We can revisit this in the future if we so decide (although unlikely there's much point).