### PR TITLE
US78151 - TA108231 Break out d2l-list-item-filter

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -12,7 +12,7 @@
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
-<link rel="import" href="d2l-filter-menu-content.html">
+<link rel="import" href="d2l-filter-menu-content/d2l-filter-menu-content.html">
 <link rel="import" href="d2l-search-widget-custom.html">
 <link rel="import" href="localize-behavior.html">
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -115,7 +115,7 @@
 			}
 		</style>
 
-		<div class="search-and-filter d2l-all-courses-hidden">
+		<div class="search-and-filter">
 			<d2l-search-widget-custom
 				hidden$="[[!_hasEnrollments]]"
 				my-enrollments-entity="[[myEnrollmentsEntity]]"

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -336,7 +336,7 @@
 			},
 			_onLowerThreshold: function() {
 				this.$.scrollThreshold.clearTriggers();
-				this.$.filterMenuContent._loadMore();
+				this.$.filterMenuContent.loadMore();
 			},
 			_onResize: function() {
 				this._updateTileSizes();

--- a/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content.html
@@ -322,6 +322,15 @@
 				this.$.semesterSearchWidget.search();
 				this._selectSemesterList();
 			},
+			loadMore: function() {
+				// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
+				// Generate the request based off of which tab is selected, and whether there are more to load or not
+				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden') && this._hasMoreDepartments) {
+					this.$.moreDepartmentsRequest.generateRequest();
+				} else if (this._hasMoreSemesters) {
+					this.$.moreSemestersRequest.generateRequest();
+				}
+			},
 			_parser: null,
 			_checkSelected: function(entity) {
 				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
@@ -344,18 +353,6 @@
 				this.set('filterText', this.localize('filtering.filter'));
 				this.set('_numSemesterFilters', 0);
 				this.set('_numDepartmentFilters', 0);
-			},
-			_loadMore: function() {
-				// Generate the request based off of which tab is selected, and whether there are more to load or not
-				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden')) {
-					if (this._hasMoreDepartments) {
-						this.$.moreDepartmentsRequest.generateRequest();
-					}
-				} else {
-					if (this._hasMoreSemesters) {
-						this.$.moreSemestersRequest.generateRequest();
-					}
-				}
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -4,93 +4,10 @@
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="../../d2l-menu/d2l-menu.html">
-<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-behavior.html">
-<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-styles.html">
 <link rel="import" href="../../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../localize-behavior.html">
-
-<dom-module id="d2l-list-item-filter">
-	<template>
-		<style include="d2l-menu-item-selectable-styles">
-			:host {
-				padding: 0.5rem 1rem;
-			}
-
-			:host > span {
-				font-size: 0.8rem;
-			}
-
-			:host d2l-icon {
-				--d2l-icon-height: 1rem;
-				--d2l-icon-width: 1rem;
-				visibility: visible;
-				margin-right: 0.5rem;
-			}
-		</style>
-		<d2l-ajax
-			auto
-			url="[[_organizationUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onOrganizationResponse">
-		</d2l-ajax>
-		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
-		<span>[[text]]</span>
-	</template>
-	<script>
-		'use strict';
-		Polymer({
-			is: 'd2l-list-item-filter',
-			properties: {
-				enrollmentEntity: {
-					type: Object,
-					observer: '_onEnrollmentEntityChanged'
-				},
-				selected: {
-					type: Boolean,
-					observer: '_onSelectedChanged',
-					reflectToAttribute: true
-				},
-				_organizationUrl: String
-			},
-			behaviors: [
-				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
-			],
-			attached: function() {
-				Polymer.RenderStatus.afterNextRender(this, function() {
-					this.listen(this, 'd2l-menu-item-select', '_onSelect');
-				}.bind(this));
-			},
-			_onEnrollmentEntityChanged: function(entity) {
-				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
-					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
-				}
-			},
-			_onOrganizationResponse: function(response) {
-				if (response.detail.status === 200 ) {
-					if (!this._parser) {
-						this._parser = document.createElement('d2l-siren-parser');
-					}
-
-					var entity = this._parser.parse(response.detail.xhr.response);
-
-					this.set('text', entity.properties.name);
-					this.set('value', entity.getLinkByRel('self').href);
-				}
-			},
-			_onSelect: function(e) {
-				this.set('selected', !this.selected);
-				this.__onSelect(e);
-			},
-			_onSelectedChanged: function(e) {
-				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
-				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
-				this.__onSelectedChanged(e);
-			},
-			_parser: null
-		});
-	</script>
-</dom-module>
+<link rel="import" href="d2l-list-item-filter.html">
 
 <dom-module is="d2l-filter-menu-content">
 	<template>

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -1,14 +1,14 @@
-<link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
-<link rel="import" href="../d2l-colors/d2l-colors.html">
-<link rel="import" href="../d2l-icons/d2l-icons.html">
-<link rel="import" href="../d2l-menu/d2l-menu.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-behavior.html">
-<link rel="import" href="../d2l-menu/d2l-menu-item-selectable-styles.html">
-<link rel="import" href="../d2l-search-widget/d2l-search-widget.html">
-<link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
-<link rel="import" href="localize-behavior.html">
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-icons/d2l-icons.html">
+<link rel="import" href="../../d2l-menu/d2l-menu.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-behavior.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-styles.html">
+<link rel="import" href="../../d2l-search-widget/d2l-search-widget.html">
+<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../localize-behavior.html">
 
 <dom-module id="d2l-list-item-filter">
 	<template>

--- a/d2l-filter-menu-content/d2l-list-item-filter.html
+++ b/d2l-filter-menu-content/d2l-list-item-filter.html
@@ -1,0 +1,88 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-icons/d2l-icons.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-behavior.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-styles.html">
+<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+
+<dom-module id="d2l-list-item-filter">
+	<template>
+		<style include="d2l-menu-item-selectable-styles">
+			:host {
+				padding: 0.5rem 1rem;
+			}
+
+			:host > span {
+				font-size: 0.8rem;
+			}
+
+			:host d2l-icon {
+				--d2l-icon-height: 1rem;
+				--d2l-icon-width: 1rem;
+				visibility: visible;
+				margin-right: 0.5rem;
+			}
+		</style>
+		<d2l-ajax
+			auto
+			url="[[_organizationUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onOrganizationResponse">
+		</d2l-ajax>
+		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
+		<span>[[text]]</span>
+	</template>
+	<script>
+		'use strict';
+		Polymer({
+			is: 'd2l-list-item-filter',
+			properties: {
+				enrollmentEntity: {
+					type: Object,
+					observer: '_onEnrollmentEntityChanged'
+				},
+				selected: {
+					type: Boolean,
+					observer: '_onSelectedChanged',
+					reflectToAttribute: true
+				},
+				_organizationUrl: String
+			},
+			behaviors: [
+				window.D2L.PolymerBehaviors.MenuItemSelectableBehavior
+			],
+			attached: function() {
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					this.listen(this, 'd2l-menu-item-select', '_onSelect');
+				}.bind(this));
+			},
+			_onEnrollmentEntityChanged: function(entity) {
+				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
+					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
+				}
+			},
+			_onOrganizationResponse: function(response) {
+				if (response.detail.status === 200 ) {
+					if (!this._parser) {
+						this._parser = document.createElement('d2l-siren-parser');
+					}
+
+					var entity = this._parser.parse(response.detail.xhr.response);
+
+					this.set('text', entity.properties.name);
+					this.set('value', entity.getLinkByRel('self').href);
+				}
+			},
+			_onSelect: function(e) {
+				this.set('selected', !this.selected);
+				this.__onSelect(e);
+			},
+			_onSelectedChanged: function(e) {
+				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
+				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
+				this.__onSelectedChanged(e);
+			},
+			_parser: null
+		});
+	</script>
+</dom-module>

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -6,7 +6,7 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../d2l-filter-menu-content.html">
+		<link rel="import" href="../../d2l-filter-menu-content/d2l-filter-menu-content.html">
 	</head>
 	<body>
 		<test-fixture id="d2l-filter-menu-content-fixture">

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -46,57 +46,6 @@ describe('d2l-filter-menu-content', function() {
 		expect(widget._searchSemestersAction.href).to.equal('/enrollments');
 	});
 
-	describe('d2l-list-item-filter', function() {
-		var listItem;
-
-		beforeEach(function() {
-			listItem = fixture('d2l-list-item-filter-fixture');
-		});
-
-		it('should change icon when selected state changes', function() {
-			expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box-unchecked');
-
-			listItem.set('selected', true);
-
-			expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box');
-		});
-
-		it('should fetch the organization when the enrollment changes', function() {
-			var stub = sinon.stub(listItem.$$('d2l-ajax'), 'generateRequest');
-
-			listItem.set('enrollmentEntity', parser.parse(enrollment));
-
-			expect(stub.called).to.be.true;
-			expect(listItem._organizationUrl).to.equal('/organizations/1');
-		});
-
-		it('should update text and value based off of organizations response', function(done) {
-			var server = sinon.fakeServer.create();
-			server.respondImmediately = true;
-			server.respondWith(
-				'GET',
-				'/organizations/1',
-				[200, '{}', JSON.stringify({
-					properties: {
-						name: 'foo'
-					},
-					links: [{
-						rel: ['self'],
-						href: 'bar'
-					}]
-				})]);
-
-			listItem.set('enrollmentEntity', parser.parse(enrollment));
-
-			setTimeout(function() {
-				expect(listItem.text).to.equal('foo');
-				expect(listItem.value).to.equal('bar');
-				server.restore();
-				done();
-			});
-		});
-	});
-
 	describe('Visibility', function() {
 		it('should signal that it should be hidden if user does not have enough departments/semesters', function(done) {
 			var handler = function(e) {

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -276,14 +276,14 @@ describe('d2l-filter-menu-content', function() {
 			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
 			widget._selectDepartmentList();
 
-			widget._loadMore();
+			widget.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.false;
 
 			widget.set('_hasMoreDepartments', true);
 
-			widget._loadMore();
+			widget.loadMore();
 
 			expect(departmentStub.called).to.be.true;
 			expect(semesterStub.called).to.be.false;
@@ -294,14 +294,14 @@ describe('d2l-filter-menu-content', function() {
 			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
 			widget._selectSemesterList();
 
-			widget._loadMore();
+			widget.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.false;
 
 			widget.set('_hasMoreSemesters', true);
 
-			widget._loadMore();
+			widget.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.true;

--- a/test/d2l-filter-menu-content/d2l-list-item-filter.html
+++ b/test/d2l-filter-menu-content/d2l-list-item-filter.html
@@ -6,15 +6,15 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../d2l-filter-menu-content/d2l-filter-menu-content.html">
+		<link rel="import" href="../../d2l-filter-menu-content/d2l-list-item-filter.html">
 	</head>
 	<body>
-		<test-fixture id="d2l-filter-menu-content-fixture">
+		<test-fixture id="d2l-list-item-filter-fixture">
 			<template>
-				<d2l-filter-menu-content></d2l-filter-menu-content>
+				<d2l-list-item-filter></d2l-list-item-filter>
 			</template>
 		</test-fixture>
 
-		<script src="d2l-filter-menu-content.js"></script>
+		<script src="d2l-list-item-filter.js"></script>
 	</body>
 </html>

--- a/test/d2l-filter-menu-content/d2l-list-item-filter.js
+++ b/test/d2l-filter-menu-content/d2l-list-item-filter.js
@@ -1,0 +1,67 @@
+/* global describe, it, beforeEach, fixture, expect, sinon */
+
+'use strict';
+
+var listItem,
+	enrollment,
+	parser;
+
+beforeEach(function() {
+	parser = document.createElement('d2l-siren-parser');
+	enrollment = {
+		rel: ['enrollment'],
+		links: [{
+			rel: ['self'],
+			href: '/enrollments'
+		}, {
+			rel: ['/organization'],
+			href: '/organizations/1'
+		}]
+	};
+	listItem = fixture('d2l-list-item-filter-fixture');
+});
+
+describe('d2l-list-item-filter', function() {
+	it('should change icon when selected state changes', function() {
+		expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box-unchecked');
+
+		listItem.set('selected', true);
+
+		expect(listItem.$$('d2l-icon').icon).to.equal('d2l-tier2:check-box');
+	});
+
+	it('should fetch the organization when the enrollment changes', function() {
+		var stub = sinon.stub(listItem.$$('d2l-ajax'), 'generateRequest');
+
+		listItem.set('enrollmentEntity', parser.parse(enrollment));
+
+		expect(stub.called).to.be.true;
+		expect(listItem._organizationUrl).to.equal('/organizations/1');
+	});
+
+	it('should update text and value based off of organizations response', function(done) {
+		var server = sinon.fakeServer.create();
+		server.respondImmediately = true;
+		server.respondWith(
+			'GET',
+			'/organizations/1',
+			[200, '{}', JSON.stringify({
+				properties: {
+					name: 'foo'
+				},
+				links: [{
+					rel: ['self'],
+					href: 'bar'
+				}]
+			})]);
+
+		listItem.set('enrollmentEntity', parser.parse(enrollment));
+
+		setTimeout(function() {
+			expect(listItem.text).to.equal('foo');
+			expect(listItem.value).to.equal('bar');
+			server.restore();
+			done();
+		});
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
 				'./d2l-course-tile/d2l-course-tile.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
 				'./d2l-filter-menu-content/d2l-filter-menu-content.html',
+				'./d2l-filter-menu-content/d2l-list-item-filter.html',
 				'./d2l-image-selector-tile/d2l-image-selector-tile.html',
 				'./d2l-my-courses/d2l-my-courses.html',
 				'./d2l-touch-menu-item/d2l-touch-menu-item.html',


### PR DESCRIPTION
This is a bit of precursor work to creating the simplified filter menu view. The only noticeable effect should be that I un-hid the search/filter stuff.

I moved `d2l-filter-menu-content` into a folder, and broke out `d2l-list-item-filter` from it into its own file (and updated tests/links accordingly). Just wanted to do this large-but-no-real-change diff separately, so that the real change(s) are nicer to code review/test.

Acceptance Criteria/risks:

- Filter/search is visible again
- Filter menu still loads content normally
- Filter menu still has tabbed view, and lists departments and semesters in separate tabs
- Not really much risk 😐 Pretty sure this either works, or a bunch of errors would happen due to misaligned directories/import paths

@jstefaniuk-d2l [called it.](https://github.com/Brightspace/d2l-my-courses-ui/pull/207#discussion_r88941050)
