### PR TITLE
Fix blank images issue

### DIFF
--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -77,16 +77,16 @@
 				this._updateImageSource();
 			},
 			_updateImageSource: function(newValue, oldValue) {
-				this._imageClass = 'hidden';
 
 				this._srcset = this.getImageSrcset(this.image, this.type);
 				this._tileSizes = this._generateSizes(this.sizes);
 
-				if (this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type) &&
-					this._imageClass.indexOf('shown') > -1
-				) {
+				var same = this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type);
+				var shown = (this._imageClass || '').indexOf('shown') > -1;
+				if (same && shown) {
 					setTimeout(this._showImage.bind(this), 50);
 				}
+				this._imageClass = 'hidden';
 			},
 			_defaultSizes: {
 				mobile: { maxwidth: 767, size: 100 },

--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -25,7 +25,7 @@
 		</style>
 
 		<img
-			src="[[getDefaultImageLink(image, 'narrow')]]"
+			src="[[getDefaultImageLink(image, type)]]"
 			srcset$=[[_srcset]]
 			sizes$=[[_tileSizes]]
 			on-load="_showImage"
@@ -76,11 +76,15 @@
 			ready: function() {
 				this._updateImageSource();
 			},
-			_updateImageSource: function() {
+			_updateImageSource: function(newValue, oldValue) {
 				this._imageClass = 'hidden';
 
 				this._srcset = this.getImageSrcset(this.image, this.type);
 				this._tileSizes = this._generateSizes(this.sizes);
+
+				if (this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type)) {
+					setTimeout(this._showImage.bind(this), 50);
+				}
 			},
 			_defaultSizes: {
 				mobile: { maxwidth: 767, size: 100 },

--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -82,7 +82,9 @@
 				this._srcset = this.getImageSrcset(this.image, this.type);
 				this._tileSizes = this._generateSizes(this.sizes);
 
-				if (this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type)) {
+				if (this.getDefaultImageLink(newValue, this.type) === this.getDefaultImageLink(oldValue, this.type) &&
+					this._imageClass.indexOf('shown') > -1
+				) {
 					setTimeout(this._showImage.bind(this), 50);
 				}
 			},


### PR DESCRIPTION
fix issue where image would permanently hide if you swapped out the image object but the new one had the same data

To trigger the old error:

- Checkout master
- Search for "paint"
- Search for "paints"
- Notice how everything is nice and grey