### PR TITLE
animate the alerts and delay image failure

### DIFF
--- a/d2l-alert.html
+++ b/d2l-alert.html
@@ -7,6 +7,7 @@
 		<style include="d2l-typography-shared-styles">
 			:host {
 				@apply(--d2l-body-small-text);
+				animation: 600ms ease drop-in;
 			}
 			.message-wrapper {
 				position: relative;
@@ -49,6 +50,17 @@
 				border-top-right-radius: 3px;
 				border-bottom-right-radius: 3px;
 			}
+			@keyframes drop-in {
+				from {
+					transform: translate(0,-10px);
+					opacity: 0.0;
+				}
+				to {
+					transform: translate(0,0);
+					opacity: 1;
+				}
+			}
+		}
 		</style>
 		<div class="message-wrapper">
 			<div class="message-highlight"></div>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -292,7 +292,9 @@
 				this._removeAlert('setCourseImageFailure');
 				if (details && details.detail) {
 					if (details.detail.status === 'failure') {
-						this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+						setTimeout(function() {
+							this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 					}
 				}
 				this.$$('#all-courses-pinned').setCourseImage(details);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -344,7 +344,9 @@
 				this._removeAlert('setCourseImageFailure');
 				if (e && e.detail) {
 					if (e.detail.status === 'failure') {
-						this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+						setTimeout(function() {
+							this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 					}
 				}
 				this.$$('d2l-all-courses').setCourseImage(e);

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -1,11 +1,12 @@
-/* global describe, it, beforeEach, fixture, expect, sinon */
+/* global describe, it, beforeEach, afterEach, fixture, expect, sinon */
 
 'use strict';
 
 describe('d2l-all-courses', function() {
 	var widget,
 		pinnedEnrollmentEntity,
-		unpinnedEnrollmentEntity;
+		unpinnedEnrollmentEntity,
+		clock;
 
 	beforeEach(function() {
 		var parser = document.createElement('d2l-siren-parser');
@@ -31,7 +32,14 @@ describe('d2l-all-courses', function() {
 				href: '/organizations/123'
 			}]
 		});
+
+		clock = sinon.useFakeTimers();
+
 		widget = fixture('d2l-all-courses-fixture');
+	});
+
+	afterEach(function() {
+		clock.restore;
 	});
 
 	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {
@@ -148,6 +156,7 @@ describe('d2l-all-courses', function() {
 		it('should add a setCourseImageFailure warning alert when a request to set the image fails', function() {
 			var setCourseImageEvent = { detail: { status: 'failure'} };
 			widget.setCourseImage(setCourseImageEvent);
+			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
 		});
 
@@ -160,6 +169,7 @@ describe('d2l-all-courses', function() {
 		it('should remove a setCourseImageFailure warning alert when a request to set the image is made', function() {
 			var setCourseImageEvent = { detail: { status: 'failure'} };
 			widget.setCourseImage(setCourseImageEvent);
+			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
 			setCourseImageEvent = { detail: { status: 'set'} };
 			widget.setCourseImage(setCourseImageEvent);

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -126,14 +126,18 @@ describe('d2l-my-courses', function() {
 			}]
 		};
 
+	var clock;
+
 	beforeEach(function() {
 		server = sinon.fakeServer.create();
 		server.respondImmediately = true;
+		clock = sinon.useFakeTimers();
 
 		widget = fixture('d2l-my-courses-fixture');
 	});
 
 	afterEach(function() {
+		clock.restore();
 		server.restore();
 	});
 
@@ -392,6 +396,7 @@ describe('d2l-my-courses', function() {
 		it('should add a setCourseImageFailure warning alert when a request to set the image fails', function() {
 			var setCourseImageEvent = { detail: { status: 'failure'} };
 			widget._setCourseImageEvent(setCourseImageEvent);
+			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
 		});
 
@@ -404,6 +409,7 @@ describe('d2l-my-courses', function() {
 		it('should remove a setCourseImageFailure warning alert when a request to set the image is made', function() {
 			var setCourseImageEvent = { detail: { status: 'failure'} };
 			widget._setCourseImageEvent(setCourseImageEvent);
+			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
 			setCourseImageEvent = { detail: { status: 'set'} };
 			widget._setCourseImageEvent(setCourseImageEvent);
@@ -412,20 +418,19 @@ describe('d2l-my-courses', function() {
 	});
 
 	describe('User interaction', function() {
-		it('should rescale the all courses view when it is opened', function(done) {
+		it('should rescale the all courses view when it is opened', function() {
 			var allCoursesRescaleSpy = sinon.spy(widget.$$('d2l-all-courses'), '_rescaleCourseTileRegions');
 
 			widget.$$('button').click();
 
-			setTimeout(function() {
-				expect(allCoursesRescaleSpy.called);
-				widget.$$('d2l-all-courses')._rescaleCourseTileRegions.restore();
-				done();
-			}, 100);
+			clock.tick(100);
+			expect(allCoursesRescaleSpy.called);
+			widget.$$('d2l-all-courses')._rescaleCourseTileRegions.restore();
 		});
 
 		it('should remove a setCourseImageFailure alert when the all-courses overlay is closed', function() {
 			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
+			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
 			widget.$['all-courses']._handleClose();
 			expect(widget._alerts).to.not.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });


### PR DESCRIPTION
Bob requested two things:
1) the warning alert should not show up until the animation on the tile also does (and that one waits one second before turning into the X); and
2) the alerts should animate in, sort of 'dropping' into place similar to how the dropdown content does if you click on the little bell up in the main brightspace nav bar.