### PR TITLE
Working cut of alert on image set failure

### DIFF
--- a/d2l-alert-behavior.html
+++ b/d2l-alert-behavior.html
@@ -1,0 +1,52 @@
+<link rel="import" href="../polymer/polymer.html">
+
+<script>
+	'use strict';
+
+	(function() {
+		window.D2L = window.D2L || {};
+		window.D2L.MyCourses = window.D2L.MyCourses || {};
+
+		/*
+		* Behavior for my courses alert messages
+		*
+		* This contains utility functions for adding and removing alerts
+		*
+		* @polymerBehavior window.D2L.MyCourses.AlertBehavior
+s		*/
+		window.D2L.MyCourses.AlertBehavior = {
+			properties: {
+				// Array containing alert objects for display
+				_alerts: {
+					type: Array,
+					value: function() { return []; }
+				}
+			},
+			_addAlert: function(type, name, message) {
+				if (this._alerts) {
+					this.push('_alerts', {
+						alertType: type,
+						alertName: name,
+						alertMessage: message
+					});
+				}
+			},
+			_hasAlert: function(name) {
+				if (!this._alerts || this._alerts.length <= 0) {
+					return false;
+				}
+				return this._alerts.some(function(alert) {
+					return alert.alertName === name;
+				});
+			},
+			_removeAlert: function(name) {
+				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
+					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
+				}
+			},
+			_clearAlerts: function() {
+				this._alerts = [];
+			}
+		};
+	})();
+</script>

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -22,12 +22,26 @@
 				left: 0;
 				bottom: 0;
 				width: 6px;
-				background-color: #1598cb;
 				border-top-left-radius: 3px;
 				border-bottom-left-radius: 3px;
 				border-top-right-radius: 0;
 				border-bottom-right-radius: 0;
 				margin: -1px;
+			}
+			:host[alert-type="error"] .message-highlight {
+				background-color: #f0533f;
+			}
+			:host[alert-type="warning"] .message-highlight {
+				background-color: #ffce51;
+			}
+			:host[alert-type="call-to-action"] .message-highlight {
+				background-color: #1598cb;
+			}
+			:host[alert-type="reinforcement"] .message-highlight {
+				background-color: #7c8695;
+			}
+			:host[alert-type="confirmation"] .message-highlight {
+				background-color: #00ae81;
 			}
 			:host-context([dir='rtl']) .message-highlight {
 				left: auto;
@@ -38,8 +52,7 @@
 				border-bottom-right-radius: 3px;
 			}
 		</style>
-
-		<div class="message-wrapper" hidden$="{{!visible}}">
+		<div class="message-wrapper">
 			<div class="message-highlight"></div>
 			<content></content>
 		</div>
@@ -51,9 +64,10 @@
 		Polymer({
 			is: 'd2l-alert',
 			properties: {
-				visible: {
-					type: Boolean,
-					value: false
+				'alert-type': {
+					type: String,
+					value: 'call-to-action',
+					reflectToAttribute: true
 				}
 			}
 		});

--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -28,19 +28,19 @@
 				border-bottom-right-radius: 0;
 				margin: -1px;
 			}
-			:host[alert-type="error"] .message-highlight {
+			:host[type="error"] .message-highlight {
 				background-color: #f0533f;
 			}
-			:host[alert-type="warning"] .message-highlight {
+			:host[type="warning"] .message-highlight {
 				background-color: #ffce51;
 			}
-			:host[alert-type="call-to-action"] .message-highlight {
+			:host[type="call-to-action"] .message-highlight {
 				background-color: #1598cb;
 			}
-			:host[alert-type="reinforcement"] .message-highlight {
+			:host[type="reinforcement"] .message-highlight {
 				background-color: #7c8695;
 			}
-			:host[alert-type="confirmation"] .message-highlight {
+			:host[type="confirmation"] .message-highlight {
 				background-color: #00ae81;
 			}
 			:host-context([dir='rtl']) .message-highlight {
@@ -64,7 +64,7 @@
 		Polymer({
 			is: 'd2l-alert',
 			properties: {
-				'alert-type': {
+				type: {
 					type: String,
 					value: 'call-to-action',
 					reflectToAttribute: true

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -345,7 +345,7 @@
 		<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 
 		<template is="dom-repeat" items="{{_alerts}}">
-			<d2l-alert alert-type="[[item.alertType]]">
+			<d2l-alert type="[[item.alertType]]">
 				{{item.alertMessage}}
 			</d2l-alert>
 		</template>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -11,6 +11,7 @@
 <link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
 <link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="d2l-alert.html">
+<link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
@@ -464,17 +465,14 @@
 					value: function() {
 						return [];
 					}
-				},
-				_alerts: {
-					type: Array,
-					value: function() { return []; }
 				}
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				window.D2L.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.CourseManagementBehavior,
-				window.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.UtilityBehavior,
+				window.D2L.MyCourses.AlertBehavior
 			],
 			listeners: {
 				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening'
@@ -747,32 +745,10 @@
 				this.$.sortDropdown.toggleOpen();
 			},
 			_updateEnrollmentAlerts: function(hasPinnedEnrollments) {
-				this._alerts = [];
+				this._clearAlerts();
 
 				if (!hasPinnedEnrollments) {
 					this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
-				}
-			},
-			_addAlert: function(type, name, message) {
-				if (this._alerts) {
-					this.push('_alerts', {
-						alertType: type,
-						alertName: name,
-						alertMessage: message
-					});
-				}
-			},
-			_hasAlert: function(name) {
-				if (!this._alerts || this._alerts.length <= 0) {
-					return false;
-				}
-				return this._alerts.some(function(alert) {
-					return alert.alertName === name;
-				});
-			},
-			_removeAlert: function(name) {
-				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
-					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
 				}
 			},
 			_onSimpleOverlayOpening: function() {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -70,6 +70,7 @@
 				/* end overrides */
 			}
 			d2l-alert {
+				display: block;
 				margin-bottom: 20px;
 			}
 			d2l-icon {
@@ -343,9 +344,9 @@
 
 		<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 
-		<template is="dom-if" if="[[!_hasPinnedEnrollments]]">
-			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
-				{{localize('noPinnedCoursesMessage')}}
+		<template is="dom-repeat" items="{{_alerts}}">
+			<d2l-alert alert-type="[[item.alertType]]">
+				{{item.alertMessage}}
 			</d2l-alert>
 		</template>
 
@@ -463,6 +464,10 @@
 					value: function() {
 						return [];
 					}
+				},
+				_alerts: {
+					type: Array,
+					value: function() { return []; }
 				}
 			},
 			behaviors: [
@@ -471,8 +476,15 @@
 				window.D2L.MyCourses.CourseManagementBehavior,
 				window.D2L.MyCourses.UtilityBehavior
 			],
+			listeners: {
+				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening'
+			},
+			observers: [
+				'_updateEnrollmentAlerts(_hasPinnedEnrollments)'
+			],
 			ready: function() {
 				this.usePendingLists = true;
+				this._updateEnrollmentAlerts(this._hasPinnedEnrollments);
 
 				// Both course tile grids in this view should have the same number of columns, so use a custom getter
 				var courseTileGrids = Polymer.dom(this.root).querySelectorAll('d2l-course-tile-grid');
@@ -513,6 +525,12 @@
 				this.delayCourseTileLoad = false;
 			},
 			setCourseImage: function(details) {
+				this._removeAlert('setCourseImageFailure');
+				if (details && details.detail) {
+					if (details.detail.status === 'failure') {
+						this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+					}
+				}
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
@@ -727,6 +745,38 @@
 				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');
 
 				this.$.sortDropdown.toggleOpen();
+			},
+			_updateEnrollmentAlerts: function(hasPinnedEnrollments) {
+				this._alerts = [];
+
+				if (!hasPinnedEnrollments) {
+					this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
+				}
+			},
+			_addAlert: function(type, name, message) {
+				if (this._alerts) {
+					this.push('_alerts', {
+						alertType: type,
+						alertName: name,
+						alertMessage: message
+					});
+				}
+			},
+			_hasAlert: function(name) {
+				if (!this._alerts || this._alerts.length <= 0) {
+					return false;
+				}
+				return this._alerts.some(function(alert) {
+					return alert.alertName === name;
+				});
+			},
+			_removeAlert: function(name) {
+				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
+					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
+				}
+			},
+			_onSimpleOverlayOpening: function() {
+				this._removeAlert('setCourseImageFailure');
 			}
 		});
 	</script>

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -309,7 +309,7 @@
 
 		.fail-icon {
 			display: none;
-			color: var(--d2l-color-cinnabar);
+			color: #ffce51;
 		}
 
 		.change-image-success,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -50,7 +50,8 @@
 				display: none;
 			}
 			d2l-alert {
-				padding-bottom: 30px;
+				display: block;
+				margin-bottom: 20px;
 				clear: both;
 			}
 			d2l-loading-spinner {
@@ -85,14 +86,16 @@
 		</d2l-loading-spinner>
 
 		<div class="my-courses-content hidden">
-			<d2l-alert visible="[[!_hasPinnedEnrollments]]">
-				{{_alertMessage}}
-				<a
-					is="d2l-link"
-					href="Javascript:void(0);"
-					hidden$="[[_hasEnrollments]]"
-					on-tap="_refreshPage">{{localize('refresh')}}</a>
-			</d2l-alert>
+			<template is="dom-repeat" items="{{_alerts}}">
+				<d2l-alert alert-type="[[item.alertType]]">
+					{{item.alertMessage}}
+					<a
+						is="d2l-link"
+						href="Javascript:void(0);"
+						hidden$="[[_hasEnrollments]]"
+						on-tap="_refreshPage">{{localize('refresh')}}</a>
+				</d2l-alert>
+			</template>
 			<d2l-course-tile-grid
 				enrollments="{{pinnedEnrollments}}"
 				tile-sizes="[[_tileSizes]]"
@@ -177,8 +180,11 @@
 				tenantId: String,
 				// URL to send telemetry to
 				telemetryEndpoint: String,
-				// Message to display in alert if no enrollments are found
-				_alertMessage: String,
+				// Array containing alert objects for display
+				_alerts: {
+					type: Array,
+					value: function() { return []; }
+				},
 				// URL constructed to fetch a user's enrollments with the enrollments search Action
 				_enrollmentsSearchUrl: String,
 				// Object containing the last response from an enrollments search request
@@ -203,11 +209,16 @@
 			listeners: {
 				'open-change-image-view': '_openChangeImageView',
 				'set-course-image': '_setCourseImageEvent',
-				'clear-image-scroll-threshold': '_clearImageScrollThreshold'
+				'clear-image-scroll-threshold': '_clearImageScrollThreshold',
+				'simple-overlay-closed': '_onSimpleOverlayClosed'
 			},
+			observers: [
+				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
+			],
 			ready: function() {
 				this._pinnedCoursesMap = {};
-				this._alertMessage = this.localize('noCoursesMessage');
+				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
+
 				this.toggleClass('hidden', true, this.$.courseTiles);
 				this.toggleClass('hidden', true, this.$.courseList);
 			},
@@ -294,10 +305,6 @@
 						{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
 						{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
-					if (this._hasEnrollments) {
-						this._alertMessage = this.localize('noPinnedCoursesMessage');
-					}
-
 					this.fire('recalculate-columns');
 				}
 
@@ -345,6 +352,12 @@
 				}
 			},
 			_setCourseImageEvent: function(e) {
+				this._removeAlert('setCourseImageFailure');
+				if (e && e.detail) {
+					if (e.detail.status === 'failure') {
+						this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+					}
+				}
 				this.$$('d2l-all-courses').setCourseImage(e);
 				this.$$('d2l-course-tile-grid').setCourseImage(e);
 			},
@@ -353,6 +366,42 @@
 			},
 			_clearImageScrollThreshold: function() {
 				this.$['image-selector-threshold'].clearTriggers();
+			},
+			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
+				this._alerts = [];
+
+				if (hasEnrollments) {
+					if (!hasPinnedEnrollments) {
+						this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
+					}
+				} else {
+					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
+				}
+			},
+			_addAlert: function(type, name, message) {
+				if (this._alerts) {
+					this.push('_alerts', {
+						alertType: type,
+						alertName: name,
+						alertMessage: message
+					});
+				}
+			},
+			_hasAlert: function(name) {
+				if (!this._alerts || this._alerts.length <= 0) {
+					return false;
+				}
+				return this._alerts.some(function(alert) {
+					return alert.alertName === name;
+				});
+			},
+			_removeAlert: function(name) {
+				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
+					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
+				}
+			},
+			_onSimpleOverlayClosed: function() {
+				this._removeAlert('setCourseImageFailure');
 			}
 		});
 	</script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="d2l-alert.html">
+<link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-simple-overlay.html">
 <link rel="import" href="d2l-all-courses.html">
 <link rel="import" href="d2l-course-tile-grid.html">
@@ -180,11 +181,6 @@
 				tenantId: String,
 				// URL to send telemetry to
 				telemetryEndpoint: String,
-				// Array containing alert objects for display
-				_alerts: {
-					type: Array,
-					value: function() { return []; }
-				},
 				// URL constructed to fetch a user's enrollments with the enrollments search Action
 				_enrollmentsSearchUrl: String,
 				// Object containing the last response from an enrollments search request
@@ -204,7 +200,8 @@
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				window.D2L.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.InteractionDetectionBehavior,
-				window.D2L.MyCourses.CourseManagementBehavior
+				window.D2L.MyCourses.CourseManagementBehavior,
+				window.D2L.MyCourses.AlertBehavior
 			],
 			listeners: {
 				'open-change-image-view': '_openChangeImageView',
@@ -368,7 +365,7 @@
 				this.$['image-selector-threshold'].clearTriggers();
 			},
 			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
-				this._alerts = [];
+				this._clearAlerts();
 
 				if (hasEnrollments) {
 					if (!hasPinnedEnrollments) {
@@ -376,28 +373,6 @@
 					}
 				} else {
 					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
-				}
-			},
-			_addAlert: function(type, name, message) {
-				if (this._alerts) {
-					this.push('_alerts', {
-						alertType: type,
-						alertName: name,
-						alertMessage: message
-					});
-				}
-			},
-			_hasAlert: function(name) {
-				if (!this._alerts || this._alerts.length <= 0) {
-					return false;
-				}
-				return this._alerts.some(function(alert) {
-					return alert.alertName === name;
-				});
-			},
-			_removeAlert: function(name) {
-				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
-					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
 				}
 			},
 			_onSimpleOverlayClosed: function() {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -87,7 +87,7 @@
 
 		<div class="my-courses-content hidden">
 			<template is="dom-repeat" items="{{_alerts}}">
-				<d2l-alert alert-type="[[item.alertType]]">
+				<d2l-alert type="[[item.alertType]]">
 					{{item.alertMessage}}
 					<a
 						is="d2l-link"

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -46,7 +46,7 @@
 			],
 			listeners: {
 				'neon-animation-finish': '_onNeonAnimationFinish',
-				'close-simple-overlay': '_handleCloseSimpleOverlayEvent'
+				'image-selector-tile-image-selected': '_handleCloseSimpleOverlayEvent'
 			},
 			properties: {
 				// Title for overlay
@@ -106,6 +106,7 @@
 			},
 			_handleClose: function() {
 				this.close();
+				this.fire('simple-overlay-closed');
 				this.fire('recalculate-columns');
 			},
 			_handleCloseSimpleOverlayEvent: function(e) {

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -133,7 +133,7 @@
 				this.$.setImageRequest.generateRequest();
 				this._doTelemetrySetImageRequest();
 				this._fireCourseImageMessage('set');
-				this.fire('close-simple-overlay');
+				this.fire('image-selector-tile-image-selected');
 			},
 			_updateImageSource: function() {
 				var courseImage = Polymer.dom(this.root).querySelector('img');

--- a/test/d2l-alert/d2l-alert.js
+++ b/test/d2l-alert/d2l-alert.js
@@ -13,15 +13,12 @@ describe('d2l-alert', function() {
 		expect(component.innerHTML).to.contain('Alert text');
 	});
 
-	it('should hide content when visible=false', function() {
-		component.visible = false;
-
-		expect(component.$$('.message-wrapper').hasAttribute('hidden')).to.be.true;
+	it('should apply the call-to-action alert-type by default', function() {
+		expect(component.attributes.getNamedItem('alert-type').value).to.equal('call-to-action');
 	});
 
-	it('should show content when visible=true', function() {
-		component.visible = true;
-
-		expect(component.$$('.message-wrapper').hasAttribute('hidden')).to.be.false;
+	it('should apply the alert-type property value as an attribute', function() {
+		component['alert-type'] = 'reinforcement';
+		expect(component.attributes.getNamedItem('alert-type').value).to.equal('reinforcement');
 	});
 });

--- a/test/d2l-alert/d2l-alert.js
+++ b/test/d2l-alert/d2l-alert.js
@@ -13,12 +13,12 @@ describe('d2l-alert', function() {
 		expect(component.innerHTML).to.contain('Alert text');
 	});
 
-	it('should apply the call-to-action alert-type by default', function() {
-		expect(component.attributes.getNamedItem('alert-type').value).to.equal('call-to-action');
+	it('should apply the call-to-action alert type by default', function() {
+		expect(component.attributes.getNamedItem('type').value).to.equal('call-to-action');
 	});
 
-	it('should apply the alert-type property value as an attribute', function() {
-		component['alert-type'] = 'reinforcement';
-		expect(component.attributes.getNamedItem('alert-type').value).to.equal('reinforcement');
+	it('should apply the alert type property value as an attribute', function() {
+		component['type'] = 'reinforcement';
+		expect(component.attributes.getNamedItem('type').value).to.equal('reinforcement');
 	});
 });

--- a/test/d2l-image-selector-tile/d2l-image-selector-tile.js
+++ b/test/d2l-image-selector-tile/d2l-image-selector-tile.js
@@ -17,9 +17,9 @@ describe('<d2l-image-selector-tile>', function() {
 		expect(widget).to.exist;
 	});
 
-	it('fires a close-simple-overlay message when clicked', function() {
+	it('fires a image-selector-tile-image-selected message when clicked', function() {
 		var messageSent = false;
-		widget.addEventListener('close-simple-overlay', function() {
+		widget.addEventListener('image-selector-tile-image-selected', function() {
 			messageSent = true;
 		});
 
@@ -65,10 +65,10 @@ describe('<d2l-image-selector-tile>', function() {
 			expect(widget._fireCourseImageMessage.calledWith('set')).to.equal(true);
 		});
 
-		it('fires a "close simple overlay event"', function() {
+		it('fires a "image-selector-tile-image-selected event"', function() {
 			widget.fire = sinon.stub();
 			widget._selectImage();
-			expect(widget.fire.calledWith('close-simple-overlay')).to.equal(true);
+			expect(widget.fire.calledWith('image-selector-tile-image-selected')).to.equal(true);
 		});
 
 		it('generates a setImageRequest', function() {


### PR DESCRIPTION
This will display a warning alert when the change image action fails. Also changes the color of the failure icon to the warning yellow (as per Bob). Allows for multiple alerts to be displayed at the same time (such as if you get an image failure on the all courses page while no images are pinned, both the no pinned images call-to-action and the change image failure warning are displayed simultaneously).

TODO:

- [x] Rebase
- [x] Tests
- [x] Use the localized text for the set image failure message  
- [x] Change `alert-type` to `type`
- [x] Add duplicate logic into a behavior