### PR TITLE
US78151 - Improve filter fetching

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -270,8 +270,8 @@
 				sort-field="[[_sortField]]">
 			</d2l-search-widget-custom>
 
-			<div id="filterAndSort">
-				<div id="filterSection">
+			<div id="filterAndSort" class="hidden">
+				<div id="filterSection" class="hidden">
 					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
 					<d2l-dropdown id="filterDropdown">
 						<button
@@ -521,8 +521,13 @@
 				// Load course tile and filter contents. Called from d2l-my-courses.
 				this.delayCourseTileLoad = false;
 
-				this.$.departmentSearchWidget.search();
-				this.$.semesterSearchWidget.search();
+				// Only make the call to load the filter menu contents if user has a
+				// substantial number of enrollments - otherwise, hide the filter menu
+				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
+					this.$.departmentSearchWidget.search();
+					this.$.semesterSearchWidget.search();
+					this.toggleClass('hidden', false, this.$.filterAndSort);
+				}
 			},
 			setCourseImage: function(details) {
 				this._removeAlert('setCourseImageFailure');
@@ -595,9 +600,16 @@
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);
 			},
-			_updateMoreParameters: function(entity, moreUrlPath, hasMorePath) {
+			_onSearchResults: function(entity, moreUrlPath, hasMorePath) {
 				this.set(hasMorePath, entity.hasLinkByRel('next'));
 				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
+
+				// If user has >1 departments or >1 semesters, signal to d2l-all-courses to show filters
+				if (this._departments && this._departments.length > 1
+					|| this._semesters && this._semesters.length > 1
+				) {
+					this.toggleClass('hidden', false, this.$.filterSection);
+				}
 			},
 			_onFilterDropdownClose: function() {
 				// If the dropdown is closed by clicking elsewhere, we need to manually update _filterDropdownOpen
@@ -611,12 +623,12 @@
 				this._selectSemesterList();
 			},
 			_onDepartmentSearchResults: function(e) {
-				this._updateMoreParameters(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
 				this.set('_departments', e.detail.entities);
+				this._onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
 			},
 			_onSemesterSearchResults: function(e) {
-				this._updateMoreParameters(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
 				this.set('_semesters', e.detail.entities);
+				this._onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
 			},
 			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
@@ -626,7 +638,7 @@
 						this.push(organizationsPath, entity);
 					}.bind(this));
 
-					this._updateMoreParameters(responseEntity, moreUrlPath, hasMorePath);
+					this._onSearchResults(responseEntity, moreUrlPath, hasMorePath);
 				}
 			},
 			_onMoreDepartmentsResponse: function(response) {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -36,6 +36,11 @@
 				margin-right: 0.5rem;
 			}
 		</style>
+		<d2l-ajax
+			url="[[_url]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onResponse">
+		</d2l-ajax>
 		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
 	</template>
@@ -43,11 +48,30 @@
 		'use strict';
 		Polymer({
 			is: 'd2l-list-item-filter',
+			properties: {
+				entity: {
+					type: Object,
+					observer: '_onEntityChanged'
+				},
+				_url: String
+			},
 			behaviors: [
 				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
 			],
 			listeners: {
 				'd2l-menu-item-select': '_onSelect'
+			},
+			_onEntityChanged: function(entity) {
+				this.set('_url', entity.links[1].href);
+				this.$$('d2l-ajax').generateRequest();
+			},
+			_onResponse: function(response) {
+				if (response.detail.status === 200 ) {
+					var parser = document.createElement('d2l-siren-parser');
+					var entity = parser.parse(response.detail.xhr.response);
+
+					this.set('text', entity.properties.name);
+				}
 			},
 			_onSelect: function(e) {
 				this.set('selected', !this.selected);
@@ -209,12 +233,6 @@
 		</style>
 
 		<d2l-ajax
-			id="organizationsRequest"
-			url="[[_organizationsUrl]]"
-			on-iron-ajax-response="_onOrganizationsResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
 			id="moreDepartmentsRequest"
 			url="[[_moreDepartmentsUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
@@ -290,8 +308,7 @@
 									<template is="dom-repeat" items="[[_semesterOrganizations]]">
 										<d2l-list-item-filter
 											value="[[getEntityIdentifier(item)]]"
-											text="[[item.properties.name]]"
-											selected="[[item.properties.selected]]">
+											entity="[[item]]">
 										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
@@ -307,8 +324,7 @@
 									<template is="dom-repeat" items="[[_departmentOrganizations]]">
 										<d2l-list-item-filter
 											value="[[getEntityIdentifier(item)]]"
-											text="[[item.properties.name]]"
-											selected="[[item.properties.selected]]">
+											entity="[[item]]">
 										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
@@ -416,38 +432,8 @@
 					value: '/d2l/api/hm/organizations',
 					readOnly: true
 				},
-				_searchSemestersAction: {
-					type: Object,
-					value: {
-						'name':'search-course-collection',
-						'method':'GET',
-						'href': '/d2l/api/hm/organizations',
-						'fields':[
-							{'name':'search', 'type':'search', 'value':''},
-							{'name':'page', 'type':'number', 'value':'1'},
-							{'name':'pageSize', 'type':'number', 'value':'20'},
-							{'name':'embedDepth', 'type':'number', 'value':'1'},
-							// 5 is the default type ID for semesters
-							// organizationTypeIds is updated by organizationsRequest
-							{'name':'organizationTypeIds', 'type':'hidden', 'value':'5'}]
-					}
-				},
-				_searchDepartmentsAction: {
-					type: Object,
-					value: {
-						'name':'search-course-collection',
-						'method':'GET',
-						'href':'/d2l/api/hm/organizations',
-						'fields':[
-							{'name':'search', 'type':'search', 'value':''},
-							{'name':'page', 'type':'number', 'value':'1'},
-							{'name':'pageSize', 'type':'number', 'value':'20'},
-							{'name':'embedDepth', 'type':'number', 'value':'1'},
-							// 203 is the default type ID for departments
-							// organizationTypeIds is updated by organizationsRequest
-							{'name':'organizationTypeIds', 'type':'hidden', 'value':'203'}]
-					}
-				},
+				_searchSemestersAction: Object,
+				_searchDepartmentsAction: Object,
 				_semesterOrganizations: {
 					type: Array,
 					value: function() {
@@ -518,8 +504,12 @@
 				var itemCount = Math.max(this.pinnedEnrollments.length, this.unpinnedEnrollments.length);
 				return itemCount;
 			},
-			loadCourseTiles: function() {
+			load: function() {
+				// Load course tile and filter contents. Called from d2l-my-courses.
 				this.delayCourseTileLoad = false;
+
+				this.$.departmentSearchWidget.search();
+				this.$.semesterSearchWidget.search();
 			},
 			setCourseImage: function(details) {
 				this._removeAlert('setCourseImageFailure');
@@ -581,7 +571,14 @@
 				}
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
-				// Fetch semesters/departments for the filter lists
+				// Set up search URLs and search Actions for filter dropdown
+				if (entity) {
+					var parser = document.createElement('d2l-siren-parser');
+					var myEnrollmentsEntity = parser.parse(entity);
+
+					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
+					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
+				}
 			},
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);
@@ -628,52 +625,6 @@
 			},
 			_onMoreSemestersResponse: function(response) {
 				this._onMoreResponse(response, '_semesterOrganizations', '_moreSemestersUrl', '_hasMoreSemesters');
-			},
-			_onOrganizationsResponse: function(response) {
-				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length <= 20) {
-					// Small optimization - hide filter menu and don't fetch contents if user doesn't have a lot of enrollments
-					this.toggleClass('hidden', true, this.$.filterAndSort);
-					return;
-				}
-
-				if (response.detail.status === 200) {
-					var parser = document.createElement('d2l-siren-parser');
-					var responseEntity = parser.parse(response.detail.xhr.response);
-
-					var departmentId = responseEntity.getActionByName('add-department-filter').getFieldByName('organizationTypeIds').value;
-					var departmentAction = {
-						name: 'search-course-collection',
-						method: 'GET',
-						href: this._organizationsUrl,
-						fields: [
-							{ name: 'organizationTypeIds', type: 'hidden', value: departmentId },
-							{ name: 'search', type: 'search', value: '' },
-							{ name: 'page', type: 'number', value: '1' },
-							{ name: 'pageSize', type: 'number', value: '20' },
-							{ name: 'embedDepth', type: 'number', value: '1' }
-						]
-					};
-					this.set('_searchDepartmentsAction', departmentAction);
-
-					var semesterId = responseEntity.getActionByName('add-semester-filter').getFieldByName('organizationTypeIds').value;
-					var semesterAction = {
-						name: 'search-course-collection',
-						method: 'GET',
-						href: this._organizationsUrl,
-						fields: [
-							{ name: 'organizationTypeIds', type: 'hidden', value: semesterId },
-							{ name: 'search', type: 'search', value: '' },
-							{ name: 'page', type: 'number', value: '1' },
-							{ name: 'pageSize', type: 'number', value: '20' },
-							{ name: 'embedDepth', type: 'number', value: '1' }
-						]
-					};
-					this.set('_searchSemestersAction', semesterAction);
-
-					// This calls .clear() on both search widgets (which searches with an empty query),
-					// so this needs to run after we have both search Actions updated
-					this._selectSemesterList();
-				}
 			},
 			_onResize: function() {
 				this._updateTileSizes();

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -381,10 +381,9 @@
 					type: Boolean,
 					value: true
 				},
-				// URL for search widget; should have search-my-enrollments Action
-				searchUrl: {
-					type: String,
-					value: ''
+				myEnrollmentsEntity: {
+					type: Object,
+					observer: '_myEnrollmentsEntityChanged'
 				},
 				_departmentOrganizations: {
 					type: Array,
@@ -580,6 +579,9 @@
 				if (this.$$('#filterDropdownOpener:focus') === null && this.$$('#filterDropdownOpener:hover') === null) {
 					this.toggleClass('focus', false, this.$.filterText);
 				}
+			},
+			_myEnrollmentsEntityChanged: function(entity) {
+				// Fetch semesters/departments for the filter lists
 			},
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -53,6 +53,12 @@
 					type: Object,
 					observer: '_onEntityChanged'
 				},
+				selected: {
+					type: Boolean,
+					value: false,
+					observer: '__onSelectedChanged',
+					reflectToAttribute: true
+				},
 				_url: String
 			},
 			behaviors: [
@@ -78,6 +84,11 @@
 				this.set('selected', !this.selected);
 				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
 				this.__onSelect(e);
+			},
+			__onSelectedChanged: function(e) {
+				// The selected state is changed by _checkSelected below - need to update the icon when this happens
+				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
+				this._onSelectedChanged(e);
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -37,9 +37,10 @@
 			}
 		</style>
 		<d2l-ajax
-			url="[[_url]]"
+			auto
+			url="[[_organizationUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onResponse">
+			on-iron-ajax-response="_onOrganizationResponse">
 		</d2l-ajax>
 		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
@@ -51,6 +52,7 @@
 			properties: {
 				enrollmentEntity: {
 					type: Object,
+					value: function() { return {}; },
 					observer: '_onEnrollmentEntityChanged'
 				},
 				selected: {
@@ -59,7 +61,7 @@
 					observer: '__onSelectedChanged',
 					reflectToAttribute: true
 				},
-				_url: String
+				_organizationUrl: String
 			},
 			behaviors: [
 				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
@@ -68,13 +70,15 @@
 				'd2l-menu-item-select': '_onSelect'
 			},
 			_onEnrollmentEntityChanged: function(entity) {
-				this.set('_url', entity.getLinkByRel(/\/organization$/).href);
-				this.$$('d2l-ajax').generateRequest();
+				this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
 			},
-			_onResponse: function(response) {
+			_onOrganizationResponse: function(response) {
 				if (response.detail.status === 200 ) {
-					var parser = document.createElement('d2l-siren-parser');
-					var entity = parser.parse(response.detail.xhr.response);
+					if (!this._parser) {
+						this._parser = document.createElement('d2l-siren-parser');
+					}
+
+					var entity = this._parser.parse(response.detail.xhr.response);
 
 					this.set('text', entity.properties.name);
 					this.set('value', entity.getLinkByRel('self').href);
@@ -82,14 +86,14 @@
 			},
 			_onSelect: function(e) {
 				this.set('selected', !this.selected);
-				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
 				this.__onSelect(e);
 			},
 			__onSelectedChanged: function(e) {
-				// The selected state is changed by _checkSelected below - need to update the icon when this happens
+				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
 				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
 				this._onSelectedChanged(e);
-			}
+			},
+			_parser: null
 		});
 	</script>
 </dom-module>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -62,7 +62,7 @@
 				'd2l-menu-item-select': '_onSelect'
 			},
 			_onEntityChanged: function(entity) {
-				this.set('_url', entity.links[1].href);
+				this.set('_url', entity.getLinkByRel(/\/organization$/).href);
 				this.$$('d2l-ajax').generateRequest();
 			},
 			_onResponse: function(response) {
@@ -71,6 +71,7 @@
 					var entity = parser.parse(response.detail.xhr.response);
 
 					this.set('text', entity.properties.name);
+					this.set('value', entity.getLinkByRel('self').href);
 				}
 			},
 			_onSelect: function(e) {
@@ -271,7 +272,7 @@
 						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
 							<div class="dropdown-content-header">
 								<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
-								<template is="dom-if" if="[[_isFiltered]]">
+								<template is="dom-if" if="[[_showClearButton]]">
 									<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 								</template>
 							</div>
@@ -305,10 +306,10 @@
 									search-field-name="search"
 									cache-responses></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.semester')}}">
-									<template is="dom-repeat" items="[[_semesterOrganizations]]">
+									<template is="dom-repeat" items="[[_semesters]]">
 										<d2l-list-item-filter
-											value="[[getEntityIdentifier(item)]]"
-											entity="[[item]]">
+											entity="[[item]]"
+											selected="[[_checkSelected(item)]]">
 										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
@@ -321,10 +322,10 @@
 									search-field-name="search"
 									cache-responses></d2l-search-widget>
 								<d2l-menu label="{{localize('filtering.department')}}">
-									<template is="dom-repeat" items="[[_departmentOrganizations]]">
+									<template is="dom-repeat" items="[[_departments]]">
 										<d2l-list-item-filter
-											value="[[getEntityIdentifier(item)]]"
-											entity="[[item]]">
+											entity="[[item]]"
+											selected="[[_checkSelected(item)]]">
 										</d2l-list-item-filter>
 									</template>
 								</d2l-menu>
@@ -401,13 +402,13 @@
 					type: Object,
 					observer: '_myEnrollmentsEntityChanged'
 				},
-				_departmentOrganizations: {
+				_departments: {
 					type: Array,
 					value: function() {
 						return [];
 					}
 				},
-				_isFiltered: {
+				_showClearButton: {
 					type: Boolean,
 					value: false
 				},
@@ -427,14 +428,9 @@
 					type: String,
 					value: ''
 				},
-				_organizationsUrl: {
-					type: String,
-					value: '/d2l/api/hm/organizations',
-					readOnly: true
-				},
 				_searchSemestersAction: Object,
 				_searchDepartmentsAction: Object,
-				_semesterOrganizations: {
+				_semesters: {
 					type: Array,
 					value: function() {
 						return [];
@@ -489,6 +485,8 @@
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 
 				window.addEventListener('resize', this._onResize.bind(this));
+
+				this._parser = document.createElement('d2l-siren-parser');
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
@@ -524,23 +522,23 @@
 			_filterDropdownOpen: false,
 			_numSemesterFilters: 0,
 			_numDepartmentFilters: 0,
+			_parser: null,
 			_sortTextOptions: {
 				'courseCode': 'sorting.sortCourseCode',
 				'courseName': 'sorting.sortCourseName',
 				'pinDate': 'sorting.sortDatePinned',
 				'lastAccessed': 'sorting.sortLastAccessed'
 			},
-			_checkFilterEntities: function(entities) {
-				entities.forEach(function(entity) {
-					var id = this.getEntityIdentifier(entity);
-					entity.properties.selected = this._parentOrganizations.indexOf(id) > -1;
-				}.bind(this));
+			_checkSelected: function(entity) {
+				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
+				var id = entity.getLinkByRel(/\/organization$/).href;
+				return this._parentOrganizations.indexOf(id) > -1;
 			},
 			_clearFilters: function() {
 				Polymer.dom(this.$.filterDropdown).querySelectorAll('d2l-menu-item-checkbox').forEach(function(item) {
 					item.selected = false;
 				});
-				this._isFiltered = false;
+				this._showClearButton = false;
 				// Clear button is removed via dom-if, so need to manually set focus to next element
 				this.$.semesterListButton.focus();
 				this._parentOrganizations = [];
@@ -573,8 +571,7 @@
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown
 				if (entity) {
-					var parser = document.createElement('d2l-siren-parser');
-					var myEnrollmentsEntity = parser.parse(entity);
+					var myEnrollmentsEntity = this._parser.parse(entity);
 
 					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
 					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
@@ -584,8 +581,6 @@
 				this.toggleClass('focus', true, this.$.filterText);
 			},
 			_updateMoreParameters: function(entity, moreUrlPath, hasMorePath) {
-				this._checkFilterEntities(entity.entities);
-
 				this.set(hasMorePath, entity.hasLinkByRel('next'));
 				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
 			},
@@ -601,12 +596,12 @@
 				this._selectSemesterList();
 			},
 			_onDepartmentSearchResults: function(e) {
-				this.set('_departmentOrganizations', e.detail.entities);
 				this._updateMoreParameters(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
+				this.set('_departments', e.detail.entities);
 			},
 			_onSemesterSearchResults: function(e) {
-				this.set('_semesterOrganizations', e.detail.entities);
 				this._updateMoreParameters(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
+				this.set('_semesters', e.detail.entities);
 			},
 			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
@@ -621,10 +616,10 @@
 				}
 			},
 			_onMoreDepartmentsResponse: function(response) {
-				this._onMoreResponse(response, '_departmentOrganizations', '_moreDepartmentsUrl', '_hasMoreDepartments');
+				this._onMoreResponse(response, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
 			},
 			_onMoreSemestersResponse: function(response) {
-				this._onMoreResponse(response, '_semesterOrganizations', '_moreSemestersUrl', '_hasMoreSemesters');
+				this._onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
 			},
 			_onResize: function() {
 				this._updateTileSizes();
@@ -682,7 +677,7 @@
 					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'num', this._parentOrganizations.length);
 				}
 
-				this._isFiltered = this._parentOrganizations.length > 0;
+				this._showClearButton = this._parentOrganizations.length > 0;
 				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
 					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
 					: this.localize('filtering.semester');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -231,7 +231,7 @@
 		<div class="search-and-filter">
 			<d2l-search-widget-custom
 				hidden$="[[_hasEnrollments]]"
-				search-root-url="[[searchUrl]]"
+				my-enrollments-entity="[[myEnrollmentsEntity]]"
 				parent-organizations="[[_parentOrganizations]]"
 				sort-field="[[_sortField]]">
 			</d2l-search-widget-custom>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -49,9 +49,9 @@
 		Polymer({
 			is: 'd2l-list-item-filter',
 			properties: {
-				entity: {
+				enrollmentEntity: {
 					type: Object,
-					observer: '_onEntityChanged'
+					observer: '_onEnrollmentEntityChanged'
 				},
 				selected: {
 					type: Boolean,
@@ -67,7 +67,7 @@
 			listeners: {
 				'd2l-menu-item-select': '_onSelect'
 			},
-			_onEntityChanged: function(entity) {
+			_onEnrollmentEntityChanged: function(entity) {
 				this.set('_url', entity.getLinkByRel(/\/organization$/).href);
 				this.$$('d2l-ajax').generateRequest();
 			},
@@ -319,7 +319,7 @@
 								<d2l-menu label="{{localize('filtering.semester')}}">
 									<template is="dom-repeat" items="[[_semesters]]">
 										<d2l-list-item-filter
-											entity="[[item]]"
+											enrollment-entity="[[item]]"
 											selected="[[_checkSelected(item)]]">
 										</d2l-list-item-filter>
 									</template>
@@ -335,7 +335,7 @@
 								<d2l-menu label="{{localize('filtering.department')}}">
 									<template is="dom-repeat" items="[[_departments]]">
 										<d2l-list-item-filter
-											entity="[[item]]"
+											enrollment-entity="[[item]]"
 											selected="[[_checkSelected(item)]]">
 										</d2l-list-item-filter>
 									</template>
@@ -616,8 +616,7 @@
 			},
 			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
-					var parser = document.createElement('d2l-siren-parser');
-					var responseEntity = parser.parse(response.detail.xhr.response);
+					var responseEntity = this._parser.parse(response.detail.xhr.response);
 
 					responseEntity.entities.forEach(function(entity) {
 						this.push(organizationsPath, entity);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -320,8 +320,7 @@
 				e.preventDefault();
 				e.stopPropagation();
 				this.$$('#all-courses').open();
-				this.$$('d2l-all-courses').loadCourseTiles();
-				this.$$('d2l-all-courses').$.organizationsRequest.generateRequest();
+				this.$$('d2l-all-courses').load();
 
 				setTimeout(function() {
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -126,7 +126,7 @@
 			<d2l-all-courses
 				pinned-enrollments="{{pinnedEnrollments}}"
 				unpinned-enrollments="{{unpinnedEnrollments}}"
-				search-url="[[_enrollmentsSearchUrl]]"
+				my-enrollments-entity="[[_lastEnrollmentsSearchResponse]]"
 				locale="[[locale]]">
 			</d2l-all-courses>
 			<d2l-loading-spinner

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -109,13 +109,6 @@
 		</style>
 
 		<d2l-ajax
-			id="searchRootRequest"
-			url="[[searchRootUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onSearchRootResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
 			id="searchRequest"
 			url="[[_searchUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
@@ -196,10 +189,10 @@
 			is: 'd2l-search-widget-custom',
 
 			properties: {
-				// Root search URL, which should have the search Action in the response
-				searchRootUrl: {
+				// Entity returned by the "my-enrollments" link on the /enrollments root
+				myEnrollmentsEntity: {
 					type: String,
-					observer: '_onSearchRootUrlChanged'
+					observer: '_myEnrollmentsEntityChanged'
 				},
 
 				// Value to send for the `sortField` parameter in the search query
@@ -431,18 +424,18 @@
 				return this._advancedSearchUrl + searchTerm;
 			},
 
-			_onSearchRootUrlChanged: function(url) {
-				if (url) {
-					this.$.searchRootRequest.generateRequest();
-				}
-			},
-
-			_onSearchRootResponse: function(response) {
-				if (response.detail.status === 200) {
+			_myEnrollmentsEntityChanged: function(entity) {
+				if (entity) {
 					var parser = document.createElement('d2l-siren-parser');
-					var searchRootResponse = parser.parse(response.detail.xhr.response);
+					var enrollmentsRoot = parser.parse(entity);
 
-					this._searchAction = searchRootResponse.getActionByName('search-my-enrollments');
+					if (!enrollmentsRoot.hasAction('search-my-enrollments')) {
+						return;
+					}
+
+					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
+
+					this.set('_searchAction', searchAction);
 				}
 			},
 

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -137,14 +137,14 @@ describe('smoke test', function() {
 		it('should parse and update initial departments from search widget', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
+			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
 			var event = {
 				detail: pinnedEnrollmentEntity
 			};
 
 			widget._onDepartmentSearchResults(event);
 
-			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
 
 			sandbox.restore();
 		});
@@ -152,14 +152,14 @@ describe('smoke test', function() {
 		it('should parse and update initial semesters from search widget', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
+			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
 			var event = {
 				detail: pinnedEnrollmentEntity
 			};
 
 			widget._onSemesterSearchResults(event);
 
-			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
+			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
 
 			sandbox.restore();
 		});
@@ -167,7 +167,7 @@ describe('smoke test', function() {
 		it('should parse and update lazily-loaded departments', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
+			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
 			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
 			var response = {
 				detail: {
@@ -180,7 +180,7 @@ describe('smoke test', function() {
 
 			widget._onMoreDepartmentsResponse(response);
 
-			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
 			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
 
 			sandbox.restore();
@@ -189,7 +189,7 @@ describe('smoke test', function() {
 		it('should parse and update lazily-loaded semesters', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
+			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
 			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
 			var response = {
 				detail: {
@@ -202,7 +202,7 @@ describe('smoke test', function() {
 
 			widget._onMoreSemestersResponse(response);
 
-			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
+			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
 			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
 
 			sandbox.restore();

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -103,15 +103,21 @@ describe('smoke test', function() {
 				href: '/organizations?page=2'
 			}]
 		},
+		enrollments = {
+			class: ['enrollments', 'collection'],
+			entities: [pinnedEnrollment, unpinnedEnrollment],
+			links: [{
+				rel: ['self'],
+				href: '/enrollments'
+			}]
+		},
 		pinnedEnrollmentEntity,
-		unpinnedEnrollmentEntity,
-		organizationsEntity;
+		unpinnedEnrollmentEntity;
 
 	before(function() {
 		var parser = document.createElement('d2l-siren-parser');
 		pinnedEnrollmentEntity = parser.parse(pinnedEnrollment);
 		unpinnedEnrollmentEntity = parser.parse(unpinnedEnrollment);
-		organizationsEntity = parser.parse(organizations);
 	});
 
 	beforeEach(function() {
@@ -157,16 +163,14 @@ describe('smoke test', function() {
 		it('should parse and update initial departments from search widget', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var checkEntitySpy = sandbox.spy(widget, '_checkFilterEntities');
-			var updateMoreParametersSpy = sandbox.spy(widget, '_updateMoreParameters');
+			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
 			var event = {
-				detail: organizationsEntity
+				detail: pinnedEnrollmentEntity
 			};
 
 			widget._onDepartmentSearchResults(event);
 
-			sinon.assert.called(checkEntitySpy);
-			sinon.assert.calledWith(updateMoreParametersSpy, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
 
 			sandbox.restore();
 		});
@@ -174,49 +178,47 @@ describe('smoke test', function() {
 		it('should parse and update initial semesters from search widget', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var checkEntitySpy = sandbox.spy(widget, '_checkFilterEntities');
-			var updateMoreParametersSpy = sandbox.spy(widget, '_updateMoreParameters');
+			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
 			var event = {
-				detail: organizationsEntity
+				detail: pinnedEnrollmentEntity
 			};
 
 			widget._onSemesterSearchResults(event);
 
-			sinon.assert.called(checkEntitySpy);
-			sinon.assert.calledWith(updateMoreParametersSpy, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
+			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
 
 			sandbox.restore();
 		});
 
-		it('should parse and update lazily-loaded semesters', function() {
+		it('should parse and update lazily-loaded departments', function(done) {
 			var sandbox = sinon.sandbox.create();
 
-			var checkEntitySpy = sandbox.spy(widget, '_checkFilterEntities');
-			var updateMoreParametersSpy = sandbox.spy(widget, '_updateMoreParameters');
+			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
 			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
 			var response = {
 				detail: {
 					status: 200,
 					xhr: {
-						response: organizations
+						response: enrollments
 					}
 				}
 			};
 
 			widget._onMoreDepartmentsResponse(response);
 
-			sinon.assert.called(checkEntitySpy);
-			sinon.assert.calledWith(updateMoreParametersSpy, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
-			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departmentOrganizations', '_moreDepartmentsUrl', '_hasMoreDepartments');
+			setTimeout(function() {
+				sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
+				sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
 
-			sandbox.restore();
+				sandbox.restore();
+				done();
+			}, 100);
 		});
 
-		it('should parse and update lazily-loaded departments', function() {
+		it('should parse and update lazily-loaded semesters', function() {
 			var sandbox = sinon.sandbox.create();
 
-			var checkEntitySpy = sandbox.spy(widget, '_checkFilterEntities');
-			var updateMoreParametersSpy = sandbox.spy(widget, '_updateMoreParameters');
+			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
 			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
 			var response = {
 				detail: {
@@ -229,9 +231,8 @@ describe('smoke test', function() {
 
 			widget._onMoreSemestersResponse(response);
 
-			sinon.assert.called(checkEntitySpy);
-			sinon.assert.calledWith(updateMoreParametersSpy, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
-			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_semesterOrganizations', '_moreSemestersUrl', '_hasMoreSemesters');
+			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
+			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
 
 			sandbox.restore();
 		});

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -77,32 +77,6 @@ describe('smoke test', function() {
 				}]
 			}]
 		},
-		organizations = {
-			class: ['paged', 'organization', 'collection'],
-			entities: [{
-				rel: ['https://api.brightspace.com/rels/organization'],
-				class: ['active', 'course-offering'],
-				properties: {
-					name: 'Course name',
-					code: 'COURSE100'
-				},
-				links: [{
-					rel: ['self'],
-					href: '/organizations/1'
-				}, {
-					rel: ['https://api.brightspace.com/rels/organization-homepage'],
-					href: 'http://example.com/1/home',
-					type: 'text/html'
-				}]
-			}],
-			links: [{
-				rel: ['self'],
-				href: '/organizations'
-			}, {
-				rel: ['next'],
-				href: '/organizations?page=2'
-			}]
-		},
 		enrollments = {
 			class: ['enrollments', 'collection'],
 			entities: [pinnedEnrollment, unpinnedEnrollment],
@@ -190,7 +164,7 @@ describe('smoke test', function() {
 			sandbox.restore();
 		});
 
-		it('should parse and update lazily-loaded departments', function(done) {
+		it('should parse and update lazily-loaded departments', function() {
 			var sandbox = sinon.sandbox.create();
 
 			var updateMoreParametersStub = sandbox.stub(widget, '_updateMoreParameters');
@@ -206,13 +180,10 @@ describe('smoke test', function() {
 
 			widget._onMoreDepartmentsResponse(response);
 
-			setTimeout(function() {
-				sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
-				sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
+			sinon.assert.calledWith(updateMoreParametersStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
 
-				sandbox.restore();
-				done();
-			}, 100);
+			sandbox.restore();
 		});
 
 		it('should parse and update lazily-loaded semesters', function() {
@@ -224,7 +195,7 @@ describe('smoke test', function() {
 				detail: {
 					status: 200,
 					xhr: {
-						response: organizations
+						response: enrollments
 					}
 				}
 			};


### PR DESCRIPTION
Previously, the filter dropdown was being populated by calls to the /organizations HM API - however, this meant all users would see all departments/semesters in those lists, which isn't correct (it was an easier first slice is all).

This changes the fetching of those items to be via the /enrollments domain - meaning you will only receive semesters and departments you are enrolled in. This works, as admins and instructors are generally directly enrolled in semesters and departments, whereas students are not. This is also a much faster API call, even considering the fact that we're now fetching enrollments, then fetching all the organizations - so much faster that we could probably even get away with only fetching them when the user actually clicks the "Filter" menu (but for now, it's just whenever the all courses overlay is opened).

I also reduced the number of API calls we're doing - the `d2l-my-courses` component does the initial /enrollments call, then does the `search-my-enrollments` action. The response from that is then passed to `d2l-all-courses` (this is what is new), so we don't have to re-fetch that.