### PR TITLE
Update d2l-siren-parser-ui

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,7 @@
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^0.2.4",
-    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.1",
+    "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",
     "iron-a11y-announcer": "^1.0.5",
     "iron-a11y-keys": "^1.0.6",


### PR DESCRIPTION
Addresses a problem that was causing some test failures due to trying to parse nothing. In the context of the tests, it's fine that we're passing nothing (usually just means something wasn't fully mocked out), but without this update the tests would fail for an effectively-unrelated reason.

Should solve build failures like https://travis-ci.org/Brightspace/d2l-my-courses-ui/builds/186197684. This is actually _slightly_ circumventing the issue, since we could avoid it entirely by mocking out everything in tests.