### PR TITLE
fix the squished user-uploaded images

### DIFF
--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -3,6 +3,11 @@
 <dom-module id="d2l-course-image">
 	<template>
 		<style>
+			:host {
+				display: flex;
+				align-items: center;
+			}
+
 			.hidden {
 				opacity: 0;
 			}
@@ -19,8 +24,8 @@
 			}
 
 			img {
-				height: 100%;
-				min-width: 100%;
+				min-height: 100%;
+				width: 100%;
 			}
 		</style>
 


### PR DESCRIPTION
I noticed that on daylightDemo user-uploaded images were in a rough shape, so here's a fix for that

Upload an image and verify that what's shown isn't distorted and makes sense, ideally someone with safari could test