### PR TITLE
Show loading spinner in filter menu

### DIFF
--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
+<link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-utility-behavior.html">
 <link rel="import" href="../localize-behavior.html">
@@ -12,7 +13,8 @@
 	<template>
 		<style>
 			:host {
-				display: block;
+				display: flex;
+				flex-direction: column;
 			}
 			.d2l-filter-menu-content-invisible {
 				visibility: hidden;
@@ -24,6 +26,9 @@
 			button:focus {
 				text-decoration: underline;
 				color: var(--d2l-color-celestine);
+			}
+			d2l-loading-spinner {
+				align-self: center;
 			}
 			.clear-button {
 				@apply(--d2l-body-small-text);
@@ -63,14 +68,17 @@
 			on-iron-ajax-response="_onSemestersResponse">
 		</d2l-ajax>
 
-		<div class="dropdown-content-header">
+		<d2l-loading-spinner size="50">
+		</d2l-loading-spinner>
+
+		<div id="filterHeader" class="dropdown-content-header d2l-filter-menu-content-hidden">
 			<span class="dropdown-content-header-text">{{localize('filtering.filterBy')}}</span>
 			<template is="dom-if" if="[[_showClearButton]]">
 				<button class="clear-button" on-tap="_clearFilters">{{localize('filtering.clear')}}</button>
 			</template>
 		</div>
 
-		<div id="contentView">
+		<div id="contentView" class="d2l-filter-menu-content-hidden">
 			<d2l-filter-menu-content-simple
 				id="simpleContent"
 				hidden$="[[_hasManyFilters]]">
@@ -173,6 +181,10 @@
 					if (!this._departments || !this._semesters) {
 						return;
 					}
+
+					this.toggleClass('d2l-filter-menu-content-hidden', true, this.$$('d2l-loading-spinner'));
+					this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.contentView);
+					this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.filterHeader);
 
 					this.set('_hasManyFilters', this._departments.length + this._semesters.length > 7);
 					if (this._hasManyFilters) {

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -58,14 +58,16 @@
 			id="departmentsRequest"
 			url="[[_departmentsUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onDepartmentsResponse">
+			on-iron-ajax-response="_onDepartmentsResponse"
+			on-iron-ajax-error="_onErrorResponse">
 		</d2l-ajax>
 
 		<d2l-ajax
 			id="semestersRequest"
 			url="[[_semestersUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onSemestersResponse">
+			on-iron-ajax-response="_onSemestersResponse"
+			on-iron-ajax-error="_onErrorResponse">
 		</d2l-ajax>
 
 		<d2l-loading-spinner size="50">
@@ -160,6 +162,11 @@
 				this.set('_currentFilters', []);
 				this.set('filterText', this.localize('filtering.filter'));
 			},
+			_hideLoadingSpinner: function() {
+				this.toggleClass('d2l-filter-menu-content-hidden', true, this.$$('d2l-loading-spinner'));
+				this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.contentView);
+				this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.filterHeader);
+			},
 			_myEnrollmentsEntityChanged: function(entity) {
 				// Set up search URLs and search Actions for filter dropdown
 				if (entity && entity.actions) {
@@ -182,9 +189,7 @@
 						return;
 					}
 
-					this.toggleClass('d2l-filter-menu-content-hidden', true, this.$$('d2l-loading-spinner'));
-					this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.contentView);
-					this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.filterHeader);
+					this._hideLoadingSpinner();
 
 					this.set('_hasManyFilters', this._departments.length + this._semesters.length > 7);
 					if (this._hasManyFilters) {
@@ -200,6 +205,9 @@
 			},
 			_onDepartmentsResponse: function(response) {
 				this.__onResponse(response, '_departments');
+			},
+			_onErrorResponse: function() {
+				this._hideLoadingSpinner();
 			},
 			_onSemestersResponse: function(response) {
 				this.__onResponse(response, '_semesters');

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -68,10 +68,26 @@ describe('d2l-filter-menu-content', function() {
 					href: '/organizations/1'
 				}]
 			};
+
+			component.myEnrollmentsEntity = myEnrollmentsEntity;
 		});
 
 		afterEach(function() {
 			server.restore();
+		});
+
+		it('should show a spinner and hide contents until data is fetched', function(done) {
+			var handler = function() {
+				expect(component.$$('d2l-loading-spinner').classList.contains('d2l-filter-menu-content-hidden')).to.be.true;
+				document.removeEventListener('d2l-filter-menu-content-hide', handler);
+				done();
+			};
+			document.addEventListener('d2l-filter-menu-content-hide', handler);
+
+			expect(component.$$('d2l-loading-spinner').classList.contains('d2l-filter-menu-content-hidden')).to.be.false;
+			departmentsResponse = { entities: [] };
+			semestersResponse = { entities: [] };
+			component.load();
 		});
 
 		it('should signal that it should be hidden if user does not have enough departments/semesters', function(done) {
@@ -84,8 +100,6 @@ describe('d2l-filter-menu-content', function() {
 
 			departmentsResponse = { entities: [enrollment] };
 			semestersResponse = { entities: [] };
-
-			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
 		});
 
@@ -99,8 +113,6 @@ describe('d2l-filter-menu-content', function() {
 
 			departmentsResponse = { entities: [enrollment] };
 			semestersResponse = { entities: [enrollment] };
-
-			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
 		});
 
@@ -115,8 +127,6 @@ describe('d2l-filter-menu-content', function() {
 
 			departmentsResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
 			semestersResponse = { entities: [enrollment, enrollment, enrollment] };
-
-			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
 		});
 
@@ -131,10 +141,7 @@ describe('d2l-filter-menu-content', function() {
 
 			departmentsResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
 			semestersResponse = { entities: [enrollment, enrollment, enrollment, enrollment] };
-
-			component.myEnrollmentsEntity = myEnrollmentsEntity;
 			component.load();
-
 		});
 	});
 


### PR DESCRIPTION
Until the first two requests have come back, the menu is empty, so show a loading spinner until they come back.