### PR TITLE
Remove overly-generic class names. Fixes #218.

### DIFF
--- a/components/d2l-course-image.html
+++ b/components/d2l-course-image.html
@@ -9,7 +9,7 @@
 				align-items: center;
 			}
 
-			.hidden {
+			.d2l-course-image-hidden {
 				opacity: 0;
 			}
 
@@ -92,7 +92,7 @@
 				if (same && shown) {
 					setTimeout(this._showImage.bind(this), 50);
 				}
-				this._imageClass = 'hidden';
+				this._imageClass = 'd2l-course-image-hidden';
 			},
 			_defaultSizes: {
 				mobile: { maxwidth: 767, size: 100 },

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -37,7 +37,7 @@
 				--d2l-icon-width: 15px;
 				margin-top: -0.35rem;
 			}
-			.hidden {
+			.d2l-all-courses-hidden {
 				display: none !important;
 			}
 			.search-and-filter {
@@ -123,8 +123,8 @@
 				sort-field="[[_sortField]]">
 			</d2l-search-widget-custom>
 
-			<div id="filterAndSort" class="hidden">
-				<div id="filterSection" class="hidden">
+			<div id="filterAndSort" class="d2l-all-courses-hidden">
+				<div id="filterSection" class="d2l-all-courses-hidden">
 					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
 					<d2l-dropdown id="filterDropdown">
 						<button
@@ -285,7 +285,7 @@
 				// substantial number of enrollments - otherwise, hide the filter menu
 				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
 					this.$.filterMenuContent.load();
-					this.toggleClass('hidden', false, this.$.filterAndSort);
+					this.toggleClass('d2l-all-courses-hidden', false, this.$.filterAndSort);
 				}
 			},
 			setCourseImage: function(details) {

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -98,10 +98,10 @@
 			:host {
 				display: block;
 			}
-			.invisible {
+			.d2l-filter-menu-content-invisible {
 				visibility: hidden;
 			}
-			.hidden {
+			.d2l-filter-menu-content-hidden {
 				display: none !important;
 			}
 			button:hover,
@@ -347,7 +347,7 @@
 			},
 			_loadMore: function() {
 				// Generate the request based off of which tab is selected, and whether there are more to load or not
-				if (this.$.semesterList.classList.contains('hidden')) {
+				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden')) {
 					if (this._hasMoreDepartments) {
 						this.$.moreDepartmentsRequest.generateRequest();
 					}
@@ -435,8 +435,8 @@
 				this.__onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
 			},
 			__toggleSelectedList: function(list, button, highlight, selected) {
-				this.toggleClass('hidden', !selected, list);
-				this.toggleClass('invisible', !selected, highlight);
+				this.toggleClass('d2l-filter-menu-content-hidden', !selected, list);
+				this.toggleClass('d2l-filter-menu-content-invisible', !selected, highlight);
 				button.setAttribute('aria-pressed', selected);
 			},
 			_selectDepartmentList: function() {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -45,7 +45,7 @@
 			.all-courses-button:hover, .all-courses-button:focus {
 				text-decoration: underline;
 			}
-			.hidden {
+			.d2l-my-courses-hidden {
 				display: none;
 			}
 			d2l-alert {
@@ -80,11 +80,11 @@
 
 		<d2l-loading-spinner
 			id="initialLoadingSpinner"
-			class="hidden"
+			class="d2l-my-courses-hidden"
 			size="100">
 		</d2l-loading-spinner>
 
-		<div class="my-courses-content hidden">
+		<div class="my-courses-content d2l-my-courses-hidden">
 			<template is="dom-repeat" items="{{_alerts}}">
 				<d2l-alert type="[[item.alertType]]">
 					{{item.alertMessage}}
@@ -129,7 +129,7 @@
 			</d2l-all-courses>
 			<d2l-loading-spinner
 				id="lazyLoadSpinner"
-				class="hidden"
+				class="d2l-my-courses-hidden"
 				size="100">
 			</d2l-loading-spinner>
 		</d2l-simple-overlay>
@@ -214,8 +214,8 @@
 				this._pinnedCoursesMap = {};
 				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
 
-				this.toggleClass('hidden', true, this.$.courseTiles);
-				this.toggleClass('hidden', true, this.$.courseList);
+				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseTiles);
+				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseList);
 			},
 			attached: function() {
 				if (!this.delayLoad) {
@@ -298,7 +298,7 @@
 					this.fire('recalculate-columns');
 				}
 
-				this.toggleClass('hidden', true, this.$.lazyLoadSpinner);
+				this.toggleClass('d2l-my-courses-hidden', true, this.$.lazyLoadSpinner);
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this._showContent();
 			},
@@ -324,8 +324,8 @@
 				document.location.reload(true);
 			},
 			_showContent: function() {
-				this.toggleClass('hidden', true, this.$.initialLoadingSpinner);
-				this.toggleClass('hidden', false, this.$$('.my-courses-content'));
+				this.toggleClass('d2l-my-courses-hidden', true, this.$.initialLoadingSpinner);
+				this.toggleClass('d2l-my-courses-hidden', false, this.$$('.my-courses-content'));
 			},
 			_loadNextEnrollmentsPage: function() {
 				if (this.$['all-courses'].opened && this._lastEnrollmentsSearchResponse) {
@@ -335,7 +335,7 @@
 					if (lastResponseEntity.hasLink('next')) {
 						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
 						this.$.enrollmentsSearchRequest.generateRequest();
-						this.toggleClass('hidden', false, this.$.lazyLoadSpinner);
+						this.toggleClass('d2l-my-courses-hidden', false, this.$.lazyLoadSpinner);
 						this.$.lazyLoadSpinner.scrollIntoView();
 					}
 				}

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -54,7 +54,7 @@
 				margin-bottom: 30px;
 			}
 
-			#lazyLoadSpinner.hidden {
+			#lazyLoadSpinner.d2l-basic-image-selector-hidden {
 				display: none;
 			}
 		</style>
@@ -158,7 +158,7 @@
 				_nextDefaultResultPage: String,
 				_loadingSpinnerClass: {
 					type: String,
-					value: 'hidden'
+					value: 'd2l-basic-image-selector-hidden'
 				},
 				_telemetryEvent: String
 			},
@@ -233,7 +233,7 @@
 				this._nextSearchResultPage = null;
 			},
 			_onImagesRequestResponse: function(response, loadMore, isDefault) {
-				this._loadingSpinnerClass = 'hidden';
+				this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
 				if (response.detail.status !== 200) {
 					return;
 				}
@@ -321,7 +321,7 @@
 			},
 			loadMore: function() {
 				if (!this._showGrid) {
-					this._loadingSpinnerClass = 'hidden';
+					this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
 					return;
 				}
 
@@ -334,7 +334,7 @@
 					this.$.lazyLoadSpinner.scrollIntoView();
 					this.$.moreDefaultImagesRequest.generateRequest();
 				} else {
-					this._loadingSpinnerClass = 'hidden';
+					this._loadingSpinnerClass = 'd2l-basic-image-selector-hidden';
 				}
 			},
 			_moreDefaultImagesRequestResponse: function(response) {

--- a/image-selector/d2l-image-selector-tile.html
+++ b/image-selector/d2l-image-selector-tile.html
@@ -11,7 +11,7 @@
 <dom-module id="d2l-image-selector-tile">
 	<template>
 		<style include="d2l-image-selector-tile-styles">
-			.hidden {
+			.d2l-image-selector-tile-hidden {
 				opacity: 0;
 			}
 
@@ -137,7 +137,7 @@
 			},
 			_updateImageSource: function() {
 				var courseImage = Polymer.dom(this.root).querySelector('img');
-				this._imageClass = 'hidden';
+				this._imageClass = 'd2l-image-selector-tile-hidden';
 				Polymer.dom(courseImage).setAttribute('srcset', this.getImageSrcset(this.image, 'narrow'));
 				Polymer.dom(courseImage).setAttribute('sizes', '(max-width: 767px) 100vw, (max-width: 991px) and (min-width: 768px) 50vw, 33vw');
 			},

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -81,13 +81,13 @@ describe('d2l-all-courses', function() {
 	it('should hide filter menu when there are insufficient enrollments', function() {
 		widget.pinnedEnrollments = Array(19).fill(pinnedEnrollmentEntity);
 		widget.load();
-		expect(widget.$.filterAndSort.classList.contains('hidden')).to.be.true;
+		expect(widget.$.filterAndSort.classList.contains('d2l-all-courses-hidden')).to.be.true;
 	});
 
 	it('should show filter menu when there are sufficient enrollments', function() {
 		widget.pinnedEnrollments = Array(20).fill(pinnedEnrollmentEntity);
 		widget.load();
-		expect(widget.$.filterAndSort.classList.contains('hidden')).to.be.false;
+		expect(widget.$.filterAndSort.classList.contains('d2l-all-courses-hidden')).to.be.false;
 	});
 
 	describe('d2l-filter-menu-content-filters-changed', function() {

--- a/test/d2l-basic-image-selector/d2l-basic-image-selector.js
+++ b/test/d2l-basic-image-selector/d2l-basic-image-selector.js
@@ -99,12 +99,12 @@ describe('<d2l-course-tile>', function() {
 			widget._showGrid = false;
 			widget._nextSearchResultPage = 'http://test.com';
 			widget.loadMore();
-			expect(widget._loadingSpinnerClass).to.equal('hidden');
+			expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
 		});
 
 		it('hides the spinner when no response is generated', function() {
 			widget.loadMore();
-			expect(widget._loadingSpinnerClass).to.equal('hidden');
+			expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
 			expect(widget.$.moreSearchImagesRequest.generateRequest.called).to.equal(false);
 			expect(widget.$.moreDefaultImagesRequest.generateRequest.called).to.equal(false);
 		});
@@ -185,13 +185,13 @@ describe('<d2l-course-tile>', function() {
 					detail: { status: 500 }
 				};
 				widget._onImagesRequestResponse(badResponse, false, false);
-				expect(widget._loadingSpinnerClass).to.equal('hidden');
+				expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
 			});
 		});
 
 		it('hides the loading spinner', function() {
 			widget._onImagesRequestResponse(response, false, false);
-			expect(widget._loadingSpinnerClass).to.equal('hidden');
+			expect(widget._loadingSpinnerClass).to.equal('d2l-basic-image-selector-hidden');
 		});
 
 		describe('and loadMore is true', function() {


### PR DESCRIPTION
Happened recently that some Bootstrap CSS overwrote ours due to a naughty !important. Renaming "hidden" and "invisible" class names to hopefully prevent that sort of thing happening again.