### PR TITLE
US78151 - Don't fetch filter items for a small number of enrollments

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -625,6 +625,12 @@
 				this._onMoreResponse(response, '_semesterOrganizations', '_moreSemestersUrl', '_hasMoreSemesters');
 			},
 			_onOrganizationsResponse: function(response) {
+				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length <= 20) {
+					// Small optimization - hide filter menu and don't fetch contents if user doesn't have a lot of enrollments
+					this.toggleClass('hidden', true, this.$.filterAndSort);
+					return;
+				}
+
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var responseEntity = parser.parse(response.detail.xhr.response);


### PR DESCRIPTION
The call to fetch filters is expensive, and is largely pointless if a user only has a handful of enrollments. If a user only has a small number of enrollments, there's no need to do the (expensive) calls to fetch filters - if absolutely required, the search functionality should be enough.

To do:

- [x] Check with Bob to make sure 20 is the right magic number