### PR TITLE
add course offering link to ellipsis menu

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -81,6 +81,12 @@ the user has in that organization - student, teacher, TA, etc.
 					</button>
 					<d2l-dropdown-menu id="overflow-dropdown">
 						<d2l-menu label$="[[_courseSettingsLabel]]">
+							<template is="dom-if" if="{{_courseInfoUrl}}" restamp="true">
+								<d2l-menu-item-link id="see-course-info-link"
+									text="{{localize('courseOfferingInformation')}}"
+									href="{{_courseInfoUrl}}">
+								</d2l-menu-item-link>
+							</template>
 							<template is="dom-if" if="{{_canChangeCourseImage}}" restamp="true">
 								<d2l-menu-item id="change-image-button"
 									text="{{localize('changeImage')}}"
@@ -149,6 +155,7 @@ the user has in that organization - student, teacher, TA, etc.
 				userId: String,
 				// Configuration value passed in to toggle course code
 				showCourseCode: Boolean,
+				_courseInfoUrl: String,
 				// Body sent for pin/unpin action
 				_enrollmentPinBody: String,
 				// HTTP method used by the pin/unpin action
@@ -404,6 +411,11 @@ the user has in that organization - student, teacher, TA, etc.
 					var organization = parser.parse(response.detail.xhr.response);
 
 					this._organization = organization;
+
+					var rel = /course-offering-info-page/;
+					var courseInfoUrl = organization && organization.getLinkByRel(rel);
+					this._courseInfoUrl = (courseInfoUrl) ? courseInfoUrl.href : null;
+
 					this._setCourseImageSrc();
 					this._organizationHomepageUrl = organization.getLinkByRel(/\/organization-homepage$/).href;
 					this._canChangeCourseImage = this._getCanChangeCourseImage(organization);

--- a/image-selector/d2l-basic-image-selector.html
+++ b/image-selector/d2l-basic-image-selector.html
@@ -313,7 +313,7 @@
 				this._images = (searchImages.length > 0) ? searchImages : this._defaultImages;
 			},
 			_getChangeCourseImageLink: function(organization) {
-				var rel = /edit-image-page/;
+				var rel = /course-offering-info-page/;
 				var editImagePage = organization && organization.getLinkByRel(rel);
 				if (editImagePage) {
 					return editImagePage.href;

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -50,6 +50,7 @@
 								'changeImage': 'Change Image',
 								'useThisImage': 'Use this image',
 								'courseSettings': '{course} course settings',
+								'courseOfferingInformation': 'Course Offering Information',
 								'filtering.filter': 'Filter',
 								'filtering.filterBy': 'Filter By',
 								'filtering.filterSingle': 'Filter: 1 Filter',


### PR DESCRIPTION
Also needs: https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/4218/overview

Acceptance criteria:
- If the user has access to the courseOfferingInformation page, a menu item shows up for it in the `...` menu.
- Clicking on the link brings you to that courses Course Offering Information page
- If they don't have access to the page, don't show the link