### PR TITLE
upgrading to d2l-ajax 3.2.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "app-localize-behavior": "https://github.com/Brightspace/app-localize-behavior.git#master",
-    "d2l-ajax": "^3.2.0",
+    "d2l-ajax": "^3.2.1",
     "d2l-colors": "^2.2.3",
     "d2l-dropdown": "^3.0.4",
     "d2l-icons": "^2.15.2",


### PR DESCRIPTION
This picks up a fix that lets the XSRF token be cached in IE.