### PR TITLE
Fix some flickering in ie

### DIFF
--- a/image-selector/d2l-image-selector-tile-styles.html
+++ b/image-selector/d2l-image-selector-tile-styles.html
@@ -46,6 +46,7 @@
 				left: 0;
 				transition: transform 0.35s, saturate 0.35s;
 				transform: scale(1.0) translateZ(0);
+				overflow: hidden;
 			}
 
 			.no-image .d2l-image-tile-content,


### PR DESCRIPTION
Looks like ie bugs out a bit with animation unless the `overflow: hidden` is directly above the element (or something else, but putting this here fixes the problem)