### PR TITLE
max-height should be 2x line-height

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -120,7 +120,7 @@
 		}
 		.course-text {
 			width: 100%;
-			max-height: 75px;
+			max-height: 3rem;
 			overflow: hidden;
 			position: relative;
 			margin-top: 0.4rem;


### PR DESCRIPTION
Was set to 2x line-height + 15px, causing part of a third line of text to show if the course name was long enough. [See here in typography](https://github.com/BrightspaceUI/typography/blob/master/d2l-typography.html#L108). This has been here forever, guess we just don't generally have course names that are that long!

Still doesn't address the no-ellipses-without-webkit from #86, but since we can have both single- or multi-line text in the course titles, all the existing solutions to that that I've found wouldn't work for us.

Before:
![image](https://cloud.githubusercontent.com/assets/6231623/20023115/320c6680-a2b4-11e6-9e48-85cf5aed16e9.png)

After:
![image](https://cloud.githubusercontent.com/assets/6231623/20023128/4e495402-a2b4-11e6-8be7-4bc229ccceb4.png)
