### PR TITLE
Determine if can change image by existence of set-catalog-image action

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -481,8 +481,7 @@ in that organization - student, teacher, TA, etc.
 				this._onUnpinHover({detail: {hoverState: false}});
 			},
 			_getCanChangeCourseImage: function(organization) {
-				var rel = /edit-image-page/;
-				return organization && organization.getLinkByRel(rel);
+				return organization && organization.getActionByName('set-catalog-image');
 			},
 			_setCourseImageSrc: function() {
 				this._image = this._organization.getSubEntityByClass('course-image');

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -293,6 +293,24 @@ describe('<d2l-course-tile>', function() {
 			widget.getDefaultImageLink = sinon.stub().returns(href);
 		});
 
+		it('should have a change-image-button if the set-catalog-image action exists on the organization', function() {
+			var orgWithSetCatalogImageAction = JSON.parse(JSON.stringify(organization));
+			orgWithSetCatalogImageAction.actions = [{
+				name: 'set-catalog-image',
+				method: 'POST',
+				href: ''
+			}];
+			var parser = document.createElement('d2l-siren-parser');
+
+			var result = widget._getCanChangeCourseImage(parser.parse(orgWithSetCatalogImageAction));
+			expect(!!result).to.equal(true);
+		});
+
+		it('should not have a change-image-button if the set-catalog-image action does not exist on the organization', function() {
+			var result = widget._getCanChangeCourseImage(organizationEntity);
+			expect(!!result).to.equal(false);
+		});
+
 		describe('status: set', function() {
 			it('toggles on the "change-image-loading" class on the tile-container', function() {
 				details.status = 'set';

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -303,12 +303,12 @@ describe('<d2l-course-tile>', function() {
 			var parser = document.createElement('d2l-siren-parser');
 
 			var result = widget._getCanChangeCourseImage(parser.parse(orgWithSetCatalogImageAction));
-			expect(!!result).to.equal(true);
+			expect(result).to.be.ok;
 		});
 
 		it('should not have a change-image-button if the set-catalog-image action does not exist on the organization', function() {
 			var result = widget._getCanChangeCourseImage(organizationEntity);
-			expect(!!result).to.equal(false);
+			expect(result).to.not.be.ok;
 		});
 
 		describe('status: set', function() {


### PR DESCRIPTION
The `edit-image-page` is actually the page where you can upload an image, but on the course tile we want to determine if the "Change Image" menu item is shown based on the existence of the `set-catalog-image` action, which is what is called when a user selects a new image from the catalog.

This fixes an issue whereby a user who has CHANGE_IMAGE permissions was unable to see the "Change Image" menu item unless they also had SEE_COURSE_INFO permission.