### PR TITLE
Don't use filters with Edge. Fixes #124.

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -118,6 +118,13 @@
 			filter: contrast(1.15);
 			transform: scale(1.1);
 		}
+		@supports (-ms-ime-align:auto) {
+			.course-image-container.hover,
+			.course-image-container.hover > .course-image img {
+				/* See https://github.com/Brightspace/d2l-my-courses-ui/issues/124 */
+				filter: none;
+			}
+		}
 		.course-text {
 			width: 100%;
 			max-height: 75px;


### PR DESCRIPTION
Edge supports filters, but they act funny (flickering when hovering over the course tiles). To prevent this, just `filter:none;` when we're in Edge - means Edge users don't get the colourization effect, but that's better than the flickering by far (and Edge users don't get the colourization anyway right now).