### PR TITLE
Update d2l-menu

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "d2l-icons": "^2.11.1",
     "d2l-link": "^3.0.0",
     "d2l-loading-spinner": "^4.0.0",
-    "d2l-menu": "^0.2.3",
+    "d2l-menu": "^0.2.4",
     "d2l-offscreen": "^2.1.0",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#0.2.1",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -70,7 +70,9 @@
 				'd2l-menu-item-select': '_onSelect'
 			},
 			_onEnrollmentEntityChanged: function(entity) {
-				this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
+				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
+					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
+				}
 			},
 			_onOrganizationResponse: function(response) {
 				if (response.detail.status === 200 ) {
@@ -88,10 +90,10 @@
 				this.set('selected', !this.selected);
 				this.__onSelect(e);
 			},
-			__onSelectedChanged: function(e) {
+			_onSelectedChanged: function(e) {
 				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
 				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
-				this._onSelectedChanged(e);
+				this.__onSelectedChanged(e);
 			},
 			_parser: null
 		});


### PR DESCRIPTION
I do believe this is what's causing CI failures right now - I [override `_onSelectedChanged`](https://github.com/Brightspace/d2l-my-courses-ui/commit/bab7e658ece32cacdb72e2fccc9283c87ab45f3f#diff-98931a3c4fd43464bdaaf7d5c18ce360R88) in `d2l-list-item-filter`, but [it's been changed to `_onSelectedChanged`](https://github.com/Brightspace/d2l-menu-ui/commit/2947d3ddd1a97fcba5ac46c4bb4f42f6e3ba4094).