### PR TITLE
Allow fetching of enrollment entity on external pin/unpin event

### DIFF
--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -176,18 +176,18 @@
 			_fetchEnrollmentEntity: function(orgUnitId, pinned) {
 				if (!this._fetchEnrollmentAjaxPinned) {
 					this._fetchEnrollmentAjaxPinned = document.createElement('d2l-ajax');
-					this._fetchEnrollmentAjaxPinned.onResponse = 
+					this._fetchEnrollmentAjaxPinned.onResponse =
 						this._onFetchEnrollmentEntityPinnedResponse.bind(this);
 				}
 
 				if (!this._fetchEnrollmentAjaxUnpinned) {
 					this._fetchEnrollmentAjaxUnpinned = document.createElement('d2l-ajax');
-					this._fetchEnrollmentAjaxUnpinned.onResponse = 
+					this._fetchEnrollmentAjaxUnpinned.onResponse =
 						this._onFetchEnrollmentEntityUnpinnedResponse.bind(this);
 				}
 
-				var ajax = pinned 
-					? this._fetchEnrollmentAjaxPinned 
+				var ajax = pinned
+					? this._fetchEnrollmentAjaxPinned
 					: this._fetchEnrollmentAjaxUnpinned;
 
 				ajax.url = this.fetchEnrollmentUrl + orgUnitId;

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -173,50 +173,51 @@
 					entity._actionsByName['pin-course'] = entity.actions[0];
 				}
 			},
-			_pinEnrollment: function(orgUnitId) {
-				var enrollmentId = this._enrollmentIdMap[orgUnitId];
-
-				if (enrollmentId) {
-					this._moveEnrollmentToPinnedList(enrollmentId);
-				} else {
-					this._fetchEnrollmentEntity(orgUnitId, true);
-				}
-			},
-			_unpinEnrollment: function(orgUnitId) {
-				var enrollmentId = this._enrollmentIdMap[orgUnitId];
-
-				if (enrollmentId) {
-					this._moveEnrollmentToUnpinnedList(enrollmentId);
-				} else {
-					this._fetchEnrollmentEntity(orgUnitId, false);
-				}
-			},
 			_fetchEnrollmentEntity: function(orgUnitId, pinned) {
-				var ajax = document.createElement('d2l-ajax');
+				if (!this._fetchEnrollmentAjaxPinned) {
+					this._fetchEnrollmentAjaxPinned = document.createElement('d2l-ajax');
+					this._fetchEnrollmentAjaxPinned.onResponse = 
+						this._onFetchEnrollmentEntityPinnedResponse.bind(this);
+				}
+
+				if (!this._fetchEnrollmentAjaxUnpinned) {
+					this._fetchEnrollmentAjaxUnpinned = document.createElement('d2l-ajax');
+					this._fetchEnrollmentAjaxUnpinned.onResponse = 
+						this._onFetchEnrollmentEntityUnpinnedResponse.bind(this);
+				}
+
+				var ajax = pinned 
+					? this._fetchEnrollmentAjaxPinned 
+					: this._fetchEnrollmentAjaxUnpinned;
 
 				ajax.url = this.fetchEnrollmentUrl + orgUnitId;
 				ajax.method = 'GET';
-				ajax.onResponse = function(response) {
-					if (response.detail.status === 200 || response.detail.status === 304) {
-						// Parse siren entity
-						var parser = document.createElement('d2l-siren-parser');
-						var enrollmentEntity = parser.parse(response.detail.xhr.response);
-
-						if (pinned) {
-							// Enforce specific pin state
-							this._setEnrollmentPinData(enrollmentEntity, pinned);
-						} else {
-							pinned = enrollmentEntity.hasClass('pinned');
-						}
-
-						if (pinned) {
-							this._moveEnrollmentToPinnedList(enrollmentEntity);
-						} else {
-							this._moveEnrollmentToUnpinnedList(enrollmentEntity);
-						}
-					}
-				}.bind(this);
 				ajax.generateRequest();
+			},
+			_onFetchEnrollmentEntityPinnedResponse: function(response) {
+				this._onFetchEnrollmentEntityResponse(response, true);
+			},
+			_onFetchEnrollmentEntityUnpinnedResponse: function(response) {
+				this._onFetchEnrollmentEntityResponse(response, false);
+			},
+			_onFetchEnrollmentEntityResponse: function(response, pinned) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					this._sirenParser = this._sirenParser || document.createElement('d2l-siren-parser');
+					var enrollmentEntity = this._sirenParser.parse(response.detail.xhr.response);
+
+					if (pinned) {
+						// Enforce specific pin state
+						this._setEnrollmentPinData(enrollmentEntity, pinned);
+					} else {
+						pinned = enrollmentEntity.hasClass('pinned');
+					}
+
+					if (pinned) {
+						this._moveEnrollmentToPinnedList(enrollmentEntity);
+					} else {
+						this._moveEnrollmentToUnpinnedList(enrollmentEntity);
+					}
+				}
 			}
 		};
 

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -177,13 +177,13 @@
 				if (!this._fetchEnrollmentAjaxPinned) {
 					this._fetchEnrollmentAjaxPinned = document.createElement('d2l-ajax');
 					this._fetchEnrollmentAjaxPinned.onResponse =
-						this._onFetchEnrollmentEntityPinnedResponse.bind(this);
+						this._onFetchEnrollmentEntityResponse.bind(this, true);
 				}
 
 				if (!this._fetchEnrollmentAjaxUnpinned) {
 					this._fetchEnrollmentAjaxUnpinned = document.createElement('d2l-ajax');
 					this._fetchEnrollmentAjaxUnpinned.onResponse =
-						this._onFetchEnrollmentEntityUnpinnedResponse.bind(this);
+						this._onFetchEnrollmentEntityResponse.bind(this, false);
 				}
 
 				var ajax = pinned
@@ -194,13 +194,7 @@
 				ajax.method = 'GET';
 				ajax.generateRequest();
 			},
-			_onFetchEnrollmentEntityPinnedResponse: function(response) {
-				this._onFetchEnrollmentEntityResponse(response, true);
-			},
-			_onFetchEnrollmentEntityUnpinnedResponse: function(response) {
-				this._onFetchEnrollmentEntityResponse(response, false);
-			},
-			_onFetchEnrollmentEntityResponse: function(response, pinned) {
+			_onFetchEnrollmentEntityResponse: function(pinned, response) {
 				if (response.detail.status === 200 || response.detail.status === 304) {
 					this._sirenParser = this._sirenParser || document.createElement('d2l-siren-parser');
 					var enrollmentEntity = this._sirenParser.parse(response.detail.xhr.response);

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -174,10 +174,49 @@
 				}
 			},
 			_pinEnrollment: function(orgUnitId) {
-				this._moveEnrollmentToPinnedList(this._enrollmentIdMap[orgUnitId]);
+				var enrollmentId = this._enrollmentIdMap[orgUnitId];
+
+				if (enrollmentId) {
+					this._moveEnrollmentToPinnedList(enrollmentId);
+				} else {
+					this._fetchEnrollmentEntity(orgUnitId, true);
+				}
 			},
 			_unpinEnrollment: function(orgUnitId) {
-				this._moveEnrollmentToUnpinnedList(this._enrollmentIdMap[orgUnitId]);
+				var enrollmentId = this._enrollmentIdMap[orgUnitId];
+
+				if (enrollmentId) {
+					this._moveEnrollmentToUnpinnedList(enrollmentId);
+				} else {
+					this._fetchEnrollmentEntity(orgUnitId, false);
+				}
+			},
+			_fetchEnrollmentEntity: function(orgUnitId, pinned) {
+				var ajax = document.createElement('d2l-ajax');
+
+				ajax.url = this.fetchEnrollmentUrl + orgUnitId;
+				ajax.method = 'GET';
+				ajax.onResponse = function(response) {
+					if (response.detail.status === 200 || response.detail.status === 304) {
+						// Parse siren entity
+						var parser = document.createElement('d2l-siren-parser');
+						var enrollmentEntity = parser.parse(response.detail.xhr.response);
+
+						if (pinned) {
+							// Enforce specific pin state
+							this._setEnrollmentPinData(enrollmentEntity, pinned);
+						} else {
+							pinned = enrollmentEntity.hasClass('pinned');
+						}
+
+						if (pinned) {
+							this._moveEnrollmentToPinnedList(enrollmentEntity);
+						} else {
+							this._moveEnrollmentToUnpinnedList(enrollmentEntity);
+						}
+					}
+				}.bind(this);
+				ajax.generateRequest();
 			}
 		};
 

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -205,12 +205,8 @@
 					this._sirenParser = this._sirenParser || document.createElement('d2l-siren-parser');
 					var enrollmentEntity = this._sirenParser.parse(response.detail.xhr.response);
 
-					if (pinned) {
-						// Enforce specific pin state
-						this._setEnrollmentPinData(enrollmentEntity, pinned);
-					} else {
-						pinned = enrollmentEntity.hasClass('pinned');
-					}
+					// Enforce specific pin state
+					this._setEnrollmentPinData(enrollmentEntity, pinned);
 
 					if (pinned) {
 						this._moveEnrollmentToPinnedList(enrollmentEntity);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -349,10 +349,16 @@
 			},
 			_onEnrollmentPinnedMessage: function(e) {
 				if (e.target !== this) {
-					if (e.detail.isPinned) {
-						this._pinEnrollment(e.detail.orgUnitId);
+					var enrollmentId = this._enrollmentIdMap[e.detail.orgUnitId];
+
+					if (enrollmentId) {
+						if (e.detail.isPinned) {
+							this._moveEnrollmentToPinnedList(enrollmentId);
+						} else {
+							this._moveEnrollmentToUnpinnedList(enrollmentId);
+						}
 					} else {
-						this._unpinEnrollment(e.detail.orgUnitId);
+						this._fetchEnrollmentEntity(e.detail.orgUnitId, e.detail.isPinned);
 					}
 				}
 			},

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -237,6 +237,7 @@
 					}
 
 					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
+					this.fetchEnrollmentUrl = searchAction.href + '/organizations/';
 
 					var pinDateQuery = {
 						pageSize: 25,


### PR DESCRIPTION
Fetch unknown enrollment entities on external pin/unpin event (eg, a course is pinned in the Course Selector dropdown, but the enrollment entity for that course hasn't been retrieved by My Courses yet). Otherwise, pinning a course in this sitation would result in nothing happening in My Courses, when it should add the pinned course there as well, in all circumstances.

