### PR TITLE
Fix filter dropdown behavior

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -512,6 +512,7 @@
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
@@ -522,6 +523,7 @@
 			},
 			detached: function() {
 				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
@@ -573,7 +575,6 @@
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
-			_filterDropdownOpen: false,
 			_sortTextOptions: {
 				'courseCode': 'sorting.sortCourseCode',
 				'courseName': 'sorting.sortCourseName',
@@ -594,13 +595,11 @@
 				this.set('_parentOrganizations', e.detail.filters);
 				this.set('_filterText', e.detail.text);
 			},
+			_onFilterDropdownOpen: function() {
+				this.$.filterMenuContent.open();
+			},
 			_onFilterDropdownClose: function() {
-				// If the dropdown is closed by clicking elsewhere, we need to manually update _filterDropdownOpen
-				// since _toggleFilterDropdown doesn't run.
-				// Timeout is to ensure this runs after _toggleFilterDropdown when it's clicked closed
-				setTimeout(function() {
-					this.set('_filterDropdownOpen', false);
-				}.bind(this), 100);
+				this.$.filterDropdownOpener.focus();
 			},
 			_onFilterHideChanged: function(e) {
 				this.toggleClass('d2l-all-courses-hidden', e.detail.hide, this.$.filterSection);
@@ -617,14 +616,11 @@
 			},
 			_toggleFilterDropdown: function() {
 				// This is somewhat gross, but is a side effect of using the filter text span as a secondary opener
-				if (this._filterDropdownOpen) {
+				if (this.$.filterDropdownContent.opened) {
 					this.$.filterDropdownContent.close();
-					this.$.filterDropdownOpener.focus();
 				} else {
 					this.$.filterDropdownContent.open();
-					this.$.filterMenuContent.open();
 				}
-				this.set('_filterDropdownOpen', !this._filterDropdownOpen);
 			},
 			_updateSortBy: function(e) {
 				this.set('_sortField', e.detail.value);

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -615,7 +615,6 @@
 				this._removeAlert('setCourseImageFailure');
 			},
 			_toggleFilterDropdown: function() {
-				// This is somewhat gross, but is a side effect of using the filter text span as a secondary opener
 				if (this.$.filterDropdownContent.opened) {
 					this.$.filterDropdownContent.close();
 				} else {


### PR DESCRIPTION
Fixes DE23756, where clicking on the dropdown arrow for the search filter menu won't size the dropdown correctly or initialize the dropdown contents, while clicking on the "Filter" text would.

Eg, when there are enough departments and/or semesters to show the tabbed view, it should look like this:

![filter-dropdown-tabbed-correct](https://cloud.githubusercontent.com/assets/17710124/21732326/9dbd60aa-d41e-11e6-8221-d65084d06d8c.JPG)

But, if you click on the the dropdown arrow instead of the "Filter" text, it looks like this:

![fitler-dropdown-tabbed-broken](https://cloud.githubusercontent.com/assets/17710124/21732360/b0addca8-d41e-11e6-84a2-fb1c35d82412.JPG)

Similarly, the untabbed view should be similar to this:

![filter-dropdown-untabbed-correct](https://cloud.githubusercontent.com/assets/17710124/21732368/bc471ea8-d41e-11e6-9bdf-3a4e2f6f1c19.JPG)

But if the user clicks the dropdown arrow instead of the "Filter" text, it looks like this:

![filter-dropdown-untabbed-broken](https://cloud.githubusercontent.com/assets/17710124/21732379/cf619086-d41e-11e6-98e6-da2f6ce5a16b.JPG)
