### PR TITLE
Remove overflow ellipsis from course titles (DE23270)

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -126,25 +126,11 @@
 		}
 		.course-text {
 			width: 100%;
-			max-height: 1.5em;
-			overflow: hidden;
 			position: relative;
 			margin-top: 0.4rem;
 			/* overrides to d2l-heading-4 */
 			font-weight: 400;
 			/* end overrides */
-			text-overflow: ellipsis;
-			white-space: nowrap;
-
-		}
-		@supports (-webkit-line-clamp: 2) {
-			.course-text {
-				max-height: 3em;
-				white-space: normal;
-				display: -webkit-box;
-				-webkit-line-clamp: 2;
-				-webkit-box-orient: vertical;
-			}
 		}
 		.tile-container > a:focus,
 		.tile-container > a:hover {

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -126,17 +126,25 @@
 		}
 		.course-text {
 			width: 100%;
-			max-height: 3em;
+			max-height: 1.5em;
 			overflow: hidden;
 			position: relative;
 			margin-top: 0.4rem;
 			/* overrides to d2l-heading-4 */
 			font-weight: 400;
 			/* end overrides */
-			/* ellipses for long text */
-			display: -webkit-box;
-			-webkit-line-clamp: 2;
-			-webkit-box-orient: vertical;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+
+		}
+		@supports (-webkit-line-clamp: 2) {
+			.course-text {
+				max-height: 3em;
+				white-space: normal;
+				display: -webkit-box;
+				-webkit-line-clamp: 2;
+				-webkit-box-orient: vertical;
+			}
 		}
 		.tile-container > a:focus,
 		.tile-container > a:hover {


### PR DESCRIPTION
Course titles will display in full:
![image](https://cloud.githubusercontent.com/assets/8656538/20448900/44c03dc8-adb4-11e6-804a-0cdefeaa6e7d.png)

> After discussion with Bob/Steve we decided that the end of course titles were too important to cut off, so at the expensive of some beauty, we're deciding to no longer truncate course names. Removing the truncation should fix all clamp related issues.

Story here: [DE23270](https://rally1.rallydev.com/#/51191528503d/detail/defect/75681348620)

No clampin', no worries.

![image](https://cloud.githubusercontent.com/assets/8656538/20448840/f58e6996-adb3-11e6-95ad-bc87ebe81799.png)
