### PR TITLE
Fix issue where enrollment arrays were getting aliased

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -209,8 +209,8 @@
 
 		<d2l-course-tile-grid
 			id="all-courses-pinned"
-			enrollments="{{filteredPinnedEnrollments}}"
-			enrollments-queue="{{filteredPinnedEnrollmentsQueue}}"
+			enrollments="[[filteredPinnedEnrollments]]"
+			enrollments-queue="[[filteredPinnedEnrollmentsQueue]]"
 			delay-load="[[delayLoad]]"
 			tile-sizes="[[_tileSizes]]"
 			show-course-code="[[showCourseCode]]">
@@ -220,8 +220,8 @@
 
 		<d2l-course-tile-grid
 			id="all-courses-unpinned"
-			enrollments="{{filteredUnpinnedEnrollments}}"
-			enrollments-queue="{{filteredUnpinnedEnrollmentsQueue}}"
+			enrollments="[[filteredUnpinnedEnrollments]]"
+			enrollments-queue="[[filteredUnpinnedEnrollmentsQueue]]"
 			delay-load="[[delayLoad]]"
 			tile-sizes="[[_tileSizes]]"
 			show-course-code="[[showCourseCode]]">
@@ -237,6 +237,14 @@
 	<script>
 		'use strict';
 
+		if (!Array.prototype.clone) {
+			Array.prototype.clone = function() {
+				return this.map( function(e) {
+					return Array.isArray(e) ? e.clone() : e;
+				});
+			};
+		}
+
 		Polymer({
 			is: 'd2l-all-courses',
 			properties: {
@@ -248,7 +256,6 @@
 					value: function() {
 						return [];
 					},
-					notify: true,
 					observer: '_setFilteredPinnedEnrollments'
 				},
 				// filtered pinned enrollment entities
@@ -264,15 +271,13 @@
 					value: function() {
 						return [];
 					},
-					notify: true,
 					observer: '_setFilteredUnpinnedEnrollments'
 				},
 				filteredUnpinnedEnrollments: {
 					type: Array,
 					value: function() {
 						return [];
-					},
-					notify: true
+					}
 				},
 				// Set of enrollments Entities that are being transferred from unpinned to pinned state
 				// Only used by `d2l-all-courses`
@@ -280,15 +285,13 @@
 					type: Array,
 					value: function() {
 						return [];
-					},
-					notify: true
+					}
 				},
 				filteredPinnedEnrollmentsQueue: {
 					type: Array,
 					value: function() {
 						return [];
-					},
-					notify: true
+					}
 				},
 				// Set of enrollments that are being transferred from pinned to unpinned state
 				// Only used by `d2l-all-courses`
@@ -296,15 +299,13 @@
 					type: Array,
 					value: function() {
 						return [];
-					},
-					notify: true
+					}
 				},
 				filteredUnpinnedEnrollmentsQueue: {
 					type: Array,
 					value: function() {
 						return [];
-					},
-					notify: true
+					}
 				},
 				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
 				_pinnedCoursesMap: {
@@ -412,9 +413,7 @@
 					if (pinnedEnrollmentId === enrollmentId) {
 						var foundEnrollment = this.filteredUnpinnedEnrollments[index];
 						this._setEnrollmentPinData(foundEnrollment, true);
-						this.push('pinnedEnrollments', foundEnrollment);
 						this.push('filteredPinnedEnrollmentsQueue', foundEnrollment);
-						this.splice('unpinnedEnrollments', index, 1);
 						this.splice('filteredUnpinnedEnrollments', index, 1);
 						break;
 					}
@@ -429,16 +428,13 @@
 					if (unpinnedEnrollmentId === enrollmentId) {
 						var foundEnrollment = this.filteredPinnedEnrollments[index];
 						this._setEnrollmentPinData(foundEnrollment, false);
-						this.push('unpinnedEnrollments', foundEnrollment);
 						this.push('filteredUnpinnedEnrollmentsQueue', foundEnrollment);
-						this.splice('pinnedEnrollments', index, 1);
 						this.splice('filteredPinnedEnrollments', index, 1);
 						break;
 					}
 				}
 			},
 			_onTileRemoveComplete: function(e) {
-				e.stopPropagation();
 				if (e.detail.pinned) {
 					this._moveEnrollmentToPinnedList(e.detail.enrollment);
 				} else {
@@ -543,12 +539,10 @@
 				return itemCount;
 			},
 			_setFilteredPinnedEnrollments: function() {
-				this.filteredPinnedEnrollments = [];
-				this.filteredPinnedEnrollments = this.pinnedEnrollments;
+				this.filteredPinnedEnrollments = this.pinnedEnrollments.clone();
 			},
 			_setFilteredUnpinnedEnrollments: function() {
-				this.filteredUnpinnedEnrollments = [];
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments;
+				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.clone();
 			},
 			load: function() {
 				// Load course tile and filter contents. Called from d2l-my-courses.
@@ -556,10 +550,10 @@
 				this.$['all-courses-scroll-threshold'].scrollTarget = this.$['all-courses'].scrollRegion;
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this.$['search-widget']._searchString = '';
-				this._pinnedCouresMap = {};
+				this._pinnedCoursesMap = {};
 				this._unpinnedCoursesMap = {};
-				this.filteredPinnedEnrollments = this.pinnedEnrollments;
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments;
+				this.filteredPinnedEnrollments = this.pinnedEnrollments.clone();
+				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.clone();
 				this.filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._pinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -237,14 +237,6 @@
 	<script>
 		'use strict';
 
-		if (!Array.prototype.clone) {
-			Array.prototype.clone = function() {
-				return this.map( function(e) {
-					return Array.isArray(e) ? e.clone() : e;
-				});
-			};
-		}
-
 		Polymer({
 			is: 'd2l-all-courses',
 			properties: {
@@ -539,10 +531,10 @@
 				return itemCount;
 			},
 			_setFilteredPinnedEnrollments: function() {
-				this.filteredPinnedEnrollments = this.pinnedEnrollments.clone();
+				this.filteredPinnedEnrollments = this.pinnedEnrollments.slice();
 			},
 			_setFilteredUnpinnedEnrollments: function() {
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.clone();
+				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
 			},
 			load: function() {
 				// Load course tile and filter contents. Called from d2l-my-courses.
@@ -552,8 +544,8 @@
 				this.$['search-widget']._searchString = '';
 				this._pinnedCoursesMap = {};
 				this._unpinnedCoursesMap = {};
-				this.filteredPinnedEnrollments = this.pinnedEnrollments.clone();
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.clone();
+				this.filteredPinnedEnrollments = this.pinnedEnrollments.slice();
+				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
 				this.filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._pinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -91,56 +91,62 @@
 					this.unpinnedEnrollments.length > 0 ||
 					this.unpinnedEnrollmentsQueue.length > 0);
 			},
+			_addEnrollmentToList: function(pinned, enrollmentEntity, enrollmentId) {
+				var listName = (pinned ? 'pinned' : 'unpinned') + 'Enrollments';
+
+				this._setEnrollmentPinData(enrollmentEntity, pinned);
+
+				if (this.usePendingLists) {
+					this.push(listName + 'Queue', enrollmentEntity);
+				} else {
+					this._tilesInPinStateTransition.push(enrollmentId);
+					this.unshift(listName, enrollmentEntity);
+				}
+			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
-				// Remove enrollment from unpinned list, add to pinned
-				var enrollmentId = this.getEntityIdentifier(enrollment);
+				var enrollmentId, enrollmentEntity;
 
-				this._moveEnrollmentIdToPinnedList(enrollmentId);
-			},
-			_moveEnrollmentToUnpinnedList: function(enrollment) {
-				// Remove enrollment from pinned list, add to unpinned
-				var enrollmentId = this.getEntityIdentifier(enrollment);
+				if (typeof enrollment === 'string') {
+					enrollmentId = enrollment;
+				} else {
+					enrollmentEntity = enrollment;
+					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
+				}
 
-				this._moveEnrollmentIdToUnpinnedList(enrollmentId);
-			},
-			_moveEnrollmentIdToPinnedList: function(enrollmentId) {
 				for (var index = 0; index < this.unpinnedEnrollments.length; index++) {
 					var pinnedEnrollmentId = this.getEntityIdentifier(this.unpinnedEnrollments[index]);
 					if (pinnedEnrollmentId === enrollmentId) {
-						var foundEnrollment = this.unpinnedEnrollments[index];
-						this._setEnrollmentPinData(foundEnrollment, true);
-
-						// If enabled, add to list of "to be added" pinned entities, and let consumer move to pinned list when desired
-						if (this.usePendingLists) {
-							this.push('pinnedEnrollmentsQueue', foundEnrollment);
-						} else {
-							this._tilesInPinStateTransition.push(enrollmentId);
-							this.unshift('pinnedEnrollments', foundEnrollment);
-						}
-
+						enrollmentEntity = enrollmentEntity || this.unpinnedEnrollments[index];
 						this.splice('unpinnedEnrollments', index, 1);
 						break;
 					}
 				}
+
+				if (enrollmentEntity) {
+					this._addEnrollmentToList(true, enrollmentEntity, enrollmentId);
+				}
 			},
-			_moveEnrollmentIdToUnpinnedList: function(enrollmentId) {
+			_moveEnrollmentToUnpinnedList: function(enrollment) {
+				var enrollmentId, enrollmentEntity;
+
+				if (typeof enrollment === 'string') {
+					enrollmentId = enrollment;
+				} else {
+					enrollmentEntity = enrollment;
+					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
+				}
+
 				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
 					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
 					if (unpinnedEnrollmentId === enrollmentId) {
-						var foundEnrollment = this.pinnedEnrollments[index];
-						this._setEnrollmentPinData(foundEnrollment, false);
-
-						// If enabled, add to list of "to be added" unpinned entities, and let consumer move to unpinned list when desired
-						if (this.usePendingLists) {
-							this.push('unpinnedEnrollmentsQueue', foundEnrollment);
-						} else {
-							this._tilesInPinStateTransition.push(enrollmentId);
-							this.unshift('unpinnedEnrollments', foundEnrollment);
-						}
-
+						enrollmentEntity = enrollmentEntity || this.pinnedEnrollments[index];
 						this.splice('pinnedEnrollments', index, 1);
 						break;
 					}
+				}
+
+				if (enrollmentEntity) {
+					this._addEnrollmentToList(false, enrollmentEntity, enrollmentId);
 				}
 			},
 			_onTileRemoveComplete: function(e) {
@@ -168,10 +174,10 @@
 				}
 			},
 			_pinEnrollment: function(orgUnitId) {
-				this._moveEnrollmentIdToPinnedList(this._enrollmentIdMap[orgUnitId]);
+				this._moveEnrollmentToPinnedList(this._enrollmentIdMap[orgUnitId]);
 			},
 			_unpinEnrollment: function(orgUnitId) {
-				this._moveEnrollmentIdToUnpinnedList(this._enrollmentIdMap[orgUnitId]);
+				this._moveEnrollmentToUnpinnedList(this._enrollmentIdMap[orgUnitId]);
 			}
 		};
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -90,7 +90,7 @@
 				</d2l-alert>
 			</template>
 			<d2l-course-tile-grid
-				enrollments="{{pinnedEnrollments}}"
+				enrollments="[[pinnedEnrollments]]"
 				tile-sizes="[[_tileSizes]]"
 				user-id="[[userId]]"
 				tenant-id="[[tenantId]]"
@@ -106,12 +106,12 @@
 		</div>
 
 		<d2l-all-courses
-			pinned-enrollments="{{pinnedEnrollments}}"
-			unpinned-enrollments="{{unpinnedEnrollments}}"
+			pinned-enrollments="[[pinnedEnrollments]]"
+			unpinned-enrollments="[[unpinnedEnrollments]]"
 			my-enrollments-entity="[[_lastEnrollmentsSearchResponse]]"
 			lastEnrollmentsSearchResponse="[[_lastEnrollmentsSearchResponse]]"
 			locale="[[locale]]"
-      show-course-code="[[showCourseCode]]">
+      		show-course-code="[[showCourseCode]]">
 		</d2l-all-courses>
 
 		<d2l-simple-overlay


### PR DESCRIPTION
Fixes an issue where arrays were getting aliased, causing some unintended results when pinning/unpinning. Somehow arrays in `d2l-all-courses` and `d2l-my-courses` were getting aliased by Polymer as well, which is fixed by this, but not particularly well understood why it happened..

Fixes an issue where course pin changes in the All Courses view that acted on enrollments that My Courses was unaware of would results in pinning not working. Enrollment entities are now always added to the correct list of pinned/unpinned enrollment entities, and only removed from the other list when it exists.

Enforced one-way data binding on a ton of array properties that we currently only want to use one-way.