### PR TITLE
Break out filter content

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,103 +1,19 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-behavior.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-radio.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
-<link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
+<link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
+<link rel="import" href="d2l-filter-menu-content.html">
 <link rel="import" href="d2l-search-widget-custom.html">
 <link rel="import" href="localize-behavior.html">
-
-<dom-module id="d2l-list-item-filter">
-	<template>
-		<style include="d2l-menu-item-selectable-styles">
-			:host {
-				padding: 0.5rem 1rem;
-			}
-
-			:host > span {
-				font-size: 0.8rem;
-			}
-
-			:host d2l-icon {
-				--d2l-icon-height: 1rem;
-				--d2l-icon-width: 1rem;
-				visibility: visible;
-				margin-right: 0.5rem;
-			}
-		</style>
-		<d2l-ajax
-			auto
-			url="[[_organizationUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onOrganizationResponse">
-		</d2l-ajax>
-		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
-		<span>[[text]]</span>
-	</template>
-	<script>
-		'use strict';
-		Polymer({
-			is: 'd2l-list-item-filter',
-			properties: {
-				enrollmentEntity: {
-					type: Object,
-					value: function() { return {}; },
-					observer: '_onEnrollmentEntityChanged'
-				},
-				selected: {
-					type: Boolean,
-					observer: '_onSelectedChanged',
-					reflectToAttribute: true
-				},
-				_organizationUrl: String
-			},
-			behaviors: [
-				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
-			],
-			listeners: {
-				'd2l-menu-item-select': '_onSelect'
-			},
-			_onEnrollmentEntityChanged: function(entity) {
-				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
-					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
-				}
-			},
-			_onOrganizationResponse: function(response) {
-				if (response.detail.status === 200 ) {
-					if (!this._parser) {
-						this._parser = document.createElement('d2l-siren-parser');
-					}
-
-					var entity = this._parser.parse(response.detail.xhr.response);
-
-					this.set('text', entity.properties.name);
-					this.set('value', entity.getLinkByRel('self').href);
-				}
-			},
-			_onSelect: function(e) {
-				this.set('selected', !this.selected);
-				this.__onSelect(e);
-			},
-			_onSelectedChanged: function(e) {
-				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
-				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
-				this.__onSelectedChanged(e);
-			},
-			_parser: null
-		});
-	</script>
-</dom-module>
 
 <dom-module id="d2l-all-courses">
 	<template>
@@ -122,9 +38,6 @@
 			}
 			.hidden {
 				display: none !important;
-			}
-			.invisible {
-				visibility: hidden;
 			}
 			.search-and-filter {
 				display: flex;
@@ -165,6 +78,14 @@
 				padding: 0;
 				color: var(--d2l-color-tungsten);
 			}
+			.dropdown-content-header {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				border-bottom: 1px solid var(--d2l-color-gypsum);
+				width: 100%;
+				padding: 20px;
+			}
 			@media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
 				#filterText {
 					padding-top: 4px;
@@ -175,60 +96,6 @@
 			}
 			#filterText {
 				padding-right: 4px;
-			}
-			.clear-button {
-				@apply(--d2l-body-small-text);
-				/* overrides to d2l-body-small-text */
-				color: var(--d2l-color-celestine);
-				/* end overrides */
-				background: none;
-				border: none;
-				cursor: pointer;
-				margin: 0;
-				padding: 0;
-			}
-			.dropdown-content-header {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-				border-bottom: 1px solid var(--d2l-color-gypsum);
-				width: 100%;
-				padding: 20px;
-			}
-			.dropdown-content-header-text {
-				font-weight: bold;
-			}
-			.dropdown-content-gradient {
-				background: linear-gradient(to top, white, var(--d2l-color-regolith));
-			}
-			.dropdown-content-tabs {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-			}
-			.dropdown-content-tab {
-				flex: 1;
-			}
-			.dropdown-content-tab-button {
-				@apply(--d2l-body-small-text);
-				color: var(--d2l-color-ferrite);
-				background: none;
-				border: none;
-				padding: 10px;
-				cursor: pointer;
-				display: inherit;
-			}
-			.dropdown-content-tab-highlight {
-				background-color: var(--d2l-color-celestine);
-				border-bottom-left-radius: 4px;
-				border-bottom-right-radius: 4px;
-				height: 4px;
-				width: 80%;
-				margin: auto;
-			}
-			d2l-dropdown-content d2l-search-widget {
-				--d2l-search-widget-height: 45px;
-				margin: 10px 20px;
 			}
 			button[aria-pressed="true"] {
 				color: var(--d2l-color-celestine);
@@ -241,27 +108,11 @@
 			#filterText:focus,
 			#filterText:hover + d2l-dropdown button d2l-icon,
 			#filterText:focus + d2l-dropdown button d2l-icon,
-			d2l-dropdown-content button:hover,
-			d2l-dropdown-content button:focus,
 			.focus {
 				text-decoration: underline;
 				color: var(--d2l-color-celestine);
 			}
 		</style>
-
-		<d2l-ajax
-			id="moreDepartmentsRequest"
-			url="[[_moreDepartmentsUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onMoreDepartmentsResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="moreSemestersRequest"
-			url="[[_moreSemestersUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onMoreSemestersResponse">
-		</d2l-ajax>
 
 		<div class="search-and-filter">
 			<d2l-search-widget-custom
@@ -273,7 +124,7 @@
 
 			<div id="filterAndSort" class="hidden">
 				<div id="filterSection" class="hidden">
-					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">{{localize('filtering.filter')}}</span>
+					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
 					<d2l-dropdown id="filterDropdown">
 						<button
 							id="filterDropdownOpener"
@@ -286,70 +137,10 @@
 							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 						</button>
 						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
-							<div class="dropdown-content-header">
-								<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
-								<template is="dom-if" if="[[_showClearButton]]">
-									<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
-								</template>
-							</div>
-							<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
-								<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
-									<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
-									<button
-										id="semesterListButton"
-										class="dropdown-content-tab-button"
-										on-tap="_selectSemesterList"
-										aria-pressed="true">
-										{{localize('filtering.semester')}}
-									</button>
-								</div>
-								<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
-									<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
-									<button
-										id="departmentListButton"
-										class="dropdown-content-tab-button"
-										on-tap="_selectDepartmentList"
-										aria-pressed="false">
-										{{localize('filtering.department')}}
-									</button>
-								</div>
-							</div>
-							<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
-								<d2l-search-widget
-									id="semesterSearchWidget"
-									placeholder-text="{{localize('filtering.searchSemesters')}}"
-									search-action="[[_searchSemestersAction]]"
-									search-field-name="search"
-									cache-responses></d2l-search-widget>
-								<d2l-menu label="{{localize('filtering.semester')}}">
-									<template is="dom-repeat" items="[[_semesters]]">
-										<d2l-list-item-filter
-											enrollment-entity="[[item]]"
-											selected="[[_checkSelected(item)]]">
-										</d2l-list-item-filter>
-									</template>
-								</d2l-menu>
-							</div>
-							<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
-								<d2l-search-widget
-									id="departmentSearchWidget"
-									placeholder-text="{{localize('filtering.searchDepartments')}}"
-									search-action="[[_searchDepartmentsAction]]"
-									search-field-name="search"
-									cache-responses></d2l-search-widget>
-								<d2l-menu label="{{localize('filtering.department')}}">
-									<template is="dom-repeat" items="[[_departments]]">
-										<d2l-list-item-filter
-											enrollment-entity="[[item]]"
-											selected="[[_checkSelected(item)]]">
-										</d2l-list-item-filter>
-									</template>
-								</d2l-menu>
-							</div>
-							<iron-scroll-threshold
-								id="scrollThreshold"
-								on-lower-threshold="_loadMore">
-							</iron-scroll-threshold>
+							<d2l-filter-menu-content
+								id="filter"
+								my-enrollments-entity="[[myEnrollmentsEntity]]">
+							</d2l-filter-menu-content>
 						</d2l-dropdown-content>
 					</d2l-dropdown>
 				</div>
@@ -416,42 +207,11 @@
 				},
 				myEnrollmentsEntity: {
 					type: Object,
-					observer: '_myEnrollmentsEntityChanged'
-				},
-				_departments: {
-					type: Array,
 					value: function() {
-						return [];
+						return {};
 					}
 				},
-				_showClearButton: {
-					type: Boolean,
-					value: false
-				},
-				_hasMoreDepartments: {
-					type: Boolean,
-					value: false
-				},
-				_hasMoreSemesters: {
-					type: Boolean,
-					value: false
-				},
-				_moreDepartmentsUrl: {
-					type: String,
-					value: ''
-				},
-				_moreSemestersUrl: {
-					type: String,
-					value: ''
-				},
-				_searchSemestersAction: Object,
-				_searchDepartmentsAction: Object,
-				_semesters: {
-					type: Array,
-					value: function() {
-						return [];
-					}
-				},
+				_filterText: String,
 				_sortField: {
 					type: String,
 					value: 'pinDate'
@@ -487,18 +247,14 @@
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
 				this._updateTileSizes();
+
+				this._filterText = this.localize('filtering.filter');
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.listen(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
-
-				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-
-				this.listen(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
-				this.listen(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
-
-				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
+				this.listen(this.$.filter, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.listen(this.$.filter, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 
 				window.addEventListener('resize', this._onResize.bind(this));
 
@@ -506,13 +262,9 @@
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
-				this.unlisten(this.$.filterDropdown, 'd2l-menu-item-change', '_updateFilter');
-
-				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-
-				this.unlisten(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
-				this.unlisten(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
+				this.unlisten(this.$.filter, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.unlisten(this.$.filter, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 			},
 			getCourseTileItemCount: function() {
 				var itemCount = Math.max(this.pinnedEnrollments.length, this.unpinnedEnrollments.length);
@@ -525,8 +277,7 @@
 				// Only make the call to load the filter menu contents if user has a
 				// substantial number of enrollments - otherwise, hide the filter menu
 				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
-					this.$.departmentSearchWidget.search();
-					this.$.semesterSearchWidget.search();
+					this.$.filter.load();
 					this.toggleClass('hidden', false, this.$.filterAndSort);
 				}
 			},
@@ -541,46 +292,12 @@
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
 			_filterDropdownOpen: false,
-			_numSemesterFilters: 0,
-			_numDepartmentFilters: 0,
 			_parser: null,
 			_sortTextOptions: {
 				'courseCode': 'sorting.sortCourseCode',
 				'courseName': 'sorting.sortCourseName',
 				'pinDate': 'sorting.sortDatePinned',
 				'lastAccessed': 'sorting.sortLastAccessed'
-			},
-			_checkSelected: function(entity) {
-				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
-				var id = entity.getLinkByRel(/\/organization$/).href;
-				return this._parentOrganizations.indexOf(id) > -1;
-			},
-			_clearFilters: function() {
-				Polymer.dom(this.$.filterDropdown).querySelectorAll('d2l-menu-item-checkbox').forEach(function(item) {
-					item.selected = false;
-				});
-				this._showClearButton = false;
-				// Clear button is removed via dom-if, so need to manually set focus to next element
-				this.$.semesterListButton.focus();
-				this._parentOrganizations = [];
-				this.$.filterText.textContent = this.localize('filtering.filter');
-				this.$.semesterListButton.textContent = this.localize('filtering.semester');
-				this.$.departmentListButton.textContent = this.localize('filtering.department');
-				this._numSemesterFilters = 0;
-				this._numDepartmentFilters = 0;
-			},
-			_loadMore: function() {
-				// Generate the request based off of which tab is selected, and whether there are more to load or not
-				if (this.$.semesterList.classList.contains('hidden')) {
-					if (this._hasMoreDepartments) {
-						this.$.moreDepartmentsRequest.generateRequest();
-					}
-				} else {
-					if (this._hasMoreSemesters) {
-						this.$.moreSemestersRequest.generateRequest();
-					}
-				}
-				this.$.scrollThreshold.clearTriggers();
 			},
 			_blurFilterText: function() {
 				// Only de-highlight text if focus has moved AND we're not hovering over the opener button anymore
@@ -589,28 +306,12 @@
 					this.toggleClass('focus', false, this.$.filterText);
 				}
 			},
-			_myEnrollmentsEntityChanged: function(entity) {
-				// Set up search URLs and search Actions for filter dropdown
-				if (entity) {
-					var myEnrollmentsEntity = this._parser.parse(entity);
-
-					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
-					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
-				}
-			},
 			_focusFilterText: function() {
 				this.toggleClass('focus', true, this.$.filterText);
 			},
-			_onSearchResults: function(entity, moreUrlPath, hasMorePath) {
-				this.set(hasMorePath, entity.hasLinkByRel('next'));
-				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
-
-				// If user has >1 departments or >1 semesters, signal to d2l-all-courses to show filters
-				if (this._departments && this._departments.length > 1
-					|| this._semesters && this._semesters.length > 1
-				) {
-					this.toggleClass('hidden', false, this.$.filterSection);
-				}
+			_onFilterChanged: function(e) {
+				this.set('_parentOrganizations', e.detail.value);
+				this.set('_filterText', e.detail.text);
 			},
 			_onFilterDropdownClose: function() {
 				// If the dropdown is closed by clicking elsewhere, we need to manually update _filterDropdownOpen
@@ -620,59 +321,14 @@
 					this.set('_filterDropdownOpen', false);
 				}.bind(this), 100);
 			},
-			_onFilterDropdownOpen: function() {
-				this._selectSemesterList();
-			},
-			_onDepartmentSearchResults: function(e) {
-				this.set('_departments', e.detail.entities);
-				this._onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
-			},
-			_onSemesterSearchResults: function(e) {
-				this.set('_semesters', e.detail.entities);
-				this._onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
-			},
-			_onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
-				if (response.detail.status === 200 || response.detail.status === 304) {
-					var responseEntity = this._parser.parse(response.detail.xhr.response);
-
-					responseEntity.entities.forEach(function(entity) {
-						this.push(organizationsPath, entity);
-					}.bind(this));
-
-					this._onSearchResults(responseEntity, moreUrlPath, hasMorePath);
-				}
-			},
-			_onMoreDepartmentsResponse: function(response) {
-				this._onMoreResponse(response, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
-			},
-			_onMoreSemestersResponse: function(response) {
-				this._onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
+			_onFilterHideChanged: function(e) {
+				this.toggleClass('hidden', e.detail.hide, this.$.filterSection);
 			},
 			_onResize: function() {
 				this._updateTileSizes();
 			},
-			_selectSemesterList: function() {
-				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
-				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
-				this.$.semesterSearchWidget.clear();
-				this.$.departmentSearchWidget.clear();
-				this.$.semesterList.querySelector('d2l-menu').resize();
-			},
-			_selectDepartmentList: function() {
-				this._toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
-				this._toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
-				this.$.semesterSearchWidget.clear();
-				this.$.departmentSearchWidget.clear();
-				this.$.departmentList.querySelector('d2l-menu').resize();
-			},
-			_updateTileSizes: function() {
-				this._rescaleCourseTileRegions();
-				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
-			},
-			_toggleSelectedList: function(list, button, highlight, selected) {
-				this.toggleClass('hidden', !selected, list);
-				this.toggleClass('invisible', !selected, highlight);
-				button.setAttribute('aria-pressed', selected);
+			_onSimpleOverlayOpening: function() {
+				this._removeAlert('setCourseImageFailure');
 			},
 			_toggleFilterDropdown: function() {
 				// This is somewhat gross, but is a side effect of using the filter text span as a secondary opener
@@ -681,42 +337,13 @@
 					this.$.filterDropdownOpener.focus();
 				} else {
 					this.$.filterDropdownContent.open();
+					this.$.filter.load();
 				}
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},
-			_updateFilter: function(e) {
-				var isSemester = this.$.semesterList.contains(e.target);
-
-				if (e.detail.selected) {
-					this.push('_parentOrganizations', e.detail.value);
-					isSemester ? this._numSemesterFilters++ : this._numDepartmentFilters++;
-				} else {
-					var index = this._parentOrganizations.indexOf(e.detail.value);
-					this.splice('_parentOrganizations', index, 1);
-					isSemester ? this._numSemesterFilters-- : this._numDepartmentFilters--;
-				}
-
-				if (this._parentOrganizations.length === 0) {
-					this.$.filterText.textContent = this.localize('filtering.filter');
-				} else if (this._parentOrganizations.length === 1) {
-					this.$.filterText.textContent = this.localize('filtering.filterSingle');
-				} else {
-					this.$.filterText.textContent = this.localize('filtering.filterMultiple', 'num', this._parentOrganizations.length);
-				}
-
-				this._showClearButton = this._parentOrganizations.length > 0;
-				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
-					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
-					: this.localize('filtering.semester');
-				this.$.departmentListButton.textContent = this._numDepartmentFilters > 0
-					? this.localize('filtering.departmentMultiple', 'num', this._numDepartmentFilters)
-					: this.localize('filtering.department');
-			},
 			_updateSortBy: function(e) {
 				this.set('_sortField', e.detail.value);
-
 				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');
-
 				this.$.sortDropdown.toggleOpen();
 			},
 			_updateEnrollmentAlerts: function(hasPinnedEnrollments) {
@@ -726,8 +353,9 @@
 					this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
 				}
 			},
-			_onSimpleOverlayOpening: function() {
-				this._removeAlert('setCourseImageFailure');
+			_updateTileSizes: function() {
+				this._rescaleCourseTileRegions();
+				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
@@ -141,6 +142,10 @@
 								id="filterMenuContent"
 								my-enrollments-entity="[[myEnrollmentsEntity]]">
 							</d2l-filter-menu-content>
+							<iron-scroll-threshold
+								id="scrollThreshold"
+								on-lower-threshold="_onLowerThreshold">
+							</iron-scroll-threshold>
 						</d2l-dropdown-content>
 					</d2l-dropdown>
 				</div>
@@ -256,6 +261,8 @@
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 
+				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
+
 				window.addEventListener('resize', this._onResize.bind(this));
 
 				this._parser = document.createElement('d2l-siren-parser');
@@ -323,6 +330,10 @@
 			},
 			_onFilterHideChanged: function(e) {
 				this.toggleClass('hidden', e.detail.hide, this.$.filterSection);
+			},
+			_onLowerThreshold: function() {
+				this.$.scrollThreshold.clearTriggers();
+				this.$.filterMenuContent._loadMore();
 			},
 			_onResize: function() {
 				this._updateTileSizes();

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -116,7 +116,7 @@
 
 		<div class="search-and-filter">
 			<d2l-search-widget-custom
-				hidden$="[[_hasEnrollments]]"
+				hidden$="[[!_hasEnrollments]]"
 				my-enrollments-entity="[[myEnrollmentsEntity]]"
 				parent-organizations="[[_parentOrganizations]]"
 				sort-field="[[_sortField]]">
@@ -138,7 +138,7 @@
 						</button>
 						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
 							<d2l-filter-menu-content
-								id="filter"
+								id="filterMenuContent"
 								my-enrollments-entity="[[myEnrollmentsEntity]]">
 							</d2l-filter-menu-content>
 						</d2l-dropdown-content>
@@ -253,8 +253,8 @@
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-				this.listen(this.$.filter, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
-				this.listen(this.$.filter, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
+				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 
 				window.addEventListener('resize', this._onResize.bind(this));
 
@@ -263,8 +263,8 @@
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-				this.unlisten(this.$.filter, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
-				this.unlisten(this.$.filter, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
+				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 			},
 			getCourseTileItemCount: function() {
 				var itemCount = Math.max(this.pinnedEnrollments.length, this.unpinnedEnrollments.length);
@@ -277,7 +277,7 @@
 				// Only make the call to load the filter menu contents if user has a
 				// substantial number of enrollments - otherwise, hide the filter menu
 				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
-					this.$.filter.load();
+					this.$.filterMenuContent.load();
 					this.toggleClass('hidden', false, this.$.filterAndSort);
 				}
 			},
@@ -337,7 +337,7 @@
 					this.$.filterDropdownOpener.focus();
 				} else {
 					this.$.filterDropdownContent.open();
-					this.$.filter.load();
+					this.$.filterMenuContent.load();
 				}
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -76,10 +76,21 @@
 				'enrollment-unpin-complete': '_onEnrollmentUnpinComplete'
 			},
 			observers: [
-				'_onPinnedEnrollmentsChanged(pinnedEnrollments.*)'
+				'_enrollmentsChanged(pinnedEnrollments.length, pinnedEnrollmentsQueue.length, unpinnedEnrollments.length, unpinnedEnrollmentsQueue.length)'
 			],
 			created: function() {
 				this._tilesInPinStateTransition = [];
+			},
+			_enrollmentsChanged: function() {
+				this.set('_hasPinnedEnrollments',
+					this.pinnedEnrollments.length > 0 ||
+					this.pinnedEnrollmentsQueue.length > 0);
+				// Need to factor in queues here - if user has 1 enrollment, it will briefly
+				// disappear from both enrollments arrays when pinned/unpinned
+				this.set('_hasEnrollments',
+					this._hasPinnedEnrollments ||
+					this.unpinnedEnrollments.length > 0 ||
+					this.unpinnedEnrollmentsQueue.length > 0);
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				// Remove enrollment from unpinned list, add to pinned
@@ -126,9 +137,6 @@
 						break;
 					}
 				}
-			},
-			_onPinnedEnrollmentsChanged: function(newArray) {
-				this._hasPinnedEnrollments = !newArray.base || newArray.base.length > 0;
 			},
 			_onTileRemoveComplete: function(e) {
 				if (e.detail.pinned) {

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -65,8 +65,10 @@
 			behaviors: [
 				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
 			],
-			listeners: {
-				'd2l-menu-item-select': '_onSelect'
+			attached: function() {
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					this.listen(this, 'd2l-menu-item-select', '_onSelect');
+				}.bind(this));
 			},
 			_onEnrollmentEntityChanged: function(entity) {
 				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
@@ -112,8 +114,7 @@
 				display: none !important;
 			}
 			button:hover,
-			button:focus,
-			.focus {
+			button:focus {
 				text-decoration: underline;
 				color: var(--d2l-color-celestine);
 			}

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -1,0 +1,489 @@
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-menu/d2l-menu.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-behavior.html">
+<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
+<link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
+<link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="localize-behavior.html">
+
+<dom-module id="d2l-list-item-filter">
+	<template>
+		<style include="d2l-menu-item-selectable-styles">
+			:host {
+				padding: 0.5rem 1rem;
+			}
+
+			:host > span {
+				font-size: 0.8rem;
+			}
+
+			:host d2l-icon {
+				--d2l-icon-height: 1rem;
+				--d2l-icon-width: 1rem;
+				visibility: visible;
+				margin-right: 0.5rem;
+			}
+		</style>
+		<d2l-ajax
+			auto
+			url="[[_organizationUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onOrganizationResponse">
+		</d2l-ajax>
+		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
+		<span>[[text]]</span>
+	</template>
+	<script>
+		'use strict';
+		Polymer({
+			is: 'd2l-list-item-filter',
+			properties: {
+				enrollmentEntity: {
+					type: Object,
+					value: function() { return {}; },
+					observer: '_onEnrollmentEntityChanged'
+				},
+				selected: {
+					type: Boolean,
+					observer: '_onSelectedChanged',
+					reflectToAttribute: true
+				},
+				_departments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_organizationUrl: String,
+				_semesters: {
+					type: Array,
+					value: function() { return []; }
+				}
+			},
+			behaviors: [
+				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
+			],
+			listeners: {
+				'd2l-menu-item-select': '_onSelect'
+			},
+			_onEnrollmentEntityChanged: function(entity) {
+				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
+					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
+				}
+			},
+			_onOrganizationResponse: function(response) {
+				if (response.detail.status === 200 ) {
+					if (!this._parser) {
+						this._parser = document.createElement('d2l-siren-parser');
+					}
+
+					var entity = this._parser.parse(response.detail.xhr.response);
+
+					this.set('text', entity.properties.name);
+					this.set('value', entity.getLinkByRel('self').href);
+				}
+			},
+			_onSelect: function(e) {
+				this.set('selected', !this.selected);
+				this.__onSelect(e);
+			},
+			_onSelectedChanged: function(e) {
+				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
+				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
+				this.__onSelectedChanged(e);
+			},
+			_parser: null
+		});
+	</script>
+</dom-module>
+
+<dom-module is="d2l-filter-menu-content">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+			.invisible {
+				visibility: hidden;
+			}
+			.hidden {
+				display: none !important;
+			}
+			button:hover,
+			button:focus,
+			.focus {
+				text-decoration: underline;
+				color: var(--d2l-color-celestine);
+			}
+			.clear-button {
+				@apply(--d2l-body-small-text);
+				/* overrides to d2l-body-small-text */
+				color: var(--d2l-color-celestine);
+				/* end overrides */
+				background: none;
+				border: none;
+				cursor: pointer;
+				margin: 0;
+				padding: 0;
+			}
+			.dropdown-content-header {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				border-bottom: 1px solid var(--d2l-color-gypsum);
+				width: 100%;
+				padding: 20px;
+			}
+			.dropdown-content-header-text {
+				font-weight: bold;
+			}
+			.dropdown-content-gradient {
+				background: linear-gradient(to top, white, var(--d2l-color-regolith));
+			}
+			.dropdown-content-tabs {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+			}
+			.dropdown-content-tab {
+				flex: 1;
+			}
+			.dropdown-content-tab-button {
+				@apply(--d2l-body-small-text);
+				color: var(--d2l-color-ferrite);
+				background: none;
+				border: none;
+				padding: 10px;
+				cursor: pointer;
+				display: inherit;
+			}
+			.dropdown-content-tab-highlight {
+				background-color: var(--d2l-color-celestine);
+				border-bottom-left-radius: 4px;
+				border-bottom-right-radius: 4px;
+				height: 4px;
+				width: 80%;
+				margin: auto;
+			}
+			d2l-search-widget {
+				--d2l-search-widget-height: 45px;
+				margin: 10px 20px;
+			}
+		</style>
+
+		<d2l-ajax
+			id="moreDepartmentsRequest"
+			url="[[_moreDepartmentsUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreDepartmentsResponse">
+		</d2l-ajax>
+
+		<d2l-ajax
+			id="moreSemestersRequest"
+			url="[[_moreSemestersUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreSemestersResponse">
+		</d2l-ajax>
+
+		<div class="dropdown-content-header">
+			<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
+			<template is="dom-if" if="[[_showClearButton]]">
+				<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
+			</template>
+		</div>
+		<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
+			<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
+				<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
+				<button
+					id="semesterListButton"
+					class="dropdown-content-tab-button"
+					on-tap="_selectSemesterList"
+					aria-pressed="true">
+					{{localize('filtering.semester')}}
+				</button>
+			</div>
+			<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
+				<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
+				<button
+					id="departmentListButton"
+					class="dropdown-content-tab-button"
+					on-tap="_selectDepartmentList"
+					aria-pressed="false">
+					{{localize('filtering.department')}}
+				</button>
+			</div>
+		</div>
+		<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
+			<d2l-search-widget
+				id="semesterSearchWidget"
+				placeholder-text="{{localize('filtering.searchSemesters')}}"
+				search-action="[[_searchSemestersAction]]"
+				search-field-name="search"
+				cache-responses></d2l-search-widget>
+			<d2l-menu label="{{localize('filtering.semester')}}">
+				<template is="dom-repeat" items="[[_semesters]]">
+					<d2l-list-item-filter
+						enrollment-entity="[[item]]"
+						selected="[[_checkSelected(item)]]">
+					</d2l-list-item-filter>
+				</template>
+			</d2l-menu>
+		</div>
+		<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
+			<d2l-search-widget
+				id="departmentSearchWidget"
+				placeholder-text="{{localize('filtering.searchDepartments')}}"
+				search-action="[[_searchDepartmentsAction]]"
+				search-field-name="search"
+				cache-responses></d2l-search-widget>
+			<d2l-menu label="{{localize('filtering.department')}}">
+				<template is="dom-repeat" items="[[_departments]]">
+					<d2l-list-item-filter
+						enrollment-entity="[[item]]"
+						selected="[[_checkSelected(item)]]">
+					</d2l-list-item-filter>
+				</template>
+			</d2l-menu>
+		</div>
+		<iron-scroll-threshold
+			id="scrollThreshold"
+			on-lower-threshold="_loadMore">
+		</iron-scroll-threshold>
+	</template>
+
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-filter-menu-content',
+			properties: {
+				filterText: String,
+				myEnrollmentsEntity: {
+					type: Object,
+					value: function() { return {}; },
+					observer: '_myEnrollmentsEntityChanged'
+				},
+				_currentFilters: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_departments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_hasMoreDepartments: {
+					type: Boolean,
+					value: false
+				},
+				_hasMoreSemesters: {
+					type: Boolean,
+					value: false
+				},
+				_moreDepartmentsUrl: {
+					type: String,
+					value: ''
+				},
+				_moreSemestersUrl: {
+					type: String,
+					value: ''
+				},
+				_numSemesterFilters: {
+					type: Number,
+					value: 0,
+					observer: '_numFiltersChanged'
+				},
+				_numDepartmentFilters: {
+					type: Number,
+					value: 0,
+					observer: '_numFiltersChanged'
+				},
+				_searchSemestersAction: Object,
+				_searchDepartmentsAction: Object,
+				_semesters: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_showClearButton: {
+					type: Boolean,
+					value: false
+				}
+			},
+			behaviors: [
+				window.D2L.MyCourses.LocalizeBehavior
+			],
+			ready: function() {
+				this._parser = document.createElement('d2l-siren-parser');
+				this.filterText = this.localize('filtering.filter');
+			},
+			attached: function() {
+				this.listen(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
+				this.listen(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
+				this.listen(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
+				this.listen(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+
+				//TODO this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
+			},
+			detached: function() {
+				this.unlisten(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
+				this.unlisten(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
+				this.unlisten(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
+				this.unlisten(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+			},
+			load: function() {
+				this.$.departmentSearchWidget.search();
+				this.$.semesterSearchWidget.search();
+				this._selectSemesterList();
+			},
+			_parser: null,
+			_checkSelected: function(entity) {
+				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
+				var id = entity.getLinkByRel(/\/organization$/).href;
+				return this._currentFilters.indexOf(id) > -1;
+			},
+			_clearFilters: function() {
+				this.$.departmentList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
+					item.selected = false;
+				});
+				this.$.semesterList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
+					item.selected = false;
+				});
+
+				this._showClearButton = false;
+				// Clear button is removed via dom-if, so need to manually set focus to next element
+				this.$.semesterListButton.focus();
+
+				this.set('_currentFilters', []);
+				this.set('filterText', this.localize('filtering.filter'));
+				this.set('_numSemesterFilters', 0);
+				this.set('_numDepartmentFilters', 0);
+			},
+			_loadMore: function() {
+				// Generate the request based off of which tab is selected, and whether there are more to load or not
+				if (this.$.semesterList.classList.contains('hidden')) {
+					if (this._hasMoreDepartments) {
+						this.$.moreDepartmentsRequest.generateRequest();
+					}
+				} else {
+					if (this._hasMoreSemesters) {
+						this.$.moreSemestersRequest.generateRequest();
+					}
+				}
+				this.$.scrollThreshold.clearTriggers();
+			},
+			_myEnrollmentsEntityChanged: function(entity) {
+				// Set up search URLs and search Actions for filter dropdown
+				if (entity) {
+					if (!this._parser) {
+						this.set('_parser', document.createElement('d2l-siren-parser'));
+					}
+					var myEnrollmentsEntity = this._parser.parse(entity);
+
+					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
+					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
+				}
+			},
+			_numFiltersChanged: function() {
+				this._showClearButton = this._currentFilters.length > 0;
+
+				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
+					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
+					: this.localize('filtering.semester');
+				this.$.departmentListButton.textContent = this._numDepartmentFilters > 0
+					? this.localize('filtering.departmentMultiple', 'num', this._numDepartmentFilters)
+					: this.localize('filtering.department');
+
+				if (this._currentFilters.length === 0) {
+					this.filterText = this.localize('filtering.filter');
+				} else if (this._currentFilters.length === 1) {
+					this.filterText = this.localize('filtering.filterSingle');
+				} else {
+					this.filterText = this.localize('filtering.filterMultiple', 'num', this._currentFilters.length);
+				}
+
+				this.fire('d2l-filter-menu-content-filters-changed', {
+					text: this.filterText,
+					value: this._currentFilters
+				});
+			},
+			__onSearchResults: function(entity, moreUrlPath, hasMorePath) {
+				if (!entity.hasLinkByRel) {
+					entity = this._parser.parse(entity);
+				}
+
+				this.set(hasMorePath, entity.hasLinkByRel('next'));
+				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
+
+				// If user has >1 departments or >1 semesters, signal to d2l-all-courses to show filters
+				if (this._departments && this._departments.length > 1
+					|| this._semesters && this._semesters.length > 1
+				) {
+					this.fire('d2l-filter-menu-content-hide', {
+						hide: false
+					});
+				}
+			},
+			_onDepartmentSearchResults: function(e) {
+				this.set('_departments', e.detail.entities);
+				this.__onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			},
+			_onSemesterSearchResults: function(e) {
+				this.set('_semesters', e.detail.entities);
+				this.__onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
+			},
+			__onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var responseEntity = this._parser.parse(response.detail.xhr.response);
+
+					responseEntity.entities.forEach(function(entity) {
+						this.push(organizationsPath, entity);
+					}.bind(this));
+
+					this.__onSearchResults(responseEntity, moreUrlPath, hasMorePath);
+				}
+			},
+			_onMoreDepartmentsResponse: function(response) {
+				this.__onMoreResponse(response, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
+			},
+			_onMoreSemestersResponse: function(response) {
+				this.__onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
+			},
+			__toggleSelectedList: function(list, button, highlight, selected) {
+				this.toggleClass('hidden', !selected, list);
+				this.toggleClass('invisible', !selected, highlight);
+				button.setAttribute('aria-pressed', selected);
+			},
+			_selectDepartmentList: function() {
+				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
+				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
+				this.$.departmentList.querySelector('d2l-menu').resize();
+			},
+			_selectSemesterList: function() {
+				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
+				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
+				this.$.semesterList.querySelector('d2l-menu').resize();
+			},
+			__updateFilter: function(e, path) {
+				if (e.detail.selected) {
+					this.push('_currentFilters', e.detail.value);
+					this.set(path, this[path] + 1);
+				} else {
+					var index = this._currentFilters.indexOf(e.detail.value);
+					this.splice('_currentFilters', index, 1);
+					this.set(path, this[path] - 1);
+				}
+			},
+			_updateDepartmentFilter: function(e) {
+				this.__updateFilter(e, '_numDepartmentFilters');
+			},
+			_updateSemesterFilter: function(e) {
+				this.__updateFilter(e, '_numSemesterFilters');
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -44,7 +44,6 @@
 			properties: {
 				enrollmentEntity: {
 					type: Object,
-					value: function() { return {}; },
 					observer: '_onEnrollmentEntityChanged'
 				},
 				selected: {
@@ -52,15 +51,7 @@
 					observer: '_onSelectedChanged',
 					reflectToAttribute: true
 				},
-				_departments: {
-					type: Array,
-					value: function() { return []; }
-				},
-				_organizationUrl: String,
-				_semesters: {
-					type: Array,
-					value: function() { return []; }
-				}
+				_organizationUrl: String
 			},
 			behaviors: [
 				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
@@ -417,13 +408,13 @@
 				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
 
 				// If user has >1 departments or >1 semesters, signal to d2l-all-courses to show filters
-				if (this._departments && this._departments.length > 1
-					|| this._semesters && this._semesters.length > 1
-				) {
-					this.fire('d2l-filter-menu-content-hide', {
-						hide: false
-					});
-				}
+				var smallNumberOfDepartmentsAndSemesters =
+					this._departments && this._departments.length <= 1
+					&& this._semesters && this._semesters.length <= 1;
+
+				this.fire('d2l-filter-menu-content-hide', {
+					hide: smallNumberOfDepartmentsAndSemesters
+				});
 			},
 			_onDepartmentSearchResults: function(e) {
 				this.set('_departments', e.detail.entities);

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -239,10 +239,6 @@
 				</template>
 			</d2l-menu>
 		</div>
-		<iron-scroll-threshold
-			id="scrollThreshold"
-			on-lower-threshold="_loadMore">
-		</iron-scroll-threshold>
 	</template>
 
 	<script>
@@ -314,8 +310,6 @@
 				this.listen(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
 				this.listen(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
 				this.listen(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
-
-				//TODO this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 			},
 			detached: function() {
 				this.unlisten(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
@@ -362,7 +356,6 @@
 						this.$.moreSemestersRequest.generateRequest();
 					}
 				}
-				this.$.scrollThreshold.clearTriggers();
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -292,11 +292,6 @@
 						type: 'splice'
 					}]);
 
-					this.set('enrollments', enrollmentEntities);
-
-					this._hasPinnedEnrollments = this.pinnedEnrollments.length > 0;
-					this._hasEnrollments = this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0;
-
 					var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
 					this._tileSizes = (colNum === 2) ?
 						{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -6,7 +6,6 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../../d2l-siren-parser/d2l-siren-parser.html">
 		<link rel="import" href="../../d2l-my-courses.html">
 	</head>
 	<body>

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, beforeEach, fixture, expect */
+/* global describe, it, before, beforeEach, fixture, expect, sinon */
 
 'use strict';
 
@@ -56,6 +56,43 @@ describe('d2l-all-courses', function() {
 		}
 	});
 
+	it('should hide search if user has no enrollments', function() {
+		var search = widget.$$('d2l-search-widget-custom');
+		expect(search.hidden).to.be.true;
+
+		widget.pinnedEnrollments = [pinnedEnrollmentEntity];
+
+		expect(search.hidden).to.be.false;
+	});
+
+	it('should not load filter menu content when there are insufficient enrollments', function() {
+		var stub = sinon.stub(widget.$.filterMenuContent, 'load');
+
+		widget.pinnedEnrollments = Array(19).fill(pinnedEnrollmentEntity);
+		widget.load();
+		expect(stub.called).to.be.false;
+	});
+
+	it('should load filter menu content when there are sufficient enrollments', function() {
+		var stub = sinon.stub(widget.$.filterMenuContent, 'load');
+
+		widget.pinnedEnrollments = Array(20).fill(pinnedEnrollmentEntity);
+		widget.load();
+		expect(stub.called).to.be.true;
+	});
+
+	it('should hide filter menu when there are insufficient enrollments', function() {
+		widget.pinnedEnrollments = Array(19).fill(pinnedEnrollmentEntity);
+		widget.load();
+		expect(widget.$.filterAndSort.classList.contains('hidden')).to.be.true;
+	});
+
+	it('should show filter menu when there are sufficient enrollments', function() {
+		widget.pinnedEnrollments = Array(20).fill(pinnedEnrollmentEntity);
+		widget.load();
+		expect(widget.$.filterAndSort.classList.contains('hidden')).to.be.false;
+	});
+
 	describe('d2l-filter-menu-content-filters-changed', function() {
 		var event = {
 			value: [1],
@@ -63,11 +100,12 @@ describe('d2l-all-courses', function() {
 		};
 
 		it('should update the parent organizations passed to d2l-search-widget-custom', function() {
-			expect(widget._parentOrganizations.length).to.equal(0);
+			var search = widget.$$('d2l-search-widget-custom');
+			expect(search.parentOrganizations.length).to.equal(0);
 
 			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-filters-changed', event);
 
-			expect(widget._parentOrganizations.length).to.equal(1);
+			expect(search.parentOrganizations.length).to.equal(1);
 		});
 
 		it('should update the filter menu opener text', function() {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, beforeEach, fixture, expect, sinon */
+/* global describe, it, beforeEach, fixture, expect, sinon */
 
 'use strict';
 
@@ -7,7 +7,7 @@ describe('d2l-all-courses', function() {
 		pinnedEnrollmentEntity,
 		unpinnedEnrollmentEntity;
 
-	before(function() {
+	beforeEach(function() {
 		var parser = document.createElement('d2l-siren-parser');
 		pinnedEnrollmentEntity = parser.parse({
 			class: ['pinned', 'enrollment'],
@@ -31,9 +31,6 @@ describe('d2l-all-courses', function() {
 				href: '/organizations/123'
 			}]
 		});
-	});
-
-	beforeEach(function() {
 		widget = fixture('d2l-all-courses-fixture');
 	});
 

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -1,117 +1,40 @@
-/* global describe, it, before, beforeEach, afterEach, fixture, expect, sinon */
+/* global describe, it, before, beforeEach, fixture, expect */
 
 'use strict';
 
-describe('smoke test', function() {
-	var server,
-		widget,
-		pinnedEnrollment = {
-			class: ['pinned', 'enrollment'],
-			rel: ['https://api.brightspace.com/rels/user-enrollment'],
-			actions: [{
-				name: 'unpin-course',
-				method: 'PUT',
-				href: '/enrollments/users/169/organizations/1',
-				fields: [{
-					name: 'pinned',
-					type: 'hidden',
-					value: false
-				}]
-			}],
-			links: [{
-				rel: ['https://api.brightspace.com/rels/organization'],
-				href: '/organizations/1'
-			}, {
-				rel: ['self'],
-				href: '/enrollments/users/169/organizations/1'
-			}]
-		},
-		unpinnedEnrollment = {
-			class: ['pinned', 'enrollment'],
-			rel: ['https://api.brightspace.com/rels/user-enrollment'],
-			actions: [{
-				name: 'unpin-course',
-				method: 'PUT',
-				href: '/enrollments/users/169/organizations/1',
-				fields: [{
-					name: 'pinned',
-					type: 'hidden',
-					value: false
-				}]
-			}],
-			links: [{
-				rel: ['https://api.brightspace.com/rels/organization'],
-				href: '/organizations/1'
-			}, {
-				rel: ['self'],
-				href: '/enrollments/users/169/organizations/1'
-			}]
-		},
-		organization = {
-			class: ['active', 'course-offering'],
-			properties: {
-				name: 'Course name',
-				code: 'COURSE100'
-			},
-			links: [{
-				rel: ['self'],
-				href: '/organizations/1'
-			}, {
-				rel: ['https://api.brightspace.com/rels/organization-homepage'],
-				href: 'http://example.com/1/home',
-				type: 'text/html'
-			}],
-			entities: [{
-				class: ['course-image'],
-				propeties: {
-					name: '1.jpg',
-					type: 'image/jpeg'
-				},
-				rel: ['https://api.brightspace.com/rels/organization-image'],
-				links: [{
-					rel: ['self'],
-					href: '/organizations/1/image'
-				}, {
-					rel: ['alternate'],
-					href: ''
-				}]
-			}]
-		},
-		enrollments = {
-			class: ['enrollments', 'collection'],
-			entities: [pinnedEnrollment, unpinnedEnrollment],
-			links: [{
-				rel: ['self'],
-				href: '/enrollments'
-			}]
-		},
+describe('d2l-all-courses', function() {
+	var widget,
 		pinnedEnrollmentEntity,
 		unpinnedEnrollmentEntity;
 
 	before(function() {
 		var parser = document.createElement('d2l-siren-parser');
-		pinnedEnrollmentEntity = parser.parse(pinnedEnrollment);
-		unpinnedEnrollmentEntity = parser.parse(unpinnedEnrollment);
+		pinnedEnrollmentEntity = parser.parse({
+			class: ['pinned', 'enrollment'],
+			rel: ['https://api.brightspace.com/rels/user-enrollment'],
+			links: [{
+				rel: ['self'],
+				href: '/enrollments/users/169/organizations/1'
+			}, {
+				rel: ['https://api.brightspace.com/rels/organization'],
+				href: '/organizations/123'
+			}]
+		});
+		unpinnedEnrollmentEntity = parser.parse({
+			class: ['unpinned', 'enrollment'],
+			rel: ['https://api.brightspace.com/rels/user-enrollment'],
+			links: [{
+				rel: ['self'],
+				href: '/enrollments/users/169/organizations/1'
+			}, {
+				rel: ['https://api.brightspace.com/rels/organization'],
+				href: '/organizations/123'
+			}]
+		});
 	});
 
 	beforeEach(function() {
-		// Not actually required, but avoids a bunch of errors in the test output
-		server = sinon.fakeServer.create();
-		server.respondImmediately = true;
-		server.respondWith(
-			'GET',
-			/\/organizations\/1\?embedDepth=1/,
-			[200, {}, JSON.stringify(organization)]);
-
 		widget = fixture('d2l-all-courses-fixture');
-	});
-
-	afterEach(function() {
-		server.restore();
-	});
-
-	it('should load', function() {
-		expect(widget).to.exist;
 	});
 
 	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {
@@ -133,79 +56,26 @@ describe('smoke test', function() {
 		}
 	});
 
-	describe('Filter list content', function() {
-		it('should parse and update initial departments from search widget', function() {
-			var sandbox = sinon.sandbox.create();
+	describe('d2l-filter-menu-content-filters-changed', function() {
+		var event = {
+			value: [1],
+			text: 'foo'
+		};
 
-			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
-			var event = {
-				detail: pinnedEnrollmentEntity
-			};
+		it('should update the parent organizations passed to d2l-search-widget-custom', function() {
+			expect(widget._parentOrganizations.length).to.equal(0);
 
-			widget._onDepartmentSearchResults(event);
+			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-filters-changed', event);
 
-			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
-
-			sandbox.restore();
+			expect(widget._parentOrganizations.length).to.equal(1);
 		});
 
-		it('should parse and update initial semesters from search widget', function() {
-			var sandbox = sinon.sandbox.create();
+		it('should update the filter menu opener text', function() {
+			expect(widget._filterText).to.equal('Filter');
 
-			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
-			var event = {
-				detail: pinnedEnrollmentEntity
-			};
+			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-filters-changed', event);
 
-			widget._onSemesterSearchResults(event);
-
-			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
-
-			sandbox.restore();
-		});
-
-		it('should parse and update lazily-loaded departments', function() {
-			var sandbox = sinon.sandbox.create();
-
-			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
-			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
-			var response = {
-				detail: {
-					status: 200,
-					xhr: {
-						response: enrollments
-					}
-				}
-			};
-
-			widget._onMoreDepartmentsResponse(response);
-
-			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreDepartmentsUrl', '_hasMoreDepartments');
-			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
-
-			sandbox.restore();
-		});
-
-		it('should parse and update lazily-loaded semesters', function() {
-			var sandbox = sinon.sandbox.create();
-
-			var onSearchResultsStub = sandbox.stub(widget, '_onSearchResults');
-			var onMoreResponseSpy = sandbox.spy(widget, '_onMoreResponse');
-			var response = {
-				detail: {
-					status: 200,
-					xhr: {
-						response: enrollments
-					}
-				}
-			};
-
-			widget._onMoreSemestersResponse(response);
-
-			sinon.assert.calledWith(onSearchResultsStub, sinon.match.object, '_moreSemestersUrl', '_hasMoreSemesters');
-			sinon.assert.calledWith(onMoreResponseSpy, sinon.match.object, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
-
-			sandbox.restore();
+			expect(widget._filterText).to.equal('foo');
 		});
 	});
 

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="../../d2l-filter-menu-content.html">
+	</head>
+	<body>
+		<test-fixture id="d2l-filter-menu-content-fixture">
+			<template>
+				<d2l-filter-menu-content></d2l-filter-menu-content>
+			</template>
+		</test-fixture>
+
+		<test-fixture id="d2l-list-item-filter-fixture">
+			<template>
+				<d2l-list-item-filter></d2l-list-item-filter>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-filter-menu-content.js"></script>
+	</body>
+</html>

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -239,7 +239,75 @@ describe('d2l-filter-menu-content', function() {
 				expect(widget._moreDepartmentsUrl).to.equal('/enrollments?page=2');
 				done();
 			});
+		});
 
+		it('should set internal values appropriately when there are not any more semesters', function(done) {
+			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreSemesters).to.be.false;
+				expect(widget._moreSemestersUrl).to.equal('');
+				done();
+			});
+		});
+
+		it('should set internal values appropriately when there are more semesters', function(done) {
+			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}, {
+					rel: ['next'],
+					href: '/enrollments?page=2'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreSemesters).to.be.true;
+				expect(widget._moreSemestersUrl).to.equal('/enrollments?page=2');
+				done();
+			});
+		});
+
+		it('should trigger a request for more departments when the departments tab is selected', function() {
+			var departmentStub = sinon.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
+			widget._selectDepartmentList();
+
+			widget._loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.false;
+
+			widget.set('_hasMoreDepartments', true);
+
+			widget._loadMore();
+
+			expect(departmentStub.called).to.be.true;
+			expect(semesterStub.called).to.be.false;
+		});
+
+		it('should trigger a request for more semesters when the semesters tab is selected', function() {
+			var departmentStub = sinon.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
+			widget._selectSemesterList();
+
+			widget._loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.false;
+
+			widget.set('_hasMoreSemesters', true);
+
+			widget._loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.true;
 		});
 	});
 });

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -1,0 +1,245 @@
+/* global describe, it, before, beforeEach, fixture, expect, sinon */
+
+'use strict';
+
+describe('d2l-filter-menu-content', function() {
+	var widget,
+		sandbox,
+		myEnrollmentsEntity,
+		enrollment,
+		parser;
+
+	before(function() {
+		parser = document.createElement('d2l-siren-parser');
+		myEnrollmentsEntity = parser.parse({
+			actions: [{
+				name: 'add-semester-filter',
+				href: '/enrollments'
+			}, {
+				name: 'add-department-filter',
+				href: '/enrollments'
+			}]
+		});
+		enrollment = {
+			rel: ['enrollment'],
+			links: [{
+				rel: ['self'],
+				href: '/enrollments'
+			}, {
+				rel: ['/organization'],
+				href: '/organizations/1'
+			}]
+		};
+	});
+
+	beforeEach(function() {
+		sandbox = sinon.sandbox.create();
+		widget = fixture('d2l-filter-menu-content-fixture');
+	});
+
+	it('should observe changes to myEnrollmentsEntity', function() {
+		var spy = sandbox.spy(widget, '_myEnrollmentsEntityChanged');
+
+		widget.myEnrollmentsEntity = myEnrollmentsEntity;
+
+		expect(spy.called).to.be.true;
+		expect(widget._searchDepartmentsAction.name).to.equal('add-department-filter');
+		expect(widget._searchDepartmentsAction.href).to.equal('/enrollments');
+		expect(widget._searchSemestersAction.name).to.equal('add-semester-filter');
+		expect(widget._searchSemestersAction.href).to.equal('/enrollments');
+	});
+
+	describe('d2l-list-item-filter', function() {
+		var listItem;
+
+		beforeEach(function() {
+			listItem = fixture('d2l-list-item-filter-fixture');
+		});
+
+		it('should change icon when selected state changes', function() {
+			expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box-unchecked');
+
+			listItem.set('selected', true);
+
+			expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box');
+		});
+
+		it('should fetch the organization when the enrollment changes', function() {
+			var stub = sinon.stub(listItem.$$('d2l-ajax'), 'generateRequest');
+
+			listItem.set('enrollmentEntity', parser.parse(enrollment));
+
+			expect(stub.called).to.be.true;
+			expect(listItem._organizationUrl).to.equal('/organizations/1');
+		});
+
+		it('should update text and value based off of organizations response', function(done) {
+			var server = sinon.fakeServer.create();
+			server.respondImmediately = true;
+			server.respondWith(
+				'GET',
+				'/organizations/1',
+				[200, '{}', JSON.stringify({
+					properties: {
+						name: 'foo'
+					},
+					links: [{
+						rel: ['self'],
+						href: 'bar'
+					}]
+				})]);
+
+			listItem.set('enrollmentEntity', parser.parse(enrollment));
+
+			setTimeout(function() {
+				expect(listItem.text).to.equal('foo');
+				expect(listItem.value).to.equal('bar');
+				server.restore();
+				done();
+			});
+		});
+	});
+
+	describe('Visibility', function() {
+		it('should signal that it should be hidden if user does not have enough departments/semesters', function(done) {
+			var handler = function(e) {
+				expect(e.detail.hide).to.be.false;
+				document.removeEventListener('d2l-filter-menu-content-hide', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-hide', handler);
+
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', parser.parse({
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}],
+				entities: [enrollment, enrollment]
+			}));
+		});
+
+		it('should signal that it should be shown if user has enough departments/semesters', function(done) {
+			var handler = function(e) {
+				expect(e.detail.hide).to.be.true;
+				document.removeEventListener('d2l-filter-menu-content-hide', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-hide', handler);
+
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', parser.parse({
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}],
+				entities: [enrollment]
+			}));
+		});
+	});
+
+	describe('Clear button', function() {
+		it('should be hidden when there are no filters selected', function() {
+			widget._clearFilters();
+
+			expect(widget._showClearButton).to.be.false;
+			expect(widget.$$('.clear-button')).to.be.null;
+		});
+
+		it('should appear when at least one filter is selected', function(done) {
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+
+			setTimeout(function() {
+				expect(widget._showClearButton).to.be.true;
+				expect(widget.$$('.clear-button')).to.not.be.null;
+				done();
+			});
+		});
+
+		it('should clear filters when clicked', function(done) {
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+
+			setTimeout(function() {
+				widget.$$('.clear-button').click();
+				expect(widget._showClearButton).to.be.false;
+				done();
+			});
+		});
+	});
+
+	describe('Filter text', function() {
+		it('should read "Filter" when no filters are selected', function() {
+			widget._clearFilters();
+
+			expect(widget.filterText).to.equal('Filter');
+		});
+
+		it('should read "Filter: 1 filter" when any 1 filter is selected', function(done) {
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+
+			setTimeout(function() {
+				expect(widget.filterText).to.equal('Filter: 1 Filter');
+				done();
+			});
+		});
+
+		it('should read "Filter: 2 filters" when any 2 filters are selected', function(done) {
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'bar'
+			});
+
+			setTimeout(function() {
+				expect(widget.filterText).to.equal('Filter: 2 Filters');
+				done();
+			});
+		});
+	});
+
+	describe('Lazy loading', function() {
+		it('should set internal values appropriately when there are not any more departments', function(done) {
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreDepartments).to.be.false;
+				expect(widget._moreDepartmentsUrl).to.equal('');
+				done();
+			});
+		});
+
+		it('should set internal values appropriately when there are more departments', function(done) {
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}, {
+					rel: ['next'],
+					href: '/enrollments?page=2'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreDepartments).to.be.true;
+				expect(widget._moreDepartmentsUrl).to.equal('/enrollments?page=2');
+				done();
+			});
+
+		});
+	});
+});

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, beforeEach, fixture, expect, sinon */
+/* global describe, it, beforeEach, fixture, expect, sinon */
 
 'use strict';
 
@@ -9,7 +9,7 @@ describe('d2l-filter-menu-content', function() {
 		enrollment,
 		parser;
 
-	before(function() {
+	beforeEach(function() {
 		parser = document.createElement('d2l-siren-parser');
 		myEnrollmentsEntity = parser.parse({
 			actions: [{
@@ -30,9 +30,6 @@ describe('d2l-filter-menu-content', function() {
 				href: '/organizations/1'
 			}]
 		};
-	});
-
-	beforeEach(function() {
 		sandbox = sinon.sandbox.create();
 		widget = fixture('d2l-filter-menu-content-fixture');
 	});

--- a/test/index.html
+++ b/test/index.html
@@ -13,14 +13,15 @@
 			WCT.loadSuites([
 				'./d2l-alert/d2l-alert.html',
 				'./d2l-all-courses/d2l-all-courses.html',
+				'./d2l-basic-image-selector/d2l-basic-image-selector.html',
 				'./d2l-course-tile/d2l-course-tile.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
+				'./d2l-filter-menu-content/d2l-filter-menu-content.html',
+				'./d2l-image-selector-tile/d2l-image-selector-tile.html',
 				'./d2l-my-courses/d2l-my-courses.html',
 				'./d2l-touch-menu-item/d2l-touch-menu-item.html',
 				'./d2l-utility-behavior/d2l-utility-behavior.html',
-				'./localize-behavior/localize-behavior.html',
-				'./d2l-image-selector-tile/d2l-image-selector-tile.html',
-				'./d2l-basic-image-selector/d2l-basic-image-selector.html'
+				'./localize-behavior/localize-behavior.html'
 			]);
 		</script>
 	</body>


### PR DESCRIPTION
As I've been adding stuff to filtering, I keep thinking "I should make that it's own component". Well, now I have. I wish I had done it sooner. I am sorry 😭 

This is _mostly_ just removing the `d2l-filter-list-item` out, but there are some other changes too, done due to (really small) problems found in redoing the `d2l-all-courses` tests.

To do:

- [x] Merge #207 
- [x] Change base for this PR
- [x] Write tests for new broken-out component
- [x] Get milk