### PR TITLE
make sure the overlay open closed events are named correctly and fire…

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -189,7 +189,7 @@
 				'open-change-image-view': '_openChangeImageView',
 				'set-course-image': '_setCourseImageEvent',
 				'clear-image-scroll-threshold': '_clearImageScrollThreshold',
-				'simple-overlay-closed': '_onSimpleOverlayClosed',
+				'd2l-simple-overlay-closed': '_onSimpleOverlayClosed',
 				'd2l-root-enrollment-search': '_rootEnrollmentRequest',
 				'enrollment-pinned': '_onEnrollmentPinAction',
 				'enrollment-unpinned': '_onEnrollmentPinAction'

--- a/d2l-simple-overlay.html
+++ b/d2l-simple-overlay.html
@@ -106,7 +106,7 @@
 			},
 			_handleClose: function() {
 				this.close();
-				this.fire('simple-overlay-closed');
+				this.fire('d2l-simple-overlay-closed');
 				this.fire('recalculate-columns');
 			},
 			_handleCloseSimpleOverlayEvent: function(e) {
@@ -143,6 +143,7 @@
 				this._onNodesChange();
 				Polymer.dom(this.root).querySelector('.scrollable').scrollTop = 0;
 				this._notifyDistributedChildren('d2l-simple-overlay-opening');
+				this.fire('d2l-simple-overlay-opening');
 
 				if (this._isMobile()) {
 					this.playAnimation('mobileOpen');

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -187,7 +187,7 @@ describe('d2l-all-courses', function() {
 		it('should remove a setCourseImageFailure alert when the overlay is opened', function() {
 			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
 			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
-			widget._onSimpleOverlayOpening();
+			widget.$$('d2l-simple-overlay')._renderOpened();
 			expect(widget._alerts).to.not.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
 		});
 	});


### PR DESCRIPTION
… both to children and parents.

Basically what I discovered is that the `d2l-simple-overlay-opening` listener inside d2l-all-courses.html (https://github.com/Brightspace/d2l-my-courses-ui/blob/master/d2l-all-courses.html#L361) was no longer firing because the event was only being sent to child elements of the overlay and the all-courses page is no longer a child of the overlay as of https://github.com/Brightspace/d2l-my-courses-ui/commit/6a9890dba94b79c3a17e93fbadec741ffe82e435.

So then I also noticed the interesting naming things and stuff and @ryantmer and I decided having a single event name that is raised in both directions is probably the cleanest way to go. I'll be making use of the new upwards-firing of `d2l-simple-overlay-opening` in a future PR aimed to fix the image downloading issues being exhibited in all-courses.

To Do:

- [x] Write a test or something