### PR TITLE
Add render-content (needed by new d2l-dropdown version)

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -137,7 +137,7 @@
 							aria-labelledby="filterText">
 							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 						</button>
-						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350">
+						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
 							<d2l-filter-menu-content
 								id="filterMenuContent"
 								my-enrollments-entity="[[myEnrollmentsEntity]]">


### PR DESCRIPTION
Need to render the dropdown contents manually - the newest version of d2l-dropdown defers rendering until required.

@dbatiste - We've got some weird open/close logic around this particular dropdown due to using a not-normal opener, so it seems that `__openedChanged` doesn't get called. Is this an okay approach here?

AC/Risk:

- No story for this, twas just found and fixed in like 10 minutes
- On master right now, the filter menu doesn't load the semesters and departments (it has the tabs for them, but no entries). With this change, yay, semesters and departments!
- Risk: not having this would mean the filter menu doesn't work properly 😛 