### PR TITLE
Trying to fix some things

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 node_js:
-- 4
+- 5
 sudo: false
 addons:
-  firefox: 46.0
+  firefox: latest
+  apt:
+    packages:
+      - oracle-java8-installer
+      - oracle-java8-set-default
 before_script:
 - npm run test:lint:js
 script:

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "polylint": "^2.10.1",
     "polymer-cli": "^0.12.0",
     "rimraf": "^2.5.2",
-    "wct-local": "2.0.12",
     "web-component-tester": "^4.2.2"
   }
 }


### PR DESCRIPTION
This removes the override for wct-local (fixes #171), and the override for firefox (fixes #99). To do the latter, had to specify that Java 8 should be used, which increases build times a bit, but I think worth it to get things back to most-recent versions.

This works for me locally, and Travis seems to like it, but it would be super excellent if somebody could check this out and verify that everything does indeed work for them.

(Also updated to node 5, while I was here - shouldn't have any real effect, since it's only used for build/test anyway.)