### PR TITLE
US80997 - Don't render all-courses initially

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -39,6 +39,12 @@
 				--d2l-icon-width: 15px;
 				margin-top: -0.35rem;
 			}
+			d2l-loading-spinner {
+				margin-bottom: 30px;
+				padding-bottom: 30px;
+				display: block;
+				margin: auto;
+			}
 			.d2l-all-courses-hidden {
 				display: none !important;
 			}
@@ -115,12 +121,6 @@
 				text-decoration: underline;
 				color: var(--d2l-color-celestine);
 			}
-			#lazyLoadSpinner {
-				margin-bottom: 30px;
-				padding-bottom: 30px;
-				display: block;
-				margin: auto;
-			}
 		</style>
 
 		<d2l-ajax
@@ -137,100 +137,111 @@
 			locale="[[locale]]"
 			with-backdrop>
 
-			<iron-scroll-threshold
-				id="all-courses-scroll-threshold"
-				on-lower-threshold="_loadNextEnrollmentsPage">
-			</iron-scroll-threshold>
+			<div
+				id="overlayContent"
+				class="d2l-all-courses-hidden">
 
-			<div class="search-and-filter">
-				<d2l-search-widget-custom
-					id="search-widget"
-					my-enrollments-entity="[[myEnrollmentsEntity]]"
-					parent-organizations="[[_parentOrganizations]]"
-					sort-field="[[_sortField]]">
-				</d2l-search-widget-custom>
+				<iron-scroll-threshold
+					id="all-courses-scroll-threshold"
+					on-lower-threshold="_loadNextEnrollmentsPage">
+				</iron-scroll-threshold>
 
-				<div id="filterAndSort" class="d2l-all-courses-hidden">
-					<div id="filterSection" class="d2l-all-courses-hidden">
-						<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
-						<d2l-dropdown id="filterDropdown">
+				<div class="search-and-filter">
+					<d2l-search-widget-custom
+						id="search-widget"
+						my-enrollments-entity="[[myEnrollmentsEntity]]"
+						parent-organizations="[[_parentOrganizations]]"
+						sort-field="[[_sortField]]">
+					</d2l-search-widget-custom>
+
+					<div id="filterAndSort" class="d2l-all-courses-hidden">
+						<div id="filterSection" class="d2l-all-courses-hidden">
+							<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
+							<d2l-dropdown id="filterDropdown">
+								<button
+									id="filterDropdownOpener"
+									class="d2l-dropdown-opener dropdown-button"
+									on-focus="_focusFilterText"
+									on-blur="_blurFilterText"
+									on-mouseenter="_focusFilterText"
+									on-mouseleave="_blurFilterText"
+									aria-labelledby="filterText">
+									<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+								</button>
+								<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
+									<d2l-filter-menu-content
+										id="filterMenuContent"
+										my-enrollments-entity="[[myEnrollmentsEntity]]">
+									</d2l-filter-menu-content>
+									<iron-scroll-threshold
+										id="scrollThreshold"
+										on-lower-threshold="_onLowerThreshold">
+									</iron-scroll-threshold>
+								</d2l-dropdown-content>
+							</d2l-dropdown>
+						</div>
+
+						<d2l-dropdown id="sortDropdown">
 							<button
-								id="filterDropdownOpener"
 								class="d2l-dropdown-opener dropdown-button"
-								on-focus="_focusFilterText"
-								on-blur="_blurFilterText"
-								on-mouseenter="_focusFilterText"
-								on-mouseleave="_blurFilterText"
-								aria-labelledby="filterText">
+								aria-labelledby="sortText">
+								<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
 								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 							</button>
-							<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
-								<d2l-filter-menu-content
-									id="filterMenuContent"
-									my-enrollments-entity="[[myEnrollmentsEntity]]">
-								</d2l-filter-menu-content>
-								<iron-scroll-threshold
-									id="scrollThreshold"
-									on-lower-threshold="_onLowerThreshold">
-								</iron-scroll-threshold>
-							</d2l-dropdown-content>
+							<d2l-dropdown-menu no-padding min-width="350">
+								<d2l-menu label="{{localize('sorting.sortBy')}}">
+									<div class="dropdown-content-header">
+										<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+									</div>
+									<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+									<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+									<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+									<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+								</d2l-menu>
+							</d2l-dropdown-menu>
 						</d2l-dropdown>
 					</div>
-
-					<d2l-dropdown id="sortDropdown">
-						<button
-							class="d2l-dropdown-opener dropdown-button"
-							aria-labelledby="sortText">
-							<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
-							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-						</button>
-						<d2l-dropdown-menu no-padding min-width="350">
-							<d2l-menu label="{{localize('sorting.sortBy')}}">
-								<div class="dropdown-content-header">
-									<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
-								</div>
-								<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
-							</d2l-menu>
-						</d2l-dropdown-menu>
-					</d2l-dropdown>
 				</div>
-			</div>
 
-			<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
+				<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 
-			<template is="dom-repeat" items="{{_alerts}}">
-				<d2l-alert type="[[item.alertType]]">
-					{{item.alertMessage}}
-				</d2l-alert>
-			</template>
+				<template is="dom-repeat" items="{{_alerts}}">
+					<d2l-alert type="[[item.alertType]]">
+						{{item.alertMessage}}
+					</d2l-alert>
+				</template>
 
-			<d2l-course-tile-grid
-				id="all-courses-pinned"
-				enrollments="[[filteredPinnedEnrollments]]"
-				enrollments-queue="[[filteredPinnedEnrollmentsQueue]]"
-				delay-load="[[delayLoad]]"
-				tile-sizes="[[_tileSizes]]"
-				show-course-code="[[showCourseCode]]">
-			</d2l-course-tile-grid>
+				<d2l-course-tile-grid
+					id="all-courses-pinned"
+					enrollments="[[filteredPinnedEnrollments]]"
+					enrollments-queue="[[filteredPinnedEnrollmentsQueue]]"
+					delay-load="[[delayLoad]]"
+					tile-sizes="[[_tileSizes]]"
+					show-course-code="[[showCourseCode]]">
+				</d2l-course-tile-grid>
 
-			<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
+				<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
 
-			<d2l-course-tile-grid
-				id="all-courses-unpinned"
-				enrollments="[[filteredUnpinnedEnrollments]]"
-				enrollments-queue="[[filteredUnpinnedEnrollmentsQueue]]"
-				delay-load="[[delayLoad]]"
-				tile-sizes="[[_tileSizes]]"
-				show-course-code="[[showCourseCode]]">
-			</d2l-course-tile-grid>
+				<d2l-course-tile-grid
+					id="all-courses-unpinned"
+					enrollments="[[filteredUnpinnedEnrollments]]"
+					enrollments-queue="[[filteredUnpinnedEnrollmentsQueue]]"
+					delay-load="[[delayLoad]]"
+					tile-sizes="[[_tileSizes]]"
+					show-course-code="[[showCourseCode]]">
+				</d2l-course-tile-grid>
+
 				<d2l-loading-spinner
 					id="lazyLoadSpinner"
 					class="d2l-all-courses-hidden"
 					size="100">
 				</d2l-loading-spinner>
+			</div>
+
+			<d2l-loading-spinner
+				id="overlayLoadingSpinner"
+				size="100">
+			</d2l-loading-spinner>
 		</d2l-simple-overlay>
 	</template>
 
@@ -540,7 +551,6 @@
 			},
 			load: function() {
 				// Load course tile and filter contents. Called from d2l-my-courses.
-				this.$$('#all-courses').open();
 				this.$['all-courses-scroll-threshold'].scrollTarget = this.$['all-courses'].scrollRegion;
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this.$['search-widget']._searchString = '';
@@ -556,6 +566,9 @@
 				}, this);
 				this.set('delayLoad', false);
 
+				this.toggleClass('d2l-all-courses-hidden', false, this.$.overlayContent);
+				this.toggleClass('d2l-all-courses-hidden', true, this.$.overlayLoadingSpinner);
+
 				// Only make the call to load the filter menu contents if user has a
 				// substantial number of enrollments - otherwise, hide the filter menu
 				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
@@ -567,6 +580,9 @@
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
 					this.fire('recalculate-columns');
 				}.bind(this), 50);
+			},
+			open: function() {
+				this.$$('#all-courses').open();
 			},
 			setCourseImage: function(details) {
 				this._removeAlert('setCourseImageFailure');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -242,7 +242,7 @@
 			properties: {
 				// URL constructed to fetch a user's enrollments with the enrollments search Action
 				_enrollmentsSearchUrl: String,
-					// Set of pinned enrollment Entities
+				// Set of pinned enrollment Entities
 				pinnedEnrollments: {
 					type: Array,
 					value: function() {
@@ -562,6 +562,11 @@
 					this.$.filterMenuContent.load();
 					this.toggleClass('d2l-all-courses-hidden', false, this.$.filterAndSort);
 				}
+
+				setTimeout(function() {
+					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
+					this.fire('recalculate-columns');
+				}.bind(this), 50);
 			},
 			setCourseImage: function(details) {
 				this._removeAlert('setCourseImageFailure');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -566,19 +566,22 @@
 				}, this);
 				this.set('delayLoad', false);
 
-				this.toggleClass('d2l-all-courses-hidden', false, this.$.overlayContent);
-				this.toggleClass('d2l-all-courses-hidden', true, this.$.overlayLoadingSpinner);
-
-				// Only make the call to load the filter menu contents if user has a
-				// substantial number of enrollments - otherwise, hide the filter menu
+				// Only make the call to load the filter menu contents if user has many enrollments
 				if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
 					this.$.filterMenuContent.load();
-					this.toggleClass('d2l-all-courses-hidden', false, this.$.filterAndSort);
 				}
 
 				setTimeout(function() {
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
 					this.fire('recalculate-columns');
+
+					this.toggleClass('d2l-all-courses-hidden', false, this.$.overlayContent);
+					this.toggleClass('d2l-all-courses-hidden', true, this.$.overlayLoadingSpinner);
+
+					// Show filter menu after content is shown if user has many enrollments
+					if (this.pinnedEnrollments.length + this.unpinnedEnrollments.length >= 20) {
+						this.toggleClass('d2l-all-courses-hidden', false, this.$.filterAndSort);
+					}
 				}.bind(this), 50);
 			},
 			open: function() {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -121,8 +121,8 @@
 				display: block;
 				margin: auto;
 			}
-
 		</style>
+
 		<d2l-ajax
 			id="enrollmentsSearchRequest"
 			url="[[_enrollmentsSearchUrl]]"
@@ -130,107 +130,107 @@
 			on-iron-ajax-response="_enrollmentsSearchResponse"
 			last-response="{{lastEnrollmentsSearchResponse}}">
 		</d2l-ajax>
+
 		<d2l-simple-overlay
 			id="all-courses"
 			title-name="{{localize('allCourses')}}"
 			locale="[[locale]]"
 			with-backdrop>
 
+			<iron-scroll-threshold
+				id="all-courses-scroll-threshold"
+				on-lower-threshold="_loadNextEnrollmentsPage">
+			</iron-scroll-threshold>
 
-		<iron-scroll-threshold
-			id="all-courses-scroll-threshold"
-			on-lower-threshold="_loadNextEnrollmentsPage">
-		</iron-scroll-threshold>
+			<div class="search-and-filter">
+				<d2l-search-widget-custom
+					id="search-widget"
+					my-enrollments-entity="[[myEnrollmentsEntity]]"
+					parent-organizations="[[_parentOrganizations]]"
+					sort-field="[[_sortField]]">
+				</d2l-search-widget-custom>
 
-		<div class="search-and-filter">
-			<d2l-search-widget-custom
-				id="search-widget"
-				my-enrollments-entity="[[myEnrollmentsEntity]]"
-				parent-organizations="[[_parentOrganizations]]"
-				sort-field="[[_sortField]]">
-			</d2l-search-widget-custom>
+				<div id="filterAndSort" class="d2l-all-courses-hidden">
+					<div id="filterSection" class="d2l-all-courses-hidden">
+						<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
+						<d2l-dropdown id="filterDropdown">
+							<button
+								id="filterDropdownOpener"
+								class="d2l-dropdown-opener dropdown-button"
+								on-focus="_focusFilterText"
+								on-blur="_blurFilterText"
+								on-mouseenter="_focusFilterText"
+								on-mouseleave="_blurFilterText"
+								aria-labelledby="filterText">
+								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+							</button>
+							<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
+								<d2l-filter-menu-content
+									id="filterMenuContent"
+									my-enrollments-entity="[[myEnrollmentsEntity]]">
+								</d2l-filter-menu-content>
+								<iron-scroll-threshold
+									id="scrollThreshold"
+									on-lower-threshold="_onLowerThreshold">
+								</iron-scroll-threshold>
+							</d2l-dropdown-content>
+						</d2l-dropdown>
+					</div>
 
-			<div id="filterAndSort" class="d2l-all-courses-hidden">
-				<div id="filterSection" class="d2l-all-courses-hidden">
-					<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
-					<d2l-dropdown id="filterDropdown">
+					<d2l-dropdown id="sortDropdown">
 						<button
-							id="filterDropdownOpener"
 							class="d2l-dropdown-opener dropdown-button"
-							on-focus="_focusFilterText"
-							on-blur="_blurFilterText"
-							on-mouseenter="_focusFilterText"
-							on-mouseleave="_blurFilterText"
-							aria-labelledby="filterText">
+							aria-labelledby="sortText">
+							<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
 							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 						</button>
-						<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
-							<d2l-filter-menu-content
-								id="filterMenuContent"
-								my-enrollments-entity="[[myEnrollmentsEntity]]">
-							</d2l-filter-menu-content>
-							<iron-scroll-threshold
-								id="scrollThreshold"
-								on-lower-threshold="_onLowerThreshold">
-							</iron-scroll-threshold>
-						</d2l-dropdown-content>
+						<d2l-dropdown-menu no-padding min-width="350">
+							<d2l-menu label="{{localize('sorting.sortBy')}}">
+								<div class="dropdown-content-header">
+									<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+								</div>
+								<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+							</d2l-menu>
+						</d2l-dropdown-menu>
 					</d2l-dropdown>
 				</div>
-
-				<d2l-dropdown id="sortDropdown">
-					<button
-						class="d2l-dropdown-opener dropdown-button"
-						aria-labelledby="sortText">
-						<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
-						<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-					</button>
-					<d2l-dropdown-menu no-padding min-width="350">
-						<d2l-menu label="{{localize('sorting.sortBy')}}">
-							<div class="dropdown-content-header">
-								<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
-							</div>
-							<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-							<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-							<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
-							<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
-						</d2l-menu>
-					</d2l-dropdown-menu>
-				</d2l-dropdown>
 			</div>
-		</div>
 
-		<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
+			<h2 class="d2l-heading-3">{{localize('pinnedCourses')}}</h2>
 
-		<template is="dom-repeat" items="{{_alerts}}">
-			<d2l-alert type="[[item.alertType]]">
-				{{item.alertMessage}}
-			</d2l-alert>
-		</template>
+			<template is="dom-repeat" items="{{_alerts}}">
+				<d2l-alert type="[[item.alertType]]">
+					{{item.alertMessage}}
+				</d2l-alert>
+			</template>
 
-		<d2l-course-tile-grid
-			id="all-courses-pinned"
-			enrollments="[[filteredPinnedEnrollments]]"
-			enrollments-queue="[[filteredPinnedEnrollmentsQueue]]"
-			delay-load="[[delayLoad]]"
-			tile-sizes="[[_tileSizes]]"
-			show-course-code="[[showCourseCode]]">
-		</d2l-course-tile-grid>
+			<d2l-course-tile-grid
+				id="all-courses-pinned"
+				enrollments="[[filteredPinnedEnrollments]]"
+				enrollments-queue="[[filteredPinnedEnrollmentsQueue]]"
+				delay-load="[[delayLoad]]"
+				tile-sizes="[[_tileSizes]]"
+				show-course-code="[[showCourseCode]]">
+			</d2l-course-tile-grid>
 
-		<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
+			<h2 class="d2l-heading-3">{{localize('unpinnedCourses')}}</h2>
 
-		<d2l-course-tile-grid
-			id="all-courses-unpinned"
-			enrollments="[[filteredUnpinnedEnrollments]]"
-			enrollments-queue="[[filteredUnpinnedEnrollmentsQueue]]"
-			delay-load="[[delayLoad]]"
-			tile-sizes="[[_tileSizes]]"
-			show-course-code="[[showCourseCode]]">
-		</d2l-course-tile-grid>
-			<d2l-loading-spinner
-				id="lazyLoadSpinner"
-				class="d2l-all-courses-hidden"
-				size="100">
-			</d2l-loading-spinner>
+			<d2l-course-tile-grid
+				id="all-courses-unpinned"
+				enrollments="[[filteredUnpinnedEnrollments]]"
+				enrollments-queue="[[filteredUnpinnedEnrollmentsQueue]]"
+				delay-load="[[delayLoad]]"
+				tile-sizes="[[_tileSizes]]"
+				show-course-code="[[showCourseCode]]">
+			</d2l-course-tile-grid>
+				<d2l-loading-spinner
+					id="lazyLoadSpinner"
+					class="d2l-all-courses-hidden"
+					size="100">
+				</d2l-loading-spinner>
 		</d2l-simple-overlay>
 	</template>
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -216,12 +216,6 @@
 			_createAllCourses: function() {
 				if (!this._allCoursesCreated) {
 					var allCourses = document.createElement('d2l-all-courses');
-					allCourses.pinnedEnrollments = this.pinnedEnrollments;
-					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
-					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
-					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
-					allCourses.locale = this.locale;
-					allCourses.showCourseCode = this.showCourseCode;
 					this.$.allCoursesPlaceholder.appendChild(allCourses);
 					this._allCoursesCreated = true;
 				}
@@ -312,9 +306,24 @@
 			_openAllCoursesView: function(e) {
 				this._createAllCourses();
 
+				var allCourses = this.$$('d2l-all-courses');
+				allCourses.open();
+
 				e.preventDefault();
 				e.stopPropagation();
-				this.$$('d2l-all-courses').load();
+
+				this.async(function() {
+					// The opening of the overlay lags slightly if we try to do this while it
+					// is opening - do it after the animation is finished. Animation takes
+					// 500ms, but some lag if we wait exactly that long, so +100ms for safety)
+					allCourses.pinnedEnrollments = this.pinnedEnrollments;
+					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
+					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
+					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
+					allCourses.locale = this.locale;
+					allCourses.showCourseCode = this.showCourseCode;
+					this.$$('d2l-all-courses').load();
+				}.bind(this), 600);
 			},
 			_refreshPage: function() {
 				document.location.reload(true);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -53,8 +53,6 @@
 				margin-bottom: 20px;
 				clear: both;
 			}
-
-
 		</style>
 
 		<d2l-ajax
@@ -105,14 +103,8 @@
 			</button>
 		</div>
 
-		<d2l-all-courses
-			pinned-enrollments="[[pinnedEnrollments]]"
-			unpinned-enrollments="[[unpinnedEnrollments]]"
-			my-enrollments-entity="[[_lastEnrollmentsSearchResponse]]"
-			lastEnrollmentsSearchResponse="[[_lastEnrollmentsSearchResponse]]"
-			locale="[[locale]]"
-      		show-course-code="[[showCourseCode]]">
-		</d2l-all-courses>
+		<div id="allCoursesPlaceholder">
+		</div>
 
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
@@ -147,6 +139,8 @@
 				imageCatalogLocation: String,
 				// hashed userid to send to telemetry
 				userId: String,
+				// Configuration value passed in to toggle course code
+				showCourseCode: Boolean,
 				// hashed tenantid to send to telemetry
 				tenantId: String,
 				// URL to send telemetry to
@@ -213,6 +207,7 @@
 			detached: function() {
 				document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			},
+			_allCoursesCreated: false,
 			getCourseTileItemCount: function() {
 				return this.pinnedEnrollments.length;
 			},
@@ -300,15 +295,21 @@
 				this.$['basic-image-selector-overlay'].open();
 			},
 			_openAllCoursesView: function(e) {
+				if (!this._allCoursesCreated) {
+					var allCourses = document.createElement('d2l-all-courses');
+					allCourses.pinnedEnrollments = this.pinnedEnrollments;
+					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
+					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
+					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
+					allCourses.locale = this.locale;
+					allCourses.showCourseCode = this.showCourseCode;
+					this.$.allCoursesPlaceholder.appendChild(allCourses);
+					this._allCoursesCreated = true;
+				}
+
 				e.preventDefault();
 				e.stopPropagation();
-				this.$$('d2l-all-courses').lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
 				this.$$('d2l-all-courses').load();
-
-				setTimeout(function() {
-					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
-					this.fire('recalculate-columns');
-				}.bind(this), 50);
 			},
 			_refreshPage: function() {
 				document.location.reload(true);
@@ -326,7 +327,9 @@
 						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 					}
 				}
-				this.$$('d2l-all-courses').setCourseImage(e);
+				if (this._allCoursesCreated) {
+					this.$$('d2l-all-courses').setCourseImage(e);
+				}
 				this.$$('d2l-course-tile-grid').setCourseImage(e);
 			},
 			_changeImageLoadMore: function() {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -98,7 +98,9 @@
 			<button
 				class="all-courses-button"
 				hidden$="{{!_hasEnrollments}}"
-				on-tap="_openAllCoursesView">
+				on-tap="_openAllCoursesView"
+				on-mouseover="_createAllCourses"
+				on-focus="_createAllCourses">
 				{{localize('viewAllCourses')}}
 			</button>
 		</div>
@@ -211,6 +213,19 @@
 			getCourseTileItemCount: function() {
 				return this.pinnedEnrollments.length;
 			},
+			_createAllCourses: function() {
+				if (!this._allCoursesCreated) {
+					var allCourses = document.createElement('d2l-all-courses');
+					allCourses.pinnedEnrollments = this.pinnedEnrollments;
+					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
+					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
+					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
+					allCourses.locale = this.locale;
+					allCourses.showCourseCode = this.showCourseCode;
+					this.$.allCoursesPlaceholder.appendChild(allCourses);
+					this._allCoursesCreated = true;
+				}
+			},
 			_rootEnrollmentRequest: function() {
 				this._pinnedCoursesMap = {};
 				this._unpinnedCoursesMap = {};
@@ -295,17 +310,7 @@
 				this.$['basic-image-selector-overlay'].open();
 			},
 			_openAllCoursesView: function(e) {
-				if (!this._allCoursesCreated) {
-					var allCourses = document.createElement('d2l-all-courses');
-					allCourses.pinnedEnrollments = this.pinnedEnrollments;
-					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
-					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
-					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
-					allCourses.locale = this.locale;
-					allCourses.showCourseCode = this.showCourseCode;
-					this.$.allCoursesPlaceholder.appendChild(allCourses);
-					this._allCoursesCreated = true;
-				}
+				this._createAllCourses();
 
 				e.preventDefault();
 				e.stopPropagation();

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -86,6 +86,11 @@ describe('d2l-all-courses', function() {
 	it('should show filter menu when there are sufficient enrollments', function() {
 		widget.pinnedEnrollments = Array(20).fill(pinnedEnrollmentEntity);
 		widget.load();
+
+		// Class is only changed after column recalculation is done, which is done
+		// in a setTimeout to allow for a DOM width to be set
+		clock.tick(51);
+
 		expect(widget.$.filterAndSort.classList.contains('d2l-all-courses-hidden')).to.be.false;
 	});
 

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -552,9 +552,8 @@ describe('d2l-my-courses', function() {
 
 	describe('User interaction', function() {
 		it('should rescale the all courses view when it is opened', function() {
-			var allCoursesRescaleSpy = sinon.spy(widget.$$('d2l-all-courses'), '_rescaleCourseTileRegions');
-
 			widget.$$('button').click();
+			var allCoursesRescaleSpy = sinon.spy(widget.$$('d2l-all-courses'), '_rescaleCourseTileRegions');
 
 			clock.tick(100);
 			expect(allCoursesRescaleSpy.called);
@@ -563,6 +562,7 @@ describe('d2l-my-courses', function() {
 
 		it('should remove a setCourseImageFailure alert when the all-courses overlay is closed', function() {
 			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
+			widget._openAllCoursesView(new Event('foo'));
 			clock.tick(1001);
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
 			widget.$$('d2l-all-courses').children['all-courses']._handleClose();


### PR DESCRIPTION
No point registering all these WCs (which has a negative performance impact in non-Chrome browsers) if we don't need them. This also just significantly reduces the number of WCs being rendered in general - down from >1000 on the homepage to 267, according to `D2L.Performance.getComponentCounts`.

The disadvantage of this approach is that it now takes a moment for the overlay to load the first time. While this is an improvement overall, going to see if I can find a way to make it a bit less obvious.