### PR TITLE
Remote filterText padding

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -95,9 +95,6 @@
 			#filterSection {
 				display: flex;
 			}
-			#filterText {
-				padding-right: 4px;
-			}
 			button[aria-pressed="true"] {
 				color: var(--d2l-color-celestine);
 			}


### PR DESCRIPTION
This was never exceptionally consistent across browsers, but it seems that recent typography changes have made that difference more noticeable. Since we're not using a "normal" dropdown opener for the filter menu, it makes the most sense to try to match it to the "normal" one (i.e. the sort menu). The best way to do this is to not add any padding - this does mean there's not a lot of space between the chevron on text, but at least the gap is the same between the two menus for any given browser.