### PR TITLE
US78151 - TA108233 Refactor d2l-filter-menu-content

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -525,19 +525,17 @@
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 
 				window.addEventListener('resize', this._onResize.bind(this));
-
-				this._parser = document.createElement('d2l-siren-parser');
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-filters-changed', '_onFilterChanged');
+				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 			},
 			getCourseTileItemCount: function() {
@@ -590,7 +588,6 @@
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
 			_filterDropdownOpen: false,
-			_parser: null,
 			_sortTextOptions: {
 				'courseCode': 'sorting.sortCourseCode',
 				'courseName': 'sorting.sortCourseName',
@@ -608,7 +605,7 @@
 				this.toggleClass('focus', true, this.$.filterText);
 			},
 			_onFilterChanged: function(e) {
-				this.set('_parentOrganizations', e.detail.value);
+				this.set('_parentOrganizations', e.detail.filters);
 				this.set('_filterText', e.detail.text);
 			},
 			_onFilterDropdownClose: function() {

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -1,0 +1,336 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-icons/d2l-icons.html">
+<link rel="import" href="../../d2l-menu/d2l-menu.html">
+<link rel="import" href="../../d2l-search-widget/d2l-search-widget.html">
+<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../localize-behavior.html">
+<link rel="import" href="d2l-list-item-filter.html">
+
+<dom-module is="d2l-filter-menu-content-tabbed">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+			.d2l-filter-menu-content-invisible {
+				visibility: hidden;
+			}
+			.d2l-filter-menu-content-hidden {
+				display: none !important;
+			}
+			button:hover,
+			button:focus {
+				text-decoration: underline;
+				color: var(--d2l-color-celestine);
+			}
+			.dropdown-content-gradient {
+				background: linear-gradient(to top, white, var(--d2l-color-regolith));
+			}
+			.dropdown-content-tabs {
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+			}
+			.dropdown-content-tab {
+				flex: 1;
+			}
+			.dropdown-content-tab-button {
+				@apply(--d2l-body-small-text);
+				color: var(--d2l-color-ferrite);
+				background: none;
+				border: none;
+				padding: 10px;
+				cursor: pointer;
+				display: inherit;
+			}
+			.dropdown-content-tab-highlight {
+				background-color: var(--d2l-color-celestine);
+				border-bottom-left-radius: 4px;
+				border-bottom-right-radius: 4px;
+				height: 4px;
+				width: 80%;
+				margin: auto;
+			}
+			d2l-search-widget {
+				--d2l-search-widget-height: 45px;
+				margin: 10px 20px;
+			}
+		</style>
+
+		<d2l-ajax
+			id="moreDepartmentsRequest"
+			url="[[_moreDepartmentsUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreDepartmentsResponse">
+		</d2l-ajax>
+
+		<d2l-ajax
+			id="moreSemestersRequest"
+			url="[[_moreSemestersUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onMoreSemestersResponse">
+		</d2l-ajax>
+
+		<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
+			<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
+				<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
+				<button
+					id="semesterListButton"
+					class="dropdown-content-tab-button"
+					on-tap="_selectSemesterList"
+					aria-pressed="true">
+					{{localize('filtering.semester')}}
+				</button>
+			</div>
+			<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
+				<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
+				<button
+					id="departmentListButton"
+					class="dropdown-content-tab-button"
+					on-tap="_selectDepartmentList"
+					aria-pressed="false">
+					{{localize('filtering.department')}}
+				</button>
+			</div>
+		</div>
+		<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
+			<d2l-search-widget
+				id="semesterSearchWidget"
+				placeholder-text="{{localize('filtering.searchSemesters')}}"
+				search-action="[[_searchSemestersAction]]"
+				search-field-name="search"
+				cache-responses></d2l-search-widget>
+			<d2l-menu label="{{localize('filtering.semester')}}">
+				<template is="dom-repeat" items="[[_semesters]]">
+					<d2l-list-item-filter
+						enrollment-entity="[[item]]"
+						selected="[[_checkSelected(item)]]">
+					</d2l-list-item-filter>
+				</template>
+			</d2l-menu>
+		</div>
+		<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
+			<d2l-search-widget
+				id="departmentSearchWidget"
+				placeholder-text="{{localize('filtering.searchDepartments')}}"
+				search-action="[[_searchDepartmentsAction]]"
+				search-field-name="search"
+				cache-responses></d2l-search-widget>
+			<d2l-menu label="{{localize('filtering.department')}}">
+				<template is="dom-repeat" items="[[_departments]]">
+					<d2l-list-item-filter
+						enrollment-entity="[[item]]"
+						selected="[[_checkSelected(item)]]">
+					</d2l-list-item-filter>
+				</template>
+			</d2l-menu>
+		</div>
+	</template>
+
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-filter-menu-content-tabbed',
+			properties: {
+				myEnrollmentsEntity: {
+					type: Object,
+					value: function() { return {}; },
+					observer: '_myEnrollmentsEntityChanged'
+				},
+				_currentFilters: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_departments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_hasMoreDepartments: {
+					type: Boolean,
+					value: false
+				},
+				_hasMoreSemesters: {
+					type: Boolean,
+					value: false
+				},
+				_moreDepartmentsUrl: {
+					type: String,
+					value: ''
+				},
+				_moreSemestersUrl: {
+					type: String,
+					value: ''
+				},
+				_numSemesterFilters: {
+					type: Number,
+					value: 0,
+					observer: '_numFiltersChanged'
+				},
+				_numDepartmentFilters: {
+					type: Number,
+					value: 0,
+					observer: '_numFiltersChanged'
+				},
+				_searchSemestersAction: Object,
+				_searchDepartmentsAction: Object,
+				_semesters: {
+					type: Array,
+					value: function() { return []; }
+				}
+			},
+			behaviors: [
+				window.D2L.MyCourses.LocalizeBehavior
+			],
+			attached: function() {
+				this.listen(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
+				this.listen(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
+				this.listen(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
+				this.listen(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+			},
+			detached: function() {
+				this.unlisten(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
+				this.unlisten(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
+				this.unlisten(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
+				this.unlisten(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+			},
+			load: function() {
+				this.$.departmentSearchWidget.search();
+				this.$.semesterSearchWidget.search();
+				this._selectSemesterList();
+			},
+			loadMore: function() {
+				// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
+				// Generate the request based off of which tab is selected, and whether there are more to load or not
+				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden') && this._hasMoreDepartments) {
+					this.$.moreDepartmentsRequest.generateRequest();
+				} else if (this._hasMoreSemesters) {
+					this.$.moreSemestersRequest.generateRequest();
+				}
+			},
+			__parser: null,
+			_parser: function() {
+				if (!this.__parser) {
+					this.__parser = document.createElement('d2l-siren-parser');
+				}
+				return this.__parser;
+			},
+			_checkSelected: function(entity) {
+				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
+				var id = entity.getLinkByRel(/\/organization$/).href;
+				return this._currentFilters.indexOf(id) > -1;
+			},
+			_clearFilters: function() {
+				this.$.departmentList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
+					item.selected = false;
+				});
+				this.$.semesterList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
+					item.selected = false;
+				});
+
+				// Clear button is removed via dom-if, so need to manually set focus to next element
+				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden')) {
+					this.$.departmentListButton.focus();
+				} else {
+					this.$.semesterListButton.focus();
+				}
+
+				this.set('_currentFilters', []);
+				this.set('_numSemesterFilters', 0);
+				this.set('_numDepartmentFilters', 0);
+			},
+			_myEnrollmentsEntityChanged: function(entity) {
+				// Set up search URLs and search Actions for filter dropdown
+				if (entity) {
+					var myEnrollmentsEntity = this._parser().parse(entity);
+
+					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
+					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
+				}
+			},
+			_numFiltersChanged: function() {
+				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
+					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
+					: this.localize('filtering.semester');
+				this.$.departmentListButton.textContent = this._numDepartmentFilters > 0
+					? this.localize('filtering.departmentMultiple', 'num', this._numDepartmentFilters)
+					: this.localize('filtering.department');
+
+				this.fire('d2l-filter-menu-content-filters-changed', {
+					filters: this._currentFilters
+				});
+			},
+			__onSearchResults: function(entity, moreUrlPath, hasMorePath) {
+				if (!entity.hasLinkByRel) {
+					entity = this._parser().parse(entity);
+				}
+
+				this.set(hasMorePath, entity.hasLinkByRel('next'));
+				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
+			},
+			_onDepartmentSearchResults: function(e) {
+				this.set('_departments', e.detail.entities);
+				this.__onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
+			},
+			_onSemesterSearchResults: function(e) {
+				this.set('_semesters', e.detail.entities);
+				this.__onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
+			},
+			__onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var responseEntity = this._parser().parse(response.detail.xhr.response);
+
+					responseEntity.entities.forEach(function(entity) {
+						this.push(organizationsPath, entity);
+					}.bind(this));
+
+					this.__onSearchResults(responseEntity, moreUrlPath, hasMorePath);
+				}
+			},
+			_onMoreDepartmentsResponse: function(response) {
+				this.__onMoreResponse(response, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
+			},
+			_onMoreSemestersResponse: function(response) {
+				this.__onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
+			},
+			__toggleSelectedList: function(list, button, highlight, selected) {
+				this.toggleClass('d2l-filter-menu-content-hidden', !selected, list);
+				this.toggleClass('d2l-filter-menu-content-invisible', !selected, highlight);
+				button.setAttribute('aria-pressed', selected);
+			},
+			_selectDepartmentList: function() {
+				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
+				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
+				this.$.departmentList.querySelector('d2l-menu').resize();
+			},
+			_selectSemesterList: function() {
+				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
+				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
+				this.$.semesterList.querySelector('d2l-menu').resize();
+			},
+			__updateFilter: function(e, path) {
+				if (e.detail.selected) {
+					this.push('_currentFilters', e.detail.value);
+					this.set(path, this[path] + 1);
+				} else {
+					var index = this._currentFilters.indexOf(e.detail.value);
+					this.splice('_currentFilters', index, 1);
+					this.set(path, this[path] - 1);
+				}
+			},
+			_updateDepartmentFilter: function(e) {
+				this.__updateFilter(e, '_numDepartmentFilters');
+			},
+			_updateSemesterFilter: function(e) {
+				this.__updateFilter(e, '_numSemesterFilters');
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -1,13 +1,11 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../../d2l-icons/d2l-icons.html">
-<link rel="import" href="../../d2l-menu/d2l-menu.html">
-<link rel="import" href="../../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-list-item-filter.html">
+<link rel="import" href="d2l-filter-menu-content-tabbed.html">
 
 <dom-module is="d2l-filter-menu-content">
 	<template>
@@ -48,52 +46,20 @@
 			.dropdown-content-header-text {
 				font-weight: bold;
 			}
-			.dropdown-content-gradient {
-				background: linear-gradient(to top, white, var(--d2l-color-regolith));
-			}
-			.dropdown-content-tabs {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-			}
-			.dropdown-content-tab {
-				flex: 1;
-			}
-			.dropdown-content-tab-button {
-				@apply(--d2l-body-small-text);
-				color: var(--d2l-color-ferrite);
-				background: none;
-				border: none;
-				padding: 10px;
-				cursor: pointer;
-				display: inherit;
-			}
-			.dropdown-content-tab-highlight {
-				background-color: var(--d2l-color-celestine);
-				border-bottom-left-radius: 4px;
-				border-bottom-right-radius: 4px;
-				height: 4px;
-				width: 80%;
-				margin: auto;
-			}
-			d2l-search-widget {
-				--d2l-search-widget-height: 45px;
-				margin: 10px 20px;
-			}
 		</style>
 
 		<d2l-ajax
-			id="moreDepartmentsRequest"
-			url="[[_moreDepartmentsUrl]]"
+			id="departmentsRequest"
+			url="[[_departmentsUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onMoreDepartmentsResponse">
+			on-iron-ajax-response="_onDepartmentsResponse">
 		</d2l-ajax>
 
 		<d2l-ajax
-			id="moreSemestersRequest"
-			url="[[_moreSemestersUrl]]"
+			id="semestersRequest"
+			url="[[_semestersUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onMoreSemestersResponse">
+			on-iron-ajax-response="_onSemestersResponse">
 		</d2l-ajax>
 
 		<div class="dropdown-content-header">
@@ -102,60 +68,10 @@
 				<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 			</template>
 		</div>
-		<div class="dropdown-content-tabs dropdown-content-gradient" role="tablist">
-			<div class="dropdown-content-tab" role="tab" aria-controls="semesterList">
-				<div class="dropdown-content-tab-highlight" id="semesterListHighlight"></div>
-				<button
-					id="semesterListButton"
-					class="dropdown-content-tab-button"
-					on-tap="_selectSemesterList"
-					aria-pressed="true">
-					{{localize('filtering.semester')}}
-				</button>
-			</div>
-			<div class="dropdown-content-tab" role="tab" aria-controls="departmentList">
-				<div class="dropdown-content-tab-highlight" id="departmentListHighlight"></div>
-				<button
-					id="departmentListButton"
-					class="dropdown-content-tab-button"
-					on-tap="_selectDepartmentList"
-					aria-pressed="false">
-					{{localize('filtering.department')}}
-				</button>
-			</div>
-		</div>
-		<div id="semesterList" aria-labelledby="semesterListButton" role="tabpanel">
-			<d2l-search-widget
-				id="semesterSearchWidget"
-				placeholder-text="{{localize('filtering.searchSemesters')}}"
-				search-action="[[_searchSemestersAction]]"
-				search-field-name="search"
-				cache-responses></d2l-search-widget>
-			<d2l-menu label="{{localize('filtering.semester')}}">
-				<template is="dom-repeat" items="[[_semesters]]">
-					<d2l-list-item-filter
-						enrollment-entity="[[item]]"
-						selected="[[_checkSelected(item)]]">
-					</d2l-list-item-filter>
-				</template>
-			</d2l-menu>
-		</div>
-		<div id="departmentList" aria-labelledby="departmentListButton" role="tabpanel">
-			<d2l-search-widget
-				id="departmentSearchWidget"
-				placeholder-text="{{localize('filtering.searchDepartments')}}"
-				search-action="[[_searchDepartmentsAction]]"
-				search-field-name="search"
-				cache-responses></d2l-search-widget>
-			<d2l-menu label="{{localize('filtering.department')}}">
-				<template is="dom-repeat" items="[[_departments]]">
-					<d2l-list-item-filter
-						enrollment-entity="[[item]]"
-						selected="[[_checkSelected(item)]]">
-					</d2l-list-item-filter>
-				</template>
-			</d2l-menu>
-		</div>
+		<d2l-filter-menu-content-tabbed
+			id="tabbedContent"
+			my-enrollments-entity="[[myEnrollmentsEntity]]">
+		</d2l-filter-menu-content-tabbed>
 	</template>
 
 	<script>
@@ -178,120 +94,87 @@
 					type: Array,
 					value: function() { return []; }
 				},
-				_hasMoreDepartments: {
-					type: Boolean,
-					value: false
-				},
-				_hasMoreSemesters: {
-					type: Boolean,
-					value: false
-				},
-				_moreDepartmentsUrl: {
-					type: String,
-					value: ''
-				},
-				_moreSemestersUrl: {
-					type: String,
-					value: ''
-				},
-				_numSemesterFilters: {
-					type: Number,
-					value: 0,
-					observer: '_numFiltersChanged'
-				},
-				_numDepartmentFilters: {
-					type: Number,
-					value: 0,
-					observer: '_numFiltersChanged'
-				},
-				_searchSemestersAction: Object,
-				_searchDepartmentsAction: Object,
+				_departmentsUrl: String,
 				_semesters: {
 					type: Array,
 					value: function() { return []; }
 				},
+				_semestersUrl: String,
 				_showClearButton: {
 					type: Boolean,
 					value: false
 				}
 			},
 			behaviors: [
-				window.D2L.MyCourses.LocalizeBehavior
+				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.UtilityBehavior
 			],
 			ready: function() {
-				this._parser = document.createElement('d2l-siren-parser');
 				this.filterText = this.localize('filtering.filter');
 			},
 			attached: function() {
-				this.listen(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
-				this.listen(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
-				this.listen(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
-				this.listen(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+				this.listen(this.$.tabbedContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 			},
 			detached: function() {
-				this.unlisten(this.$.departmentSearchWidget, 'd2l-search-widget-results-changed', '_onDepartmentSearchResults');
-				this.unlisten(this.$.semesterSearchWidget, 'd2l-search-widget-results-changed', '_onSemesterSearchResults');
-				this.unlisten(this.$.departmentList, 'd2l-menu-item-change', '_updateDepartmentFilter');
-				this.unlisten(this.$.semesterList, 'd2l-menu-item-change', '_updateSemesterFilter');
+				this.unlisten(this.$.tabbedContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 			},
 			load: function() {
-				this.$.departmentSearchWidget.search();
-				this.$.semesterSearchWidget.search();
-				this._selectSemesterList();
+				this.$.departmentsRequest.generateRequest();
+				this.$.semestersRequest.generateRequest();
+				this.$.tabbedContent.load();
 			},
 			loadMore: function() {
 				// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
-				// Generate the request based off of which tab is selected, and whether there are more to load or not
-				if (this.$.semesterList.classList.contains('d2l-filter-menu-content-hidden') && this._hasMoreDepartments) {
-					this.$.moreDepartmentsRequest.generateRequest();
-				} else if (this._hasMoreSemesters) {
-					this.$.moreSemestersRequest.generateRequest();
-				}
+				this.$.tabbedContent.loadMore();
 			},
-			_parser: null,
-			_checkSelected: function(entity) {
-				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
-				var id = entity.getLinkByRel(/\/organization$/).href;
-				return this._currentFilters.indexOf(id) > -1;
+			__parser: null,
+			_parser: function() {
+				if (!this.__parser) {
+					this.__parser = document.createElement('d2l-siren-parser');
+				}
+				return this.__parser;
 			},
 			_clearFilters: function() {
-				this.$.departmentList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
-					item.selected = false;
-				});
-				this.$.semesterList.querySelectorAll('d2l-list-item-filter').forEach(function(item) {
-					item.selected = false;
-				});
+				this.$.tabbedContent._clearFilters();
 
 				this._showClearButton = false;
-				// Clear button is removed via dom-if, so need to manually set focus to next element
-				this.$.semesterListButton.focus();
 
 				this.set('_currentFilters', []);
 				this.set('filterText', this.localize('filtering.filter'));
-				this.set('_numSemesterFilters', 0);
-				this.set('_numDepartmentFilters', 0);
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown
-				if (entity) {
-					if (!this._parser) {
-						this.set('_parser', document.createElement('d2l-siren-parser'));
-					}
-					var myEnrollmentsEntity = this._parser.parse(entity);
+				if (entity && entity.actions) {
+					var myEnrollmentsEntity = this._parser().parse(entity);
+					var departmentsAction  = myEnrollmentsEntity.getActionByName('add-department-filter');
+					var semestersAction = myEnrollmentsEntity.getActionByName('add-semester-filter');
 
-					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
-					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
+					this.set('_departmentsUrl', this.createActionUrl(departmentsAction));
+					this.set('_semestersUrl', this.createActionUrl(semestersAction));
 				}
 			},
-			_numFiltersChanged: function() {
-				this._showClearButton = this._currentFilters.length > 0;
+			__onResponse: function(response, path) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var entity = this._parser().parse(response.detail.xhr.response);
+					this.set(path, entity.entities);
 
-				this.$.semesterListButton.textContent = this._numSemesterFilters > 0
-					? this.localize('filtering.semesterMultiple', 'num', this._numSemesterFilters)
-					: this.localize('filtering.semester');
-				this.$.departmentListButton.textContent = this._numDepartmentFilters > 0
-					? this.localize('filtering.departmentMultiple', 'num', this._numDepartmentFilters)
-					: this.localize('filtering.department');
+					this.fire('d2l-filter-menu-content-hide', {
+						hide: this._semesters.length + this._departments.length <= 1
+					});
+
+					// TODO: Use simplified menu for small number of departments/semesters
+				}
+			},
+			_onDepartmentsResponse: function(response) {
+				this.__onResponse(response, '_departments');
+			},
+			_onSemestersResponse: function(response) {
+				this.__onResponse(response, '_semesters');
+			},
+			_onFiltersChanged: function(e) {
+				this.set('_currentFilters', e.detail.filters);
+
+				this._showClearButton = this._currentFilters.length > 0;
 
 				if (this._currentFilters.length === 0) {
 					this.filterText = this.localize('filtering.filter');
@@ -301,87 +184,10 @@
 					this.filterText = this.localize('filtering.filterMultiple', 'num', this._currentFilters.length);
 				}
 
-				this.fire('d2l-filter-menu-content-filters-changed', {
+				this.fire('d2l-filter-menu-content-change', {
 					text: this.filterText,
-					value: this._currentFilters
+					filters: this._currentFilters
 				});
-			},
-			__onSearchResults: function(entity, moreUrlPath, hasMorePath) {
-				if (!entity.hasLinkByRel) {
-					entity = this._parser.parse(entity);
-				}
-
-				this.set(hasMorePath, entity.hasLinkByRel('next'));
-				this.set(moreUrlPath, this[hasMorePath] ? entity.getLinkByRel('next').href : '');
-
-				// If user has >1 departments or >1 semesters, signal to d2l-all-courses to show filters
-				var smallNumberOfDepartmentsAndSemesters =
-					this._departments && this._departments.length <= 1
-					&& this._semesters && this._semesters.length <= 1;
-
-				this.fire('d2l-filter-menu-content-hide', {
-					hide: smallNumberOfDepartmentsAndSemesters
-				});
-			},
-			_onDepartmentSearchResults: function(e) {
-				this.set('_departments', e.detail.entities);
-				this.__onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
-			},
-			_onSemesterSearchResults: function(e) {
-				this.set('_semesters', e.detail.entities);
-				this.__onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
-			},
-			__onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
-				if (response.detail.status === 200 || response.detail.status === 304) {
-					var responseEntity = this._parser.parse(response.detail.xhr.response);
-
-					responseEntity.entities.forEach(function(entity) {
-						this.push(organizationsPath, entity);
-					}.bind(this));
-
-					this.__onSearchResults(responseEntity, moreUrlPath, hasMorePath);
-				}
-			},
-			_onMoreDepartmentsResponse: function(response) {
-				this.__onMoreResponse(response, '_departments', '_moreDepartmentsUrl', '_hasMoreDepartments');
-			},
-			_onMoreSemestersResponse: function(response) {
-				this.__onMoreResponse(response, '_semesters', '_moreSemestersUrl', '_hasMoreSemesters');
-			},
-			__toggleSelectedList: function(list, button, highlight, selected) {
-				this.toggleClass('d2l-filter-menu-content-hidden', !selected, list);
-				this.toggleClass('d2l-filter-menu-content-invisible', !selected, highlight);
-				button.setAttribute('aria-pressed', selected);
-			},
-			_selectDepartmentList: function() {
-				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
-				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
-				this.$.semesterSearchWidget.clear();
-				this.$.departmentSearchWidget.clear();
-				this.$.departmentList.querySelector('d2l-menu').resize();
-			},
-			_selectSemesterList: function() {
-				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
-				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
-				this.$.semesterSearchWidget.clear();
-				this.$.departmentSearchWidget.clear();
-				this.$.semesterList.querySelector('d2l-menu').resize();
-			},
-			__updateFilter: function(e, path) {
-				if (e.detail.selected) {
-					this.push('_currentFilters', e.detail.value);
-					this.set(path, this[path] + 1);
-				} else {
-					var index = this._currentFilters.indexOf(e.detail.value);
-					this.splice('_currentFilters', index, 1);
-					this.set(path, this[path] - 1);
-				}
-			},
-			_updateDepartmentFilter: function(e) {
-				this.__updateFilter(e, '_numDepartmentFilters');
-			},
-			_updateSemesterFilter: function(e) {
-				this.__updateFilter(e, '_numSemesterFilters');
 			}
 		});
 	</script>

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -39,7 +39,7 @@ describe('d2l-all-courses', function() {
 	});
 
 	afterEach(function() {
-		clock.restore;
+		clock.restore();
 	});
 
 	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {
@@ -89,25 +89,24 @@ describe('d2l-all-courses', function() {
 		expect(widget.$.filterAndSort.classList.contains('d2l-all-courses-hidden')).to.be.false;
 	});
 
-	describe('d2l-filter-menu-content-filters-changed', function() {
+	describe('d2l-filter-menu-content-change', function() {
 		var event = {
-			value: [1],
+			filters: [1],
 			text: 'foo'
 		};
 
-		it('should update the parent organizations passed to d2l-search-widget-custom', function() {
-			var search = widget.$$('d2l-search-widget-custom');
-			expect(search.parentOrganizations.length).to.equal(0);
+		it('should update the parent organizations', function() {
+			expect(widget._parentOrganizations.length).to.equal(0);
 
-			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-filters-changed', event);
+			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-change', event);
 
-			expect(search.parentOrganizations.length).to.equal(1);
+			expect(widget._parentOrganizations.length).to.equal(1);
 		});
 
 		it('should update the filter menu opener text', function() {
 			expect(widget._filterText).to.equal('Filter');
 
-			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-filters-changed', event);
+			widget.$$('d2l-filter-menu-content').fire('d2l-filter-menu-content-change', event);
 
 			expect(widget._filterText).to.equal('foo');
 		});

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -6,18 +6,15 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../d2l-all-courses.html">
+		<link rel="import" href="../../d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html">
 	</head>
 	<body>
-		<test-fixture id="d2l-all-courses-fixture">
+		<test-fixture id="d2l-filter-menu-content-fixture">
 			<template>
-				<d2l-all-courses
-					pinned-enrollments='[]'
-					unpinned-enrollments='[]'>
-				</d2l-all-courses>
+				<d2l-filter-menu-content-tabbed></d2l-filter-menu-content-tabbed>
 			</template>
 		</test-fixture>
 
-		<script src="d2l-all-courses.js"></script>
+		<script src="d2l-filter-menu-content-tabbed.js"></script>
 	</body>
 </html>

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.js
@@ -1,0 +1,173 @@
+/* global describe, it, beforeEach, afterEach, fixture, expect, sinon */
+
+'use strict';
+
+describe('d2l-filter-menu-content', function() {
+	var widget,
+		sandbox,
+		myEnrollmentsEntity,
+		parser;
+
+	beforeEach(function() {
+		parser = document.createElement('d2l-siren-parser');
+		myEnrollmentsEntity = parser.parse({
+			actions: [{
+				name: 'add-semester-filter',
+				href: '/enrollments'
+			}, {
+				name: 'add-department-filter',
+				href: '/enrollments'
+			}]
+		});
+		sandbox = sinon.sandbox.create();
+		widget = fixture('d2l-filter-menu-content-fixture');
+	});
+
+	afterEach(function() {
+		sandbox.restore();
+	});
+
+	it('should observe changes to myEnrollmentsEntity', function() {
+		var spy = sandbox.spy(widget, '_myEnrollmentsEntityChanged');
+
+		widget.myEnrollmentsEntity = myEnrollmentsEntity;
+
+		expect(spy.called).to.be.true;
+		expect(widget._searchDepartmentsAction.name).to.equal('add-department-filter');
+		expect(widget._searchDepartmentsAction.href).to.equal('/enrollments');
+		expect(widget._searchSemestersAction.name).to.equal('add-semester-filter');
+		expect(widget._searchSemestersAction.href).to.equal('/enrollments');
+	});
+
+	describe('d2l-filter-menu-content-filters-changed', function() {
+		it('should emit an event when a filter is added', function(done) {
+			var handler = function() {
+				document.removeEventListener('d2l-filter-menu-content-filters-changed', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
+
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+		});
+
+		it('should emit an event when a filter is removed', function(done) {
+			var handler = function() {
+				document.removeEventListener('d2l-filter-menu-content-filters-changed', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
+
+			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+				selected: false,
+				value: 'foo'
+			});
+		});
+	});
+
+	describe('Lazy loading', function() {
+		it('should set internal values appropriately when there are not any more departments', function(done) {
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreDepartments).to.be.false;
+				expect(widget._moreDepartmentsUrl).to.equal('');
+				done();
+			});
+		});
+
+		it('should set internal values appropriately when there are more departments', function(done) {
+			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}, {
+					rel: ['next'],
+					href: '/enrollments?page=2'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreDepartments).to.be.true;
+				expect(widget._moreDepartmentsUrl).to.equal('/enrollments?page=2');
+				done();
+			});
+		});
+
+		it('should set internal values appropriately when there are not any more semesters', function(done) {
+			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreSemesters).to.be.false;
+				expect(widget._moreSemestersUrl).to.equal('');
+				done();
+			});
+		});
+
+		it('should set internal values appropriately when there are more semesters', function(done) {
+			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+				links: [{
+					rel: ['self'],
+					href: '/enrollments'
+				}, {
+					rel: ['next'],
+					href: '/enrollments?page=2'
+				}]
+			});
+
+			setTimeout(function() {
+				expect(widget._hasMoreSemesters).to.be.true;
+				expect(widget._moreSemestersUrl).to.equal('/enrollments?page=2');
+				done();
+			});
+		});
+
+		it('should trigger a request for more departments when the departments tab is selected', function() {
+			var departmentStub = sandbox.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sandbox.stub(widget.$.moreSemestersRequest, 'generateRequest');
+			widget._selectDepartmentList();
+
+			widget.loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.false;
+
+			widget.set('_hasMoreDepartments', true);
+
+			widget.loadMore();
+
+			expect(departmentStub.called).to.be.true;
+			expect(semesterStub.called).to.be.false;
+		});
+
+		it('should trigger a request for more semesters when the semesters tab is selected', function() {
+			var departmentStub = sandbox.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sandbox.stub(widget.$.moreSemestersRequest, 'generateRequest');
+			widget._selectSemesterList();
+
+			widget.loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.false;
+
+			widget.set('_hasMoreSemesters', true);
+
+			widget.loadMore();
+
+			expect(departmentStub.called).to.be.false;
+			expect(semesterStub.called).to.be.true;
+		});
+	});
+});

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -1,12 +1,10 @@
-/* global describe, it, beforeEach, fixture, expect, sinon */
+/* global describe, it, beforeEach, afterEach, fixture, expect, sinon */
 
 'use strict';
 
 describe('d2l-filter-menu-content', function() {
 	var widget,
-		sandbox,
 		myEnrollmentsEntity,
-		enrollment,
 		parser;
 
 	beforeEach(function() {
@@ -14,57 +12,61 @@ describe('d2l-filter-menu-content', function() {
 		myEnrollmentsEntity = parser.parse({
 			actions: [{
 				name: 'add-semester-filter',
-				href: '/enrollments'
+				href: '/enrollments/semesters'
 			}, {
 				name: 'add-department-filter',
-				href: '/enrollments'
+				href: '/enrollments/departments'
 			}]
 		});
-		enrollment = {
-			rel: ['enrollment'],
-			links: [{
-				rel: ['self'],
-				href: '/enrollments'
-			}, {
-				rel: ['/organization'],
-				href: '/organizations/1'
-			}]
-		};
-		sandbox = sinon.sandbox.create();
 		widget = fixture('d2l-filter-menu-content-fixture');
 	});
 
 	it('should observe changes to myEnrollmentsEntity', function() {
+		var sandbox = sinon.sandbox.create();
 		var spy = sandbox.spy(widget, '_myEnrollmentsEntityChanged');
 
 		widget.myEnrollmentsEntity = myEnrollmentsEntity;
 
 		expect(spy.called).to.be.true;
-		expect(widget._searchDepartmentsAction.name).to.equal('add-department-filter');
-		expect(widget._searchDepartmentsAction.href).to.equal('/enrollments');
-		expect(widget._searchSemestersAction.name).to.equal('add-semester-filter');
-		expect(widget._searchSemestersAction.href).to.equal('/enrollments');
+		expect(widget._departmentsUrl).to.equal('/enrollments/departments');
+		expect(widget._semestersUrl).to.equal('/enrollments/semesters');
+
+		sandbox.restore();
 	});
 
 	describe('Visibility', function() {
-		it('should signal that it should be hidden if user does not have enough departments/semesters', function(done) {
-			var handler = function(e) {
-				expect(e.detail.hide).to.be.false;
-				document.removeEventListener('d2l-filter-menu-content-hide', handler);
-				done();
-			};
-			document.addEventListener('d2l-filter-menu-content-hide', handler);
+		var enrollment,
+			response,
+			server;
 
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', parser.parse({
+		beforeEach(function() {
+			server = sinon.fakeServer.create();
+			server.respondImmediately = true;
+			server.respondWith(
+				'GET',
+				/\/enrollments\/departments/,
+				function(req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					req.respond(200, {}, JSON.stringify(response));
+				});
+
+			enrollment = {
+				rel: ['enrollment'],
 				links: [{
 					rel: ['self'],
 					href: '/enrollments'
-				}],
-				entities: [enrollment, enrollment]
-			}));
+				}, {
+					rel: ['/organization'],
+					href: '/organizations/1'
+				}]
+			};
 		});
 
-		it('should signal that it should be shown if user has enough departments/semesters', function(done) {
+		afterEach(function() {
+			server.restore();
+		});
+
+		it('should signal that it should be hidden if user does not have enough departments/semesters', function(done) {
 			var handler = function(e) {
 				expect(e.detail.hide).to.be.true;
 				document.removeEventListener('d2l-filter-menu-content-hide', handler);
@@ -72,13 +74,28 @@ describe('d2l-filter-menu-content', function() {
 			};
 			document.addEventListener('d2l-filter-menu-content-hide', handler);
 
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', parser.parse({
-				links: [{
-					rel: ['self'],
-					href: '/enrollments'
-				}],
+			response = {
 				entities: [enrollment]
-			}));
+			};
+
+			widget.myEnrollmentsEntity = myEnrollmentsEntity;
+			widget.load();
+		});
+
+		it('should signal that it should be shown if user has enough departments/semesters', function(done) {
+			var handler = function(e) {
+				expect(e.detail.hide).to.be.false;
+				document.removeEventListener('d2l-filter-menu-content-hide', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-hide', handler);
+
+			response = {
+				entities: [enrollment, enrollment]
+			};
+
+			widget.myEnrollmentsEntity = myEnrollmentsEntity;
+			widget.load();
 		});
 	});
 
@@ -91,9 +108,8 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should appear when at least one filter is selected', function(done) {
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
-				selected: true,
-				value: 'foo'
+			widget.$$('d2l-filter-menu-content-tabbed').fire('d2l-filter-menu-content-filters-changed', {
+				filters: [1]
 			});
 
 			setTimeout(function() {
@@ -104,9 +120,8 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should clear filters when clicked', function(done) {
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
-				selected: true,
-				value: 'foo'
+			widget.$$('d2l-filter-menu-content-tabbed').fire('d2l-filter-menu-content-filters-changed', {
+				filters: [1]
 			});
 
 			setTimeout(function() {
@@ -125,9 +140,8 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should read "Filter: 1 filter" when any 1 filter is selected', function(done) {
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
-				selected: true,
-				value: 'foo'
+			widget.$$('d2l-filter-menu-content-tabbed').fire('d2l-filter-menu-content-filters-changed', {
+				filters: [1]
 			});
 
 			setTimeout(function() {
@@ -137,123 +151,14 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should read "Filter: 2 filters" when any 2 filters are selected', function(done) {
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
-				selected: true,
-				value: 'foo'
-			});
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
-				selected: true,
-				value: 'bar'
+			widget.$$('d2l-filter-menu-content-tabbed').fire('d2l-filter-menu-content-filters-changed', {
+				filters: [1, 1]
 			});
 
 			setTimeout(function() {
 				expect(widget.filterText).to.equal('Filter: 2 Filters');
 				done();
 			});
-		});
-	});
-
-	describe('Lazy loading', function() {
-		it('should set internal values appropriately when there are not any more departments', function(done) {
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
-				links: [{
-					rel: ['self'],
-					href: '/enrollments'
-				}]
-			});
-
-			setTimeout(function() {
-				expect(widget._hasMoreDepartments).to.be.false;
-				expect(widget._moreDepartmentsUrl).to.equal('');
-				done();
-			});
-		});
-
-		it('should set internal values appropriately when there are more departments', function(done) {
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
-				links: [{
-					rel: ['self'],
-					href: '/enrollments'
-				}, {
-					rel: ['next'],
-					href: '/enrollments?page=2'
-				}]
-			});
-
-			setTimeout(function() {
-				expect(widget._hasMoreDepartments).to.be.true;
-				expect(widget._moreDepartmentsUrl).to.equal('/enrollments?page=2');
-				done();
-			});
-		});
-
-		it('should set internal values appropriately when there are not any more semesters', function(done) {
-			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
-				links: [{
-					rel: ['self'],
-					href: '/enrollments'
-				}]
-			});
-
-			setTimeout(function() {
-				expect(widget._hasMoreSemesters).to.be.false;
-				expect(widget._moreSemestersUrl).to.equal('');
-				done();
-			});
-		});
-
-		it('should set internal values appropriately when there are more semesters', function(done) {
-			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
-				links: [{
-					rel: ['self'],
-					href: '/enrollments'
-				}, {
-					rel: ['next'],
-					href: '/enrollments?page=2'
-				}]
-			});
-
-			setTimeout(function() {
-				expect(widget._hasMoreSemesters).to.be.true;
-				expect(widget._moreSemestersUrl).to.equal('/enrollments?page=2');
-				done();
-			});
-		});
-
-		it('should trigger a request for more departments when the departments tab is selected', function() {
-			var departmentStub = sinon.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
-			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
-			widget._selectDepartmentList();
-
-			widget.loadMore();
-
-			expect(departmentStub.called).to.be.false;
-			expect(semesterStub.called).to.be.false;
-
-			widget.set('_hasMoreDepartments', true);
-
-			widget.loadMore();
-
-			expect(departmentStub.called).to.be.true;
-			expect(semesterStub.called).to.be.false;
-		});
-
-		it('should trigger a request for more semesters when the semesters tab is selected', function() {
-			var departmentStub = sinon.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
-			var semesterStub = sinon.stub(widget.$.moreSemestersRequest, 'generateRequest');
-			widget._selectSemesterList();
-
-			widget.loadMore();
-
-			expect(departmentStub.called).to.be.false;
-			expect(semesterStub.called).to.be.false;
-
-			widget.set('_hasMoreSemesters', true);
-
-			widget.loadMore();
-
-			expect(departmentStub.called).to.be.false;
-			expect(semesterStub.called).to.be.true;
 		});
 	});
 });

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
 				'./d2l-course-tile/d2l-course-tile.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
 				'./d2l-filter-menu-content/d2l-filter-menu-content.html',
+				'./d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html',
 				'./d2l-filter-menu-content/d2l-list-item-filter.html',
 				'./d2l-image-selector-tile/d2l-image-selector-tile.html',
 				'./d2l-my-courses/d2l-my-courses.html',


### PR DESCRIPTION
This breaks out some of the behaviour of `d2l-filter-menu-content` into `d2l-filter-menu-content-tabbed`. The idea behind this is that a user with a smaller number (<=7) of department/semester enrollments will see a simplified view. Doing so with the current state of things would be a pain, so I've broken out the (_significantly_ more complex) tabbed view into its own component. In the next PR, `d2l-filter-menu-content` will choose which view to present based on the number of department/semester enrollments for the current user; as of right now, this is behaviourally unchanged (always shows the tabbed view). Like #236, this is just a "the diff would make you swear fealty to Satan if I did this all once" kind of PR.

This also hopefully will make a transition to [`d2l-tabs`](https://github.com/Brightspace/d2l-tabs) easier, should we decide to use it (we should, pending some updates to it).

~~WIP-ish since this includes commits in #236, so that'll have to be merged first.~~

Acceptance Criteria:

- No behavioural change - filter menu still shows tabs for department and semester; lazy loading of additional departments/semesters still works; filter menu still hides itself when the user has a small number of enrollments; etc.

Risks:

- This is a refactor, meaning things moved around a fair amount, so it's possible that things are no longer "connected". #216 means that this is a bit less risky, since as long as `d2l-filter-menu-content` is still emitting the two events it normally emits at the right times, then we should be good.
- I've added an extra two network calls. I can't imagine this will have any significant performance impact, but it's worth noting. They're also semi-superfluous, but I haven't yet thought of a way to dedupe them intelligently.

TODO:

- [x] Merge #236 
- [x] rebase dis shiz
- [x] buy a Lamborghini