### PR TITLE
US78151 - TA108415 Simple filter menu content.

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -5,9 +5,9 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
-<link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="d2l-alert.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
@@ -622,7 +622,7 @@
 					this.$.filterDropdownOpener.focus();
 				} else {
 					this.$.filterDropdownContent.open();
-					this.$.filterMenuContent.load();
+					this.$.filterMenuContent.open();
 				}
 				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},

--- a/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
@@ -1,0 +1,84 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
+<link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-menu/d2l-menu.html">
+<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../localize-behavior.html">
+<link rel="import" href="d2l-list-item-filter.html">
+
+<dom-module is="d2l-filter-menu-content-simple">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+			.dropdown-content-gradient {
+				background: linear-gradient(to top, white, var(--d2l-color-regolith));
+			}
+		</style>
+
+		<div class="dropdown-content-gradient">
+			<d2l-menu label="{{localize('filtering.filter')}}">
+				<template is="dom-repeat" items="[[filterItems]]">
+					<d2l-list-item-filter
+						enrollment-entity="[[item]]">
+					</d2l-list-item-filter>
+				</template>
+			</d2l-menu>
+		</div>
+	</template>
+
+	<script>
+		'use strict';
+
+		Polymer({
+			is: 'd2l-filter-menu-content-simple',
+			properties: {
+				filterItems: {
+					type: Array,
+					observer: '_filterItemsChanged'
+				},
+				_currentFilters: {
+					type: Array,
+					value: function() { return []; }
+				}
+			},
+			behaviors: [
+				window.D2L.MyCourses.LocalizeBehavior
+			],
+			attached: function() {
+				this.listen(this.$$('d2l-menu'), 'd2l-menu-item-change', '_updateFilter');
+			},
+			detached: function() {
+				this.unlisten(this.$$('d2l-menu'), 'd2l-menu-item-change', '_updateFilter');
+			},
+			_clearFilters: function() {
+				this.$$('d2l-menu').querySelectorAll('d2l-list-item-filter').forEach(function(item) {
+					item.selected = false;
+				});
+				this.set('_currentFilters', []);
+				this.fire('d2l-filter-menu-content-filters-changed', {
+					filters: this._currentFilters
+				});
+
+				// Clear button is removed via dom-if, so need to manually set focus to next element
+				this.$$('d2l-menu d2l-list-item-filter').focus();
+			},
+			_filterItemsChanged: function() {
+				this.$$('d2l-menu').resize();
+			},
+			_updateFilter: function(e) {
+				if (e.detail.selected) {
+					this.push('_currentFilters', e.detail.value);
+				} else {
+					var index = this._currentFilters.indexOf(e.detail.value);
+					this.splice('_currentFilters', index, 1);
+				}
+
+				this.fire('d2l-filter-menu-content-filters-changed', {
+					filters: this._currentFilters
+				});
+			}
+		});
+	</script>
+</dom-module>

--- a/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
@@ -2,7 +2,6 @@
 <link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-menu/d2l-menu.html">
-<link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-list-item-filter.html">
 
@@ -34,10 +33,7 @@
 		Polymer({
 			is: 'd2l-filter-menu-content-simple',
 			properties: {
-				filterItems: {
-					type: Array,
-					observer: '_filterItemsChanged'
-				},
+				filterItems: Array,
 				_currentFilters: {
 					type: Array,
 					value: function() { return []; }
@@ -52,6 +48,9 @@
 			detached: function() {
 				this.unlisten(this.$$('d2l-menu'), 'd2l-menu-item-change', '_updateFilter');
 			},
+			open: function() {
+				this.$$('d2l-menu').resize();
+			},
 			_clearFilters: function() {
 				this.$$('d2l-menu').querySelectorAll('d2l-list-item-filter').forEach(function(item) {
 					item.selected = false;
@@ -63,9 +62,6 @@
 
 				// Clear button is removed via dom-if, so need to manually set focus to next element
 				this.$$('d2l-menu d2l-list-item-filter').focus();
-			},
-			_filterItemsChanged: function() {
-				this.$$('d2l-menu').resize();
 			},
 			_updateFilter: function(e) {
 				if (e.detail.selected) {

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -198,7 +198,6 @@
 			load: function() {
 				this.$.departmentSearchWidget.search();
 				this.$.semesterSearchWidget.search();
-				this._selectSemesterList();
 			},
 			loadMore: function() {
 				// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
@@ -209,13 +208,11 @@
 					this.$.moreSemestersRequest.generateRequest();
 				}
 			},
-			__parser: null,
-			_parser: function() {
-				if (!this.__parser) {
-					this.__parser = document.createElement('d2l-siren-parser');
-				}
-				return this.__parser;
+			open: function() {
+				// When opened, select the leftmost (semester) tab. Also resizes the menu, in case the backing data has changed.
+				this._selectSemesterList();
 			},
+			_parser: null,
 			_checkSelected: function(entity) {
 				// Checks if the given entity should be "selected" - used when semester/department search results change mostly
 				var id = entity.getLinkByRel(/\/organization$/).href;
@@ -246,7 +243,8 @@
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown
 				if (entity) {
-					var myEnrollmentsEntity = this._parser().parse(entity);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					var myEnrollmentsEntity = this._parser.parse(entity);
 
 					this.set('_searchDepartmentsAction', myEnrollmentsEntity.getActionByName('add-department-filter'));
 					this.set('_searchSemestersAction', myEnrollmentsEntity.getActionByName('add-semester-filter'));
@@ -266,7 +264,8 @@
 			},
 			__onSearchResults: function(entity, moreUrlPath, hasMorePath) {
 				if (!entity.hasLinkByRel) {
-					entity = this._parser().parse(entity);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					entity = this._parser.parse(entity);
 				}
 
 				this.set(hasMorePath, entity.hasLinkByRel('next'));
@@ -282,7 +281,8 @@
 			},
 			__onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
-					var responseEntity = this._parser().parse(response.detail.xhr.response);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					var responseEntity = this._parser.parse(response.detail.xhr.response);
 
 					responseEntity.entities.forEach(function(entity) {
 						this.push(organizationsPath, entity);

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
-<link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="../../d2l-menu/d2l-menu.html">
 <link rel="import" href="../../d2l-search-widget/d2l-search-widget.html">
 <link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
@@ -307,7 +305,6 @@
 			_selectDepartmentList: function() {
 				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, true);
 				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
-				this.$.semesterSearchWidget.clear();
 				this.$.departmentSearchWidget.clear();
 				this.$.departmentList.querySelector('d2l-menu').resize();
 			},
@@ -315,7 +312,6 @@
 				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
 				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
 				this.$.semesterSearchWidget.clear();
-				this.$.departmentSearchWidget.clear();
 				this.$.semesterList.querySelector('d2l-menu').resize();
 			},
 			__updateFilter: function(e, path) {

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-list-item-filter.html">
+<link rel="import" href="d2l-filter-menu-content-simple.html">
 <link rel="import" href="d2l-filter-menu-content-tabbed.html">
 
 <dom-module is="d2l-filter-menu-content">
@@ -68,10 +69,19 @@
 				<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 			</template>
 		</div>
-		<d2l-filter-menu-content-tabbed
-			id="tabbedContent"
-			my-enrollments-entity="[[myEnrollmentsEntity]]">
-		</d2l-filter-menu-content-tabbed>
+
+		<div id="contentView">
+			<d2l-filter-menu-content-simple
+				id="simpleContent"
+				hidden$="[[_hasManyFilters]]">
+			</d2l-filter-menu-content-simple>
+
+			<d2l-filter-menu-content-tabbed
+				id="tabbedContent"
+				hidden$="[[!_hasManyFilters]]"
+				my-enrollments-entity="[[myEnrollmentsEntity]]">
+			</d2l-filter-menu-content-tabbed>
+		</div>
 	</template>
 
 	<script>
@@ -95,6 +105,10 @@
 					value: function() { return []; }
 				},
 				_departmentsUrl: String,
+				_hasManyFilters: {
+					type: Boolean,
+					value: false
+				},
 				_semesters: {
 					type: Array,
 					value: function() { return []; }
@@ -113,19 +127,22 @@
 				this.filterText = this.localize('filtering.filter');
 			},
 			attached: function() {
+				this.listen(this.$.simpleContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 				this.listen(this.$.tabbedContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 			},
 			detached: function() {
+				this.unlisten(this.$.simpleContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 				this.unlisten(this.$.tabbedContent, 'd2l-filter-menu-content-filters-changed', '_onFiltersChanged');
 			},
 			load: function() {
 				this.$.departmentsRequest.generateRequest();
 				this.$.semestersRequest.generateRequest();
-				this.$.tabbedContent.load();
 			},
 			loadMore: function() {
-				// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
-				this.$.tabbedContent.loadMore();
+				if (this._hasManyFilters) {
+					// Called from d2l-all-courses, as that's where the iron-scroll-threshold is
+					this.$.tabbedContent.loadMore();
+				}
 			},
 			__parser: null,
 			_parser: function() {
@@ -135,7 +152,7 @@
 				return this.__parser;
 			},
 			_clearFilters: function() {
-				this.$.tabbedContent._clearFilters();
+				this.$$('#contentView > :not([hidden])')._clearFilters();
 
 				this._showClearButton = false;
 
@@ -148,7 +165,6 @@
 					var myEnrollmentsEntity = this._parser().parse(entity);
 					var departmentsAction  = myEnrollmentsEntity.getActionByName('add-department-filter');
 					var semestersAction = myEnrollmentsEntity.getActionByName('add-semester-filter');
-
 					this.set('_departmentsUrl', this.createActionUrl(departmentsAction));
 					this.set('_semestersUrl', this.createActionUrl(semestersAction));
 				}
@@ -158,11 +174,16 @@
 					var entity = this._parser().parse(response.detail.xhr.response);
 					this.set(path, entity.entities);
 
+					this.set('_hasManyFilters', this._departments.length + this._semesters.length > 7);
+					if (this._hasManyFilters) {
+						this.$.tabbedContent.load();
+					} else {
+						this.$.simpleContent.filterItems = this._departments.concat(this._semesters);
+					}
+
 					this.fire('d2l-filter-menu-content-hide', {
 						hide: this._semesters.length + this._departments.length <= 1
 					});
-
-					// TODO: Use simplified menu for small number of departments/semesters
 				}
 			},
 			_onDepartmentsResponse: function(response) {

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -93,26 +93,19 @@
 				filterText: String,
 				myEnrollmentsEntity: {
 					type: Object,
-					value: function() { return {}; },
 					observer: '_myEnrollmentsEntityChanged'
 				},
 				_currentFilters: {
 					type: Array,
 					value: function() { return []; }
 				},
-				_departments: {
-					type: Array,
-					value: function() { return []; }
-				},
+				_departments: Array,
 				_departmentsUrl: String,
 				_hasManyFilters: {
 					type: Boolean,
 					value: false
 				},
-				_semesters: {
-					type: Array,
-					value: function() { return []; }
-				},
+				_semesters: Array,
 				_semestersUrl: String,
 				_showClearButton: {
 					type: Boolean,
@@ -144,15 +137,15 @@
 					this.$.tabbedContent.loadMore();
 				}
 			},
-			__parser: null,
-			_parser: function() {
-				if (!this.__parser) {
-					this.__parser = document.createElement('d2l-siren-parser');
-				}
-				return this.__parser;
+			open: function() {
+				this._currentContent().open();
 			},
+			_currentContent: function() {
+				return this.$$('#contentView > :not([hidden])');
+			},
+			_parser: null,
 			_clearFilters: function() {
-				this.$$('#contentView > :not([hidden])')._clearFilters();
+				this._currentContent()._clearFilters();
 
 				this._showClearButton = false;
 
@@ -162,7 +155,9 @@
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown
 				if (entity && entity.actions) {
-					var myEnrollmentsEntity = this._parser().parse(entity);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+
+					var myEnrollmentsEntity = this._parser.parse(entity);
 					var departmentsAction  = myEnrollmentsEntity.getActionByName('add-department-filter');
 					var semestersAction = myEnrollmentsEntity.getActionByName('add-semester-filter');
 					this.set('_departmentsUrl', this.createActionUrl(departmentsAction));
@@ -171,8 +166,13 @@
 			},
 			__onResponse: function(response, path) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
-					var entity = this._parser().parse(response.detail.xhr.response);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					var entity = this._parser.parse(response.detail.xhr.response);
 					this.set(path, entity.entities);
+
+					if (!this._departments || !this._semesters) {
+						return;
+					}
 
 					this.set('_hasManyFilters', this._departments.length + this._semesters.length > 7);
 					if (this._hasManyFilters) {

--- a/d2l-filter-menu-content/d2l-list-item-filter.html
+++ b/d2l-filter-menu-content/d2l-list-item-filter.html
@@ -56,17 +56,18 @@
 					this.listen(this, 'd2l-menu-item-select', '_onSelect');
 				}.bind(this));
 			},
+			_parser: null,
 			_onEnrollmentEntityChanged: function(entity) {
-				if (entity.getLinkByRel && entity.getLinkByRel(/\/organization$/)) {
+				this._parser = this._parser || document.createElement('d2l-siren-parser');
+				entity = this._parser.parse(entity);
+
+				if (entity.getLinkByRel(/\/organization$/)) {
 					this.set('_organizationUrl', entity.getLinkByRel(/\/organization$/).href);
 				}
 			},
 			_onOrganizationResponse: function(response) {
 				if (response.detail.status === 200 ) {
-					if (!this._parser) {
-						this._parser = document.createElement('d2l-siren-parser');
-					}
-
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
 					var entity = this._parser.parse(response.detail.xhr.response);
 
 					this.set('text', entity.properties.name);
@@ -81,8 +82,7 @@
 				// The selected state can be changed by click/tap or by _checkSelected below - need to update the icon when this happens
 				this.$$('d2l-icon').setAttribute('icon', this.selected ? 'd2l-tier2:check-box' : 'd2l-tier2:check-box-unchecked');
 				this.__onSelectedChanged(e);
-			},
-			_parser: null
+			}
 		});
 	</script>
 </dom-module>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "publish:cdn": "npm run build -s && frau-publisher",
     "test": "npm run test:lint:js && npm run test:lint:wc && wct",
     "test:lint:js": "eslint --ext .js,.html .",
-    "test:lint:wc": "polylint --no-recursion --input *.html ./image-selector/*.html ./components/*.html",
+    "test:lint:wc": "polylint --no-recursion --input *.html ./image-selector/*.html ./components/*.html ./d2l-filter-menu-content/*.html",
     "test:no-lint": "wct -p"
   },
   "config": {

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="../../d2l-filter-menu-content/d2l-filter-menu-content-simple.html">
+	</head>
+	<body>
+		<test-fixture id="d2l-filter-menu-content-fixture">
+			<template>
+				<d2l-filter-menu-content-simple></d2l-filter-menu-content-simple>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-filter-menu-content-simple.js"></script>
+	</body>
+</html>

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.js
@@ -1,4 +1,4 @@
-/* global describe, it, beforeEach, fixture, expect, sinon */
+/* global describe, it, beforeEach, fixture */
 
 'use strict';
 
@@ -7,15 +7,6 @@ describe('d2l-filter-menu-content-simple', function() {
 
 	beforeEach(function() {
 		component = fixture('d2l-filter-menu-content-fixture');
-	});
-
-	it('should observe changes to filterItems', function() {
-		var spy = sinon.spy(component, '_filterItemsChanged');
-
-		component.filterItems = [1];
-
-		expect(spy.called).to.be.true;
-		spy.restore();
 	});
 
 	describe('d2l-filter-menu-content-filters-changed', function() {

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-simple.js
@@ -1,0 +1,48 @@
+/* global describe, it, beforeEach, fixture, expect, sinon */
+
+'use strict';
+
+describe('d2l-filter-menu-content-simple', function() {
+	var component;
+
+	beforeEach(function() {
+		component = fixture('d2l-filter-menu-content-fixture');
+	});
+
+	it('should observe changes to filterItems', function() {
+		var spy = sinon.spy(component, '_filterItemsChanged');
+
+		component.filterItems = [1];
+
+		expect(spy.called).to.be.true;
+		spy.restore();
+	});
+
+	describe('d2l-filter-menu-content-filters-changed', function() {
+		it('should emit an event when a filter is added', function(done) {
+			var handler = function() {
+				document.removeEventListener('d2l-filter-menu-content-filters-changed', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
+
+			component.$$('d2l-menu').fire('d2l-menu-item-change', {
+				selected: true,
+				value: 'foo'
+			});
+		});
+
+		it('should emit an event when a filter is removed', function(done) {
+			var handler = function() {
+				document.removeEventListener('d2l-filter-menu-content-filters-changed', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
+
+			component.$$('d2l-menu').fire('d2l-menu-item-change', {
+				selected: false,
+				value: 'foo'
+			});
+		});
+	});
+});

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
-describe('d2l-filter-menu-content', function() {
-	var widget,
+describe('d2l-filter-menu-content-tabbed', function() {
+	var component,
 		sandbox,
 		myEnrollmentsEntity,
 		parser;
@@ -20,7 +20,7 @@ describe('d2l-filter-menu-content', function() {
 			}]
 		});
 		sandbox = sinon.sandbox.create();
-		widget = fixture('d2l-filter-menu-content-fixture');
+		component = fixture('d2l-filter-menu-content-fixture');
 	});
 
 	afterEach(function() {
@@ -28,15 +28,15 @@ describe('d2l-filter-menu-content', function() {
 	});
 
 	it('should observe changes to myEnrollmentsEntity', function() {
-		var spy = sandbox.spy(widget, '_myEnrollmentsEntityChanged');
+		var spy = sandbox.spy(component, '_myEnrollmentsEntityChanged');
 
-		widget.myEnrollmentsEntity = myEnrollmentsEntity;
+		component.myEnrollmentsEntity = myEnrollmentsEntity;
 
 		expect(spy.called).to.be.true;
-		expect(widget._searchDepartmentsAction.name).to.equal('add-department-filter');
-		expect(widget._searchDepartmentsAction.href).to.equal('/enrollments');
-		expect(widget._searchSemestersAction.name).to.equal('add-semester-filter');
-		expect(widget._searchSemestersAction.href).to.equal('/enrollments');
+		expect(component._searchDepartmentsAction.name).to.equal('add-department-filter');
+		expect(component._searchDepartmentsAction.href).to.equal('/enrollments');
+		expect(component._searchSemestersAction.name).to.equal('add-semester-filter');
+		expect(component._searchSemestersAction.href).to.equal('/enrollments');
 	});
 
 	describe('d2l-filter-menu-content-filters-changed', function() {
@@ -47,7 +47,7 @@ describe('d2l-filter-menu-content', function() {
 			};
 			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
 
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+			component.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
 				selected: true,
 				value: 'foo'
 			});
@@ -60,7 +60,7 @@ describe('d2l-filter-menu-content', function() {
 			};
 			document.addEventListener('d2l-filter-menu-content-filters-changed', handler);
 
-			widget.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
+			component.$$('#departmentList d2l-menu').fire('d2l-menu-item-change', {
 				selected: false,
 				value: 'foo'
 			});
@@ -69,7 +69,7 @@ describe('d2l-filter-menu-content', function() {
 
 	describe('Lazy loading', function() {
 		it('should set internal values appropriately when there are not any more departments', function(done) {
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+			component.$.departmentSearchWidget.fire('d2l-search-component-results-changed', {
 				links: [{
 					rel: ['self'],
 					href: '/enrollments'
@@ -77,14 +77,14 @@ describe('d2l-filter-menu-content', function() {
 			});
 
 			setTimeout(function() {
-				expect(widget._hasMoreDepartments).to.be.false;
-				expect(widget._moreDepartmentsUrl).to.equal('');
+				expect(component._hasMoreDepartments).to.be.false;
+				expect(component._moreDepartmentsUrl).to.equal('');
 				done();
 			});
 		});
 
 		it('should set internal values appropriately when there are more departments', function(done) {
-			widget.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
+			component.$.departmentSearchWidget.fire('d2l-search-widget-results-changed', {
 				links: [{
 					rel: ['self'],
 					href: '/enrollments'
@@ -95,14 +95,14 @@ describe('d2l-filter-menu-content', function() {
 			});
 
 			setTimeout(function() {
-				expect(widget._hasMoreDepartments).to.be.true;
-				expect(widget._moreDepartmentsUrl).to.equal('/enrollments?page=2');
+				expect(component._hasMoreDepartments).to.be.true;
+				expect(component._moreDepartmentsUrl).to.equal('/enrollments?page=2');
 				done();
 			});
 		});
 
 		it('should set internal values appropriately when there are not any more semesters', function(done) {
-			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+			component.$.semesterSearchWidget.fire('d2l-search-component-results-changed', {
 				links: [{
 					rel: ['self'],
 					href: '/enrollments'
@@ -110,14 +110,14 @@ describe('d2l-filter-menu-content', function() {
 			});
 
 			setTimeout(function() {
-				expect(widget._hasMoreSemesters).to.be.false;
-				expect(widget._moreSemestersUrl).to.equal('');
+				expect(component._hasMoreSemesters).to.be.false;
+				expect(component._moreSemestersUrl).to.equal('');
 				done();
 			});
 		});
 
 		it('should set internal values appropriately when there are more semesters', function(done) {
-			widget.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
+			component.$.semesterSearchWidget.fire('d2l-search-widget-results-changed', {
 				links: [{
 					rel: ['self'],
 					href: '/enrollments'
@@ -128,43 +128,43 @@ describe('d2l-filter-menu-content', function() {
 			});
 
 			setTimeout(function() {
-				expect(widget._hasMoreSemesters).to.be.true;
-				expect(widget._moreSemestersUrl).to.equal('/enrollments?page=2');
+				expect(component._hasMoreSemesters).to.be.true;
+				expect(component._moreSemestersUrl).to.equal('/enrollments?page=2');
 				done();
 			});
 		});
 
 		it('should trigger a request for more departments when the departments tab is selected', function() {
-			var departmentStub = sandbox.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
-			var semesterStub = sandbox.stub(widget.$.moreSemestersRequest, 'generateRequest');
-			widget._selectDepartmentList();
+			var departmentStub = sandbox.stub(component.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sandbox.stub(component.$.moreSemestersRequest, 'generateRequest');
+			component._selectDepartmentList();
 
-			widget.loadMore();
+			component.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.false;
 
-			widget.set('_hasMoreDepartments', true);
+			component.set('_hasMoreDepartments', true);
 
-			widget.loadMore();
+			component.loadMore();
 
 			expect(departmentStub.called).to.be.true;
 			expect(semesterStub.called).to.be.false;
 		});
 
 		it('should trigger a request for more semesters when the semesters tab is selected', function() {
-			var departmentStub = sandbox.stub(widget.$.moreDepartmentsRequest, 'generateRequest');
-			var semesterStub = sandbox.stub(widget.$.moreSemestersRequest, 'generateRequest');
-			widget._selectSemesterList();
+			var departmentStub = sandbox.stub(component.$.moreDepartmentsRequest, 'generateRequest');
+			var semesterStub = sandbox.stub(component.$.moreSemestersRequest, 'generateRequest');
+			component._selectSemesterList();
 
-			widget.loadMore();
+			component.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.false;
 
-			widget.set('_hasMoreSemesters', true);
+			component.set('_hasMoreSemesters', true);
 
-			widget.loadMore();
+			component.loadMore();
 
 			expect(departmentStub.called).to.be.false;
 			expect(semesterStub.called).to.be.true;

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -36,7 +36,8 @@ describe('d2l-filter-menu-content', function() {
 
 	describe('Visibility and content type', function() {
 		var enrollment,
-			response,
+			departmentsResponse,
+			semestersResponse,
 			server;
 
 		beforeEach(function() {
@@ -47,7 +48,14 @@ describe('d2l-filter-menu-content', function() {
 				/\/enrollments\/departments/,
 				function(req) {
 					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
-					req.respond(200, {}, JSON.stringify(response));
+					req.respond(200, {}, JSON.stringify(departmentsResponse));
+				});
+			server.respondWith(
+				'GET',
+				/\/enrollments\/semesters/,
+				function(req) {
+					expect(req.requestHeaders['accept']).to.equal('application/vnd.siren+json');
+					req.respond(200, {}, JSON.stringify(semestersResponse));
 				});
 
 			enrollment = {
@@ -74,9 +82,8 @@ describe('d2l-filter-menu-content', function() {
 			};
 			document.addEventListener('d2l-filter-menu-content-hide', handler);
 
-			response = {
-				entities: [enrollment]
-			};
+			departmentsResponse = { entities: [enrollment] };
+			semestersResponse = { entities: [] };
 
 			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
@@ -90,9 +97,8 @@ describe('d2l-filter-menu-content', function() {
 			};
 			document.addEventListener('d2l-filter-menu-content-hide', handler);
 
-			response = {
-				entities: [enrollment, enrollment]
-			};
+			departmentsResponse = { entities: [enrollment] };
+			semestersResponse = { entities: [enrollment] };
 
 			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
@@ -100,16 +106,15 @@ describe('d2l-filter-menu-content', function() {
 
 		it('should show a simplified menu for users with <=7 semesters + departments', function(done) {
 			var handler = function() {
-				var content = component.$$('#contentView > :not([hidden])');
+				var content = component._currentContent();
 				expect(content.tagName).to.equal('D2L-FILTER-MENU-CONTENT-SIMPLE');
 				document.removeEventListener('d2l-filter-menu-content-hide', handler);
 				done();
 			};
 			document.addEventListener('d2l-filter-menu-content-hide', handler);
 
-			response = {
-				entities: [enrollment, enrollment, enrollment, enrollment, enrollment, enrollment, enrollment]
-			};
+			departmentsResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
+			semestersResponse = { entities: [enrollment, enrollment, enrollment] };
 
 			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
@@ -117,16 +122,15 @@ describe('d2l-filter-menu-content', function() {
 
 		it('should show a tabbed menu for users with >7 semesters + departments', function(done) {
 			var handler = function() {
-				var content = component.$$('#contentView > :not([hidden])');
+				var content = component._currentContent();
 				expect(content.tagName).to.equal('D2L-FILTER-MENU-CONTENT-TABBED');
 				document.removeEventListener('d2l-filter-menu-content-hide', handler);
 				done();
 			};
 			document.addEventListener('d2l-filter-menu-content-hide', handler);
 
-			response = {
-				entities: [enrollment, enrollment, enrollment, enrollment, enrollment, enrollment, enrollment, enrollment]
-			};
+			departmentsResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
+			semestersResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
 
 			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
@@ -149,7 +153,7 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should be hidden when there are no filters selected', function() {
-			component.$$('#contentView > :not([hidden])').fire('d2l-filter-menu-content-filters-changed', {
+			component._currentContent().fire('d2l-filter-menu-content-filters-changed', {
 				filters: []
 			});
 
@@ -158,7 +162,7 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should appear when at least one filter is selected', function(done) {
-			component.$$('#contentView > :not([hidden])').fire('d2l-filter-menu-content-filters-changed', {
+			component._currentContent().fire('d2l-filter-menu-content-filters-changed', {
 				filters: [1]
 			});
 
@@ -170,7 +174,7 @@ describe('d2l-filter-menu-content', function() {
 		});
 
 		it('should clear filters when clicked', function(done) {
-			component.$$('#contentView > :not([hidden])').fire('d2l-filter-menu-content-filters-changed', {
+			component._currentContent().fire('d2l-filter-menu-content-filters-changed', {
 				filters: [1]
 			});
 
@@ -184,7 +188,7 @@ describe('d2l-filter-menu-content', function() {
 
 	describe('Filter text', function() {
 		it('should read "Filter" when no filters are selected', function() {
-			component.$$('#contentView > :not([hidden])').fire('d2l-filter-menu-content-filters-changed', {
+			component._currentContent().fire('d2l-filter-menu-content-filters-changed', {
 				filters: []
 			});
 

--- a/test/index.html
+++ b/test/index.html
@@ -17,6 +17,7 @@
 				'./d2l-course-tile/d2l-course-tile.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
 				'./d2l-filter-menu-content/d2l-filter-menu-content.html',
+				'./d2l-filter-menu-content/d2l-filter-menu-content-simple.html',
 				'./d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html',
 				'./d2l-filter-menu-content/d2l-list-item-filter.html',
 				'./d2l-image-selector-tile/d2l-image-selector-tile.html',


### PR DESCRIPTION
THE FINAL FORM OF US78151, AND THE FILTER MENU IN GENERAL.

Acceptance Criteria:

- A user with <=1 semesters + departments (i.e. 1D/0S, 0D/1S, or 0D/0S) still doesn't see the filter menu
- A user with <=7 semesters + departments (e.g. 6D/1S, or 7D/0S, or 1D/1S) will now see a simplified, flat version of the filter menu (no tabs, no division between semesters and departments)
- A user with >7 semesters + departments still sees the tabbed view, which divides semesters and departments and has the search fields
- The filter menu still only shows for users with >= 20 course offering enrollments

Risks:

- Nothing I can really think of

TODO:

- [x] Merge #237 
- [x] rebase dis shiz
- [x] Eat a red solo cup