### PR TITLE
US79418 - Break course images out into their own component

### DIFF
--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -43,7 +43,7 @@
 					The type of image aspect-ratio you want,
 					currently 'tile' and 'narrow' are the only supported options
 				*/
-				sizeType: {
+				type: {
 					type: String,
 					value: 'tile'
 				},
@@ -79,7 +79,7 @@
 			_updateImageSource: function() {
 				this._imageClass = 'hidden';
 
-				this._srcset = this.getImageSrcset(this.image, this.sizeType);
+				this._srcset = this.getImageSrcset(this.image, this.type);
 				this._tileSizes = this._generateSizes(this.sizes);
 			},
 			_defaultSizes: {

--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -1,0 +1,120 @@
+<link rel="import" href="../../polymer/polymer.html">
+
+<dom-module id="d2l-course-image">
+	<template>
+		<style>
+			.hidden {
+				opacity: 0;
+			}
+
+			.shown {
+				animation-name: shown;
+				animation-duration: 0.5s;
+				animation-fill-mode: forwards;
+			}
+
+			@keyframes shown {
+				0% { opacity: 0 }
+				100% { opacity: 1; }
+			}
+
+			img {
+				height: 100%;
+				min-width: 100%;
+			}
+		</style>
+
+		<img
+			src="[[getDefaultImageLink(image, 'narrow')]]"
+			srcset$=[[_srcset]]
+			sizes$=[[_tileSizes]]
+			on-load="_showImage"
+			class$="[[_imageClass]]"
+		></img>
+
+	</template>
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-course-image',
+			properties: {
+				/*
+					The type of image aspect-ratio you want,
+					currently 'tile' and 'narrow' are the only supported options
+				*/
+				sizeType: {
+					type: String,
+					value: 'tile'
+				},
+				/*
+					The vw that the image will take up on the screen for various breakpoints,
+					Used for the srcset 'sizes' parameter, falls back to defaults if none provided
+					Example:
+					{
+						mobile: { maxwidth: 767, size: 100 },
+						tablet: { maxwidth: 991, size: 50 },
+						desktop: { size: 33 }
+					}
+					Can also take in a string which will be provided directly to the srcset
+				*/
+				sizes: Object,
+				/*
+					The image that you want to display, must be in the same format as the course-catalog images
+				*/
+				image: {
+					type: Object,
+					observer: '_updateImageSource'
+				},
+				_imageClass: String,
+				_srcset: String,
+				_tileSizes: String
+			},
+			behaviors: [
+				window.D2L.MyCourses.UtilityBehavior
+			],
+			ready: function() {
+				this._updateImageSource();
+			},
+			_updateImageSource: function() {
+				this._imageClass = 'hidden';
+
+				this._srcset = this.getImageSrcset(this.image, this.sizeType);
+				this._tileSizes = this._generateSizes(this.sizes);
+			},
+			_defaultSizes: {
+				mobile: { maxwidth: 767, size: 100 },
+				tablet: { maxwidth: 991, size: 50 },
+				desktop: { size: 33 }
+			},
+			_generateSizes: function(sizeObj) {
+				sizeObj = sizeObj || this._defaultSizes;
+
+				if (typeof sizeObj === 'object') {
+					var newSizeObj = {};
+					['mobile', 'tablet', 'desktop'].forEach(function(cur) {
+						newSizeObj[cur] = {
+							maxwidth: sizeObj[cur] && sizeObj[cur].maxwidth || this._defaultSizes[cur].maxwidth,
+							size: sizeObj[cur] && sizeObj[cur].size || this._defaultSizes[cur].maxwidth
+						};
+					}.bind(this));
+
+					var mobileString = '(max-width: ' + newSizeObj.mobile.maxwidth + 'px) ' + newSizeObj.mobile.size + 'vw';
+					var tabletString = ', (max-width: ' + newSizeObj.tablet.maxwidth + 'px) and (min-width: ' +
+						(newSizeObj.mobile.maxwidth + 1) + 'px) ' + newSizeObj.tablet.size + 'vw';
+					var desktopString = ', ' + newSizeObj.desktop.size + 'vw';
+
+					return mobileString + tabletString + desktopString;
+				} else {
+					return sizeObj;
+				}
+			},
+			_showImage: function() {
+				this._imageClass = 'shown';
+			},
+			getTileSizes: function() {
+				return this._tileSizes;
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -465,7 +465,7 @@
 					type: String,
 					value: 'pinDate'
 				},
-				_tileSizes: String,
+				_tileSizes: Object,
 				_parentOrganizations: {
 					type: Array,
 					value: function() {

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -80,9 +80,9 @@
 				},
 				/*
 				* Size the tile should render with respect to vw
-				* @type {String}
+				* @type {Object}
 				*/
-				tileSizes: String
+				tileSizes: Object
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -99,7 +99,7 @@
 			overflow: hidden;
 			z-index: 0;
 		}
-		.course-image img {
+		.course-image d2l-course-image {
 			width: 100%;
 			height: 100%;
 			object-fit: cover;
@@ -111,7 +111,7 @@
 			margin: auto;
 			transition: filter 0.25s, -webkit-filter 0.25s, transform 0.5s ease-in-out;
 		}
-		.course-image-container.hover > .course-image img {
+		.course-image-container.hover > .course-image d2l-course-image {
 			/* Ensure only one filter per layer to avoid aliasing bug in Webkit during transforms */
 			-webkit-filter: contrast(1.15);
 			filter: contrast(1.15);
@@ -119,7 +119,7 @@
 		}
 		@supports (-ms-ime-align:auto) {
 			.course-image-container.hover,
-			.course-image-container.hover > .course-image img {
+			.course-image-container.hover > .course-image d2l-course-image {
 				/* See https://github.com/Brightspace/d2l-my-courses-ui/issues/124 */
 				filter: none;
 			}

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -58,7 +58,7 @@ in that organization - student, teacher, TA, etc.
 								<d2l-icon class$="[[_iconDetails.className]]" icon="[[_iconDetails.iconName]]"></d2l-icon>
 							</div>
 						</div>
-						<d2l-course-image aria-hidden="true" image="[[_image]]" sizes="[[tileSizes]]" size-type="tile"></d2l-course-image>
+						<d2l-course-image aria-hidden="true" image="[[_image]]" sizes="[[tileSizes]]" type="tile"></d2l-course-image>
 					</div>
 				</div>
 				<div class="course-text d2l-heading-4">{{_organization.properties.name}}</div>

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -58,7 +58,7 @@ in that organization - student, teacher, TA, etc.
 								<d2l-icon class$="[[_iconDetails.className]]" icon="[[_iconDetails.iconName]]"></d2l-icon>
 							</div>
 						</div>
-						<d2l-course-image image="[[_image]]" sizes="[[tileSizes]]" size-type="tile"></d2l-course-image>
+						<d2l-course-image aria-hidden="true" image="[[_image]]" sizes="[[tileSizes]]" size-type="tile"></d2l-course-image>
 					</div>
 				</div>
 				<div class="course-text d2l-heading-4">{{_organization.properties.name}}</div>
@@ -485,8 +485,6 @@ in that organization - student, teacher, TA, etc.
 				return organization && organization.getLinkByRel(rel);
 			},
 			_setCourseImageSrc: function() {
-				var href = '', srcset = '';
-
 				this._image = this._organization.getSubEntityByClass('course-image');
 			},
 			_onFocus: function() {

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -488,16 +488,6 @@ in that organization - student, teacher, TA, etc.
 				var href = '', srcset = '';
 
 				this._image = this._organization.getSubEntityByClass('course-image');
-				/*
-				if (courseImageEntity) {
-					href = this.getDefaultImageLink(courseImageEntity) || '';
-					srcset = this.getImageSrcset(courseImageEntity, 'tile') || '';
-				}
-				var courseImage = this.$$('.course-image img');
-				this.toggleClass('hidden', href === '', courseImage);
-				Polymer.dom(courseImage).setAttribute('src', href);
-				Polymer.dom(courseImage).setAttribute('srcset', srcset);
-				*/
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -11,6 +11,7 @@
 <link rel="import" href="d2l-course-tile-styles.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-utility-behavior.html">
+<link rel="import" href="components/d2l-course-image.html">
 
 <!--
 `<d2l-course-tile>` is a clickable, interactable tile that represents a course
@@ -57,7 +58,7 @@ in that organization - student, teacher, TA, etc.
 								<d2l-icon class$="[[_iconDetails.className]]" icon="[[_iconDetails.iconName]]"></d2l-icon>
 							</div>
 						</div>
-						<img aria-hidden="true" sizes="[[tileSizes]]"/>
+						<d2l-course-image image="[[_image]]" sizes="[[tileSizes]]" size-type="tile"></d2l-course-image>
 					</div>
 				</div>
 				<div class="course-text d2l-heading-4">{{_organization.properties.name}}</div>
@@ -165,9 +166,9 @@ in that organization - student, teacher, TA, etc.
 				},
 				/*
 				* Size the tile should render with respect to vw
-				* @type {String}
+				* @type {Object}
 				*/
-				tileSizes: String,
+				tileSizes: Object,
 				/*
 				* Specifies whether the (mobile) touch menu is enabled on the course tile
 				* @type {Boolean}
@@ -222,6 +223,7 @@ in that organization - student, teacher, TA, etc.
 				*/
 				_courseSettingsLabel: String,
 				_canChangeCourseImage: Boolean,
+				_image: Object,
 				/*
 				* The icon we want to show when you select an image
 				* @type {Object}
@@ -345,17 +347,17 @@ in that organization - student, teacher, TA, etc.
 						var imagePreloader = document.createElement('img');
 						imagePreloader.setAttribute('src', newImageHref);
 						imagePreloader.setAttribute('srcset', newSrcset);
-						imagePreloader.setAttribute('sizes', this.sizes);
+						imagePreloader.setAttribute('sizes', this.$$('d2l-course-image').getTileSizes());
 						break;
 					case 'success':
-						this._displaySetImageResult(true, newImageHref, newSrcset);
+						this._displaySetImageResult(true, details.image);
 						break;
 					case 'failure':
 						this._displaySetImageResult(false);
 						break;
 				}
 			},
-			_displaySetImageResult: function(success, newImageHref, newSrcset) {
+			_displaySetImageResult: function(success, newImage) {
 				var tileContainer = this.$$('.tile-container');
 				var courseImage = this.$$('.course-image img');
 
@@ -375,8 +377,7 @@ in that organization - student, teacher, TA, etc.
 					setTimeout(function() {
 						if (success) {
 							this.toggleClass('hidden', false, courseImage);
-							Polymer.dom(courseImage).setAttribute('src', newImageHref);
-							Polymer.dom(courseImage).setAttribute('srcset', newSrcset);
+							this._image = newImage;
 						}
 						this.toggleClass(successClass, false, tileContainer);
 						this.toggleClass(failureClass, false, tileContainer);
@@ -486,7 +487,8 @@ in that organization - student, teacher, TA, etc.
 			_setCourseImageSrc: function() {
 				var href = '', srcset = '';
 
-				var courseImageEntity = this._organization.getSubEntityByClass('course-image');
+				this._image = this._organization.getSubEntityByClass('course-image');
+				/*
 				if (courseImageEntity) {
 					href = this.getDefaultImageLink(courseImageEntity) || '';
 					srcset = this.getImageSrcset(courseImageEntity, 'tile') || '';
@@ -495,6 +497,7 @@ in that organization - student, teacher, TA, etc.
 				this.toggleClass('hidden', href === '', courseImage);
 				Polymer.dom(courseImage).setAttribute('src', href);
 				Polymer.dom(courseImage).setAttribute('srcset', srcset);
+				*/
 			},
 			_onFocus: function() {
 				/* timeout needed to work around lack of support for relatedTarget */

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -216,9 +216,9 @@
 				_departmentsUrl: String,
 				/*
 				* Size the tile should render with respect to vw
-				* @type {String}
+				* @type {Object}
 				*/
-				_tileSizes: String
+				_tileSizes: Object
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -320,9 +320,10 @@
 					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
 					this._hasEnrollments = this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0;
 
-					this._tileSizes = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length) === 2 ?
-						'(max-width: 767px) 50vw, (max-width: 1243px) and (min-width: 768px) 33vw, 20vw'
-						: '(max-width: 767px) 100vw, (max-width: 1243px) and (min-width: 768px) 67vw, 25vw';
+					var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
+					this._tileSizes = (colNum === 2) ?
+						{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
+						{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
 					if (this._hasEnrollments) {
 						this._alertMessage = this.localize('noPinnedCoursesMessage');

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -32,7 +32,7 @@ The overlay supports using different animations and transitions for desktop and 
 			</div>
 			<div class="scrollable">
 				<div class="max-width">
-					<content id="content"></content>
+					<content></content>
 				</div>
 			</div>
 		</span>

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -32,7 +32,7 @@ The overlay supports using different animations and transitions for desktop and 
 			</div>
 			<div class="scrollable">
 				<div class="max-width">
-					<content></content>
+					<content id="content"></content>
 				</div>
 			</div>
 		</span>

--- a/image-selector/d2l-image-selector-tile-styles.html
+++ b/image-selector/d2l-image-selector-tile-styles.html
@@ -55,7 +55,7 @@
 				display: none;
 			}
 
-			.d2l-image-tile-content img {
+			.d2l-image-tile-content d2l-course-image {
 				height: 100%;
 				min-width: 100%;
 				background-color: lightgray;
@@ -128,16 +128,6 @@
 				margin-top: 0;
 				cursor: pointer;
 			}
-
-			.hidden {
-				opacity: 0;
-			}
-
-			.shown {
-				animation: 0.5s ease forwards shown;
-			}
-
-			@keyframes shown { 0% { opacity: 0 } 100% { opacity: 1; } }
 		</style>
 	</template>
 </dom-module>

--- a/image-selector/d2l-image-selector-tile-styles.html
+++ b/image-selector/d2l-image-selector-tile-styles.html
@@ -46,6 +46,7 @@
 				left: 0;
 				transition: transform 0.35s, saturate 0.35s;
 				transform: scale(1.0) translateZ(0);
+				overflow: hidden;
 			}
 
 			.no-image .d2l-image-tile-content,

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="../d2l-course-tile-grid-styles.html">
 <link rel="import" href="../d2l-utility-behavior.html">
+<link rel="import" href="../components/d2l-course-image.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="d2l-image-selector-tile-styles.html">
 
@@ -27,11 +28,7 @@
 				</button>
 			</div>
 			<div class="d2l-image-tile-content">
-				<img
-					src="[[getDefaultImageLink(image, 'narrow')]]"
-					on-load="_showImage"
-					class$="[[_imageClass]]"
-				></img>
+				<d2l-course-image image="[[image]]" sizes="[[_imageSizes]]" size-type="narrow"></d2l-course-image>
 			</div>
 
 			<d2l-ajax
@@ -52,9 +49,10 @@
 		Polymer({
 			is: 'd2l-image-selector-tile',
 			properties: {
-				image: {
+				image: Object,
+				_imageSizes: {
 					type: Object,
-					observer: '_updateImageSource'
+					value: { mobile: { size: 100 }, tablet: { size: 50 }, desktop: { size: 33 } }
 				},
 				organization: Object,
 				_setImageUrl: String,
@@ -64,9 +62,6 @@
 				window.D2L.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.UtilityBehavior
 			],
-			ready: function() {
-				this._updateImageSource();
-			},
 			_getTileClass: function(image) {
 				return image ? 'd2l-image-tile' : 'd2l-image-tile no-image';
 			},
@@ -112,15 +107,6 @@
 				this._fireCourseImageMessage('set');
 				this.fire('close-simple-overlay');
 			},
-			_updateImageSource: function() {
-				var courseImage = Polymer.dom(this.root).querySelector('img');
-				this._imageClass = 'hidden';
-				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
-				Polymer.dom(courseImage).setAttribute('sizes', "(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw");
-			},
-			_showImage: function() {
-				this._imageClass = 'shown';
-			}
 		});
 	</script>
 </dom-module>

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -28,7 +28,7 @@
 				</button>
 			</div>
 			<div class="d2l-image-tile-content">
-				<d2l-course-image image="[[image]]" sizes="[[_imageSizes]]" size-type="narrow"></d2l-course-image>
+				<d2l-course-image image="[[image]]" sizes="[[_imageSizes]]" type="narrow"></d2l-course-image>
 			</div>
 
 			<d2l-ajax

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -130,7 +130,7 @@ describe('<d2l-course-tile>', function() {
 		});
 
 		it('should hide image from screen readers', function() {
-			var courseImage = widget.$$('.course-image img');
+			var courseImage = widget.$$('.course-image d2l-course-image');
 			expect(courseImage.getAttribute('aria-hidden')).to.equal('true');
 		});
 
@@ -307,7 +307,7 @@ describe('<d2l-course-tile>', function() {
 				details.status = 'success';
 				widget._displaySetImageResult = sinon.stub();
 				widget.setCourseImage(details);
-				expect(widget._displaySetImageResult.calledWith(true, href)).to.equal(true);
+				expect(widget._displaySetImageResult.calledWith(true, details.image)).to.equal(true);
 			});
 		});
 
@@ -322,7 +322,7 @@ describe('<d2l-course-tile>', function() {
 	});
 
 	describe('_displaySetImageResult', function() {
-		var imageHref = 'http://testimage.ninja/',
+		var newImage = { getLinksByClass: sinon.stub().returns([]) },
 			clock,
 			success;
 
@@ -338,7 +338,7 @@ describe('<d2l-course-tile>', function() {
 			beforeEach(function() {
 				success = true;
 				expect(widget.$$('.change-image-success')).to.equal(null);
-				widget._displaySetImageResult(success, imageHref);
+				widget._displaySetImageResult(success, newImage);
 				clock.tick(1001);
 			});
 
@@ -363,7 +363,7 @@ describe('<d2l-course-tile>', function() {
 				});
 
 				it('sets the new image href', function() {
-					expect(widget.$$('.course-image img').src).to.equal(imageHref);
+					expect(widget.$$('.course-image d2l-course-image').image).to.equal(newImage);
 				});
 
 				it('removes the "change-image-success" class', function() {
@@ -375,7 +375,7 @@ describe('<d2l-course-tile>', function() {
 		describe('success: false', function() {
 			beforeEach(function() {
 				success = false;
-				widget._displaySetImageResult(success, imageHref);
+				widget._displaySetImageResult(success, newImage);
 				clock.tick(1001);
 			});
 
@@ -400,7 +400,7 @@ describe('<d2l-course-tile>', function() {
 				});
 
 				it('doesnt set a new image href', function() {
-					expect(widget.$$('.course-image img').src).to.not.equal(imageHref);
+					expect(widget.$$('.course-image d2l-course-image').image).to.not.equal(newImage);
 				});
 
 				it('removes the "change-image-failure" class', function() {


### PR DESCRIPTION
- [x] Fix tests

This will allow our nice srcset, fade-in, and different-aspect-ratio parsing behaviour to be used by others

Bob wanted the fade-in for course tile images as well, so I figured that it was a good time to factor out the common behaviour

Success Criteria: Almost exactly the same, course tiles will now fade in like the catalog images do (srcset and aspect ratios should be identical to before)

Later we should probably make a component which you pass in the organizationId/size and it gets the image by itself