### PR TITLE
Added advanced search url

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -210,7 +210,7 @@
 							</d2l-dropdown-menu>
 						</d2l-dropdown>
 			</div>
-			<div id="advancedSearchLink" class="advanced-search-link">
+			<div class="advanced-search-link">
 				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
 					</div>
 				</div>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -377,7 +377,10 @@
 					}
 				},
 				// URL that directs to the advanced search page
-				advancedSearchUrl: String
+				advancedSearchUrl: {
+					type: String,
+					observer: '_advancedSearchUrlChanged'
+				}
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -537,8 +540,6 @@
 				this._updateTileSizes();
 
 				this._filterText = this.localize('filtering.filter');
-
-				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
@@ -567,6 +568,9 @@
 			},
 			_setFilteredUnpinnedEnrollments: function() {
 				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
+			},
+			_advancedSearchUrlChanged: function() {
+				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
 			},
 			load: function() {
 				// Load course tile and filter contents. Called from d2l-my-courses.

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -152,67 +152,67 @@
 					on-lower-threshold="_loadNextEnrollmentsPage">
 				</iron-scroll-threshold>
 
-		<div id="search-and-filter">
-			<div class="search-and-filter-row">
-				<d2l-search-widget-custom
-					id="search-widget"
-					my-enrollments-entity="[[myEnrollmentsEntity]]"
-					parent-organizations="[[_parentOrganizations]]"
-					sort-field="[[_sortField]]">
-				</d2l-search-widget-custom>
+				<div id="search-and-filter">
+					<div class="search-and-filter-row">
+						<d2l-search-widget-custom
+							id="search-widget"
+							my-enrollments-entity="[[myEnrollmentsEntity]]"
+							parent-organizations="[[_parentOrganizations]]"
+							sort-field="[[_sortField]]">
+						</d2l-search-widget-custom>
 
-				<div id="filterAndSort" class="d2l-all-courses-hidden">
-					<div id="filterSection" class="d2l-all-courses-hidden">
-						<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
-						<d2l-dropdown id="filterDropdown">
-							<button
-								id="filterDropdownOpener"
-								class="d2l-dropdown-opener dropdown-button"
-								on-focus="_focusFilterText"
-								on-blur="_blurFilterText"
-								on-mouseenter="_focusFilterText"
-								on-mouseleave="_blurFilterText"
-								aria-labelledby="filterText">
-								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-							</button>
-							<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
-								<d2l-filter-menu-content
-									id="filterMenuContent"
-									my-enrollments-entity="[[myEnrollmentsEntity]]">
-								</d2l-filter-menu-content>
-								<iron-scroll-threshold
-									id="scrollThreshold"
-									on-lower-threshold="_onLowerThreshold">
-								</iron-scroll-threshold>
-							</d2l-dropdown-content>
-						</d2l-dropdown>
+						<div id="filterAndSort" class="d2l-all-courses-hidden">
+							<div id="filterSection" class="d2l-all-courses-hidden">
+								<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
+								<d2l-dropdown id="filterDropdown">
+									<button
+										id="filterDropdownOpener"
+										class="d2l-dropdown-opener dropdown-button"
+										on-focus="_focusFilterText"
+										on-blur="_blurFilterText"
+										on-mouseenter="_focusFilterText"
+										on-mouseleave="_blurFilterText"
+										aria-labelledby="filterText">
+										<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+									</button>
+									<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
+										<d2l-filter-menu-content
+											id="filterMenuContent"
+											my-enrollments-entity="[[myEnrollmentsEntity]]">
+										</d2l-filter-menu-content>
+										<iron-scroll-threshold
+											id="scrollThreshold"
+											on-lower-threshold="_onLowerThreshold">
+										</iron-scroll-threshold>
+									</d2l-dropdown-content>
+								</d2l-dropdown>
+							</div>
+
+							<d2l-dropdown id="sortDropdown">
+								<button
+									class="d2l-dropdown-opener dropdown-button"
+									aria-labelledby="sortText">
+									<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
+									<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+								</button>
+								<d2l-dropdown-menu no-padding min-width="350">
+									<d2l-menu label="{{localize('sorting.sortBy')}}">
+										<div class="dropdown-content-header">
+											<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+										</div>
+										<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+									</d2l-menu>
+								</d2l-dropdown-menu>
+							</d2l-dropdown>
+						</div>
 					</div>
-
-					<d2l-dropdown id="sortDropdown">
-						<button
-							class="d2l-dropdown-opener dropdown-button"
-							aria-labelledby="sortText">
-							<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
-							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-						</button>
-						<d2l-dropdown-menu no-padding min-width="350">
-							<d2l-menu label="{{localize('sorting.sortBy')}}">
-								<div class="dropdown-content-header">
-									<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
-								</div>
-								<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
-								<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
-							</d2l-menu>
-						</d2l-dropdown-menu>
-					</d2l-dropdown>
-				</div>
-			</div>
-			<div class="search-and-filter-row">
-				<div class="advanced-search-link">
-					<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
-				</div>
+					<div class="search-and-filter-row">
+						<div class="advanced-search-link">
+							<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
+						</div>
 					</div>
 				</div>
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -60,10 +60,10 @@
 				min-width: 100%;
 			}
 			.search-and-filter > d2l-search-widget-custom {
-				flex: calc(5 / 12);
+				flex: 1;
 			}
 			.search-and-filter > #filterAndSort {
-				flex: calc(7 / 12);
+				flex: 1.4;
 				display: flex;
 				justify-content: flex-end;
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -48,36 +48,32 @@
 			.d2l-all-courses-hidden {
 				display: none !important;
 			}
-			.search-and-filter {
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
+			#search-and-filter {
 				margin-bottom: 50px;
-				flex-wrap: wrap;
 			}
-			.advanced-search-link {
+			.search-and-filter-row {
+				display: flex;
+				justify-content: space-between;
+			}
+			.search-and-filter-row > .advanced-search-link {
 				font-size: 0.8rem;
-				min-width: 100%;
-			}
-			.search-and-filter > d2l-search-widget-custom {
 				flex: 1;
 			}
-			.search-and-filter > #filterAndSort {
+			.search-and-filter-row > d2l-search-widget-custom {
+				flex: 1;
+			}
+			.search-and-filter-row > #filterAndSort {
 				flex: 1.4;
 				display: flex;
 				justify-content: flex-end;
+				align-items: center;
 			}
 			@media screen and (max-width: 767px) {
-				.search-and-filter > d2l-search-widget-custom {
-					flex: 1;
-				}
-				.search-and-filter > #filterAndSort {
+				.search-and-filter-row > #filterAndSort {
 					display: none;
 				}
-				.advanced-search-link {
-					font-size: 0.8rem;
+				.search-and-filter-row > .advanced-search-link {
 					text-align: right;
-					flex: 1;
 				}
 			}
 			.dropdown-opener-text {
@@ -156,64 +152,67 @@
 					on-lower-threshold="_loadNextEnrollmentsPage">
 				</iron-scroll-threshold>
 
-				<div class="search-and-filter">
-					<d2l-search-widget-custom
-						id="search-widget"
-						my-enrollments-entity="[[myEnrollmentsEntity]]"
-						parent-organizations="[[_parentOrganizations]]"
-						sort-field="[[_sortField]]">
-					</d2l-search-widget-custom>
+		<div id="search-and-filter">
+			<div class="search-and-filter-row">
+				<d2l-search-widget-custom
+					id="search-widget"
+					my-enrollments-entity="[[myEnrollmentsEntity]]"
+					parent-organizations="[[_parentOrganizations]]"
+					sort-field="[[_sortField]]">
+				</d2l-search-widget-custom>
 
-					<div id="filterAndSort" class="d2l-all-courses-hidden">
-						<div id="filterSection" class="d2l-all-courses-hidden">
-							<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
-							<d2l-dropdown id="filterDropdown">
-								<button
-									id="filterDropdownOpener"
-									class="d2l-dropdown-opener dropdown-button"
-									on-focus="_focusFilterText"
-									on-blur="_blurFilterText"
-									on-mouseenter="_focusFilterText"
-									on-mouseleave="_blurFilterText"
-									aria-labelledby="filterText">
-									<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
-								</button>
-								<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
-									<d2l-filter-menu-content
-										id="filterMenuContent"
-										my-enrollments-entity="[[myEnrollmentsEntity]]">
-									</d2l-filter-menu-content>
-									<iron-scroll-threshold
-										id="scrollThreshold"
-										on-lower-threshold="_onLowerThreshold">
-									</iron-scroll-threshold>
-								</d2l-dropdown-content>
-							</d2l-dropdown>
-						</div>
-
-						<d2l-dropdown id="sortDropdown">
+				<div id="filterAndSort" class="d2l-all-courses-hidden">
+					<div id="filterSection" class="d2l-all-courses-hidden">
+						<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
+						<d2l-dropdown id="filterDropdown">
 							<button
+								id="filterDropdownOpener"
 								class="d2l-dropdown-opener dropdown-button"
-								aria-labelledby="sortText">
-								<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
+								on-focus="_focusFilterText"
+								on-blur="_blurFilterText"
+								on-mouseenter="_focusFilterText"
+								on-mouseleave="_blurFilterText"
+								aria-labelledby="filterText">
 								<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 							</button>
-							<d2l-dropdown-menu no-padding min-width="350">
-								<d2l-menu label="{{localize('sorting.sortBy')}}">
-									<div class="dropdown-content-header">
-										<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
-									</div>
-									<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-									<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-									<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
-									<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
-								</d2l-menu>
-							</d2l-dropdown-menu>
+							<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
+								<d2l-filter-menu-content
+									id="filterMenuContent"
+									my-enrollments-entity="[[myEnrollmentsEntity]]">
+								</d2l-filter-menu-content>
+								<iron-scroll-threshold
+									id="scrollThreshold"
+									on-lower-threshold="_onLowerThreshold">
+								</iron-scroll-threshold>
+							</d2l-dropdown-content>
 						</d2l-dropdown>
-			</div>
+					</div>
 
-			<div class="advanced-search-link">
-				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
+					<d2l-dropdown id="sortDropdown">
+						<button
+							class="d2l-dropdown-opener dropdown-button"
+							aria-labelledby="sortText">
+							<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
+							<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
+						</button>
+						<d2l-dropdown-menu no-padding min-width="350">
+							<d2l-menu label="{{localize('sorting.sortBy')}}">
+								<div class="dropdown-content-header">
+									<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
+								</div>
+								<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+								<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+							</d2l-menu>
+						</d2l-dropdown-menu>
+					</d2l-dropdown>
+				</div>
+			</div>
+			<div class="search-and-filter-row">
+				<div class="advanced-search-link">
+					<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
+				</div>
 					</div>
 				</div>
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -163,6 +163,7 @@
 						parent-organizations="[[_parentOrganizations]]"
 						sort-field="[[_sortField]]">
 					</d2l-search-widget-custom>
+
 					<div id="filterAndSort" class="d2l-all-courses-hidden">
 						<div id="filterSection" class="d2l-all-courses-hidden">
 							<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
@@ -210,6 +211,7 @@
 							</d2l-dropdown-menu>
 						</d2l-dropdown>
 			</div>
+
 			<div class="advanced-search-link">
 				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
 					</div>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -362,7 +362,9 @@
 					value: function() {
 						return [];
 					}
-				}
+				},
+				// URL that directs to the advanced search page
+				advancedSearchUrl: String
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -53,22 +53,32 @@
 				align-items: center;
 				justify-content: space-between;
 				margin-bottom: 50px;
+				flex-wrap: wrap;
+			}
+			.advanced-search-link {
+				font-size: 0.8rem;
+				min-width: 100%;
 			}
 			.search-and-filter > d2l-search-widget-custom {
 				flex: calc(5 / 12);
+			}
+			.search-and-filter > #filterAndSort {
+				flex: calc(7 / 12);
+				display: flex;
+				justify-content: flex-end;
 			}
 			@media screen and (max-width: 767px) {
 				.search-and-filter > d2l-search-widget-custom {
 					flex: 1;
 				}
-				#filterAndSort {
+				.search-and-filter > #filterAndSort {
 					display: none;
 				}
-			}
-			.search-and-filter > div {
-				flex: calc(7 / 12);
-				display: flex;
-				justify-content: flex-end;
+				.advanced-search-link {
+					font-size: 0.8rem;
+					text-align: right;
+					flex: 1;
+				}
 			}
 			.dropdown-opener-text {
 				@apply(--d2l-body-small-text);
@@ -153,7 +163,6 @@
 						parent-organizations="[[_parentOrganizations]]"
 						sort-field="[[_sortField]]">
 					</d2l-search-widget-custom>
-
 					<div id="filterAndSort" class="d2l-all-courses-hidden">
 						<div id="filterSection" class="d2l-all-courses-hidden">
 							<span id="filterText" class="dropdown-opener-text" on-tap="_toggleFilterDropdown">[[_filterText]]</span>
@@ -200,6 +209,9 @@
 								</d2l-menu>
 							</d2l-dropdown-menu>
 						</d2l-dropdown>
+			</div>
+			<div id="advancedSearchLink" class="advanced-search-link">
+				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
 					</div>
 				</div>
 

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -57,6 +57,7 @@
 			}
 			.search-and-filter-row > .advanced-search-link {
 				font-size: 0.8rem;
+				margin-top: 3px;
 				flex: 1;
 			}
 			.search-and-filter-row > d2l-search-widget-custom {
@@ -74,6 +75,7 @@
 				}
 				.search-and-filter-row > .advanced-search-link {
 					text-align: right;
+					margin-top: 5px;
 				}
 			}
 			.dropdown-opener-text {
@@ -209,7 +211,7 @@
 							</d2l-dropdown>
 						</div>
 					</div>
-					<div class="search-and-filter-row">
+					<div id="advancedSearchLink" class="search-and-filter-row d2l-all-courses-hidden">
 						<div class="advanced-search-link">
 							<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
 						</div>
@@ -537,6 +539,8 @@
 				this._updateTileSizes();
 
 				this._filterText = this.localize('filtering.filter');
+
+				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -163,6 +163,8 @@ the user has in that organization - student, teacher, TA, etc.
 				userId: String,
 				// Configuration value passed in to toggle course code
 				showCourseCode: Boolean,
+				_notificationTitle: String,
+				_notificationDate: String,
 				_courseInfoUrl: String,
 				// Body sent for pin/unpin action
 				_enrollmentPinBody: String,

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -195,9 +195,7 @@ the user has in that organization - student, teacher, TA, etc.
 				// The JSON string of the telemetry event that will be sent on the opening of the change image UI */
 				_telemetryEvent: String,
 				_dateFormatter: Object,
-				_fullDateFormatter: Object,
-				_notificationTitle: String,
-				_notificationDate: String
+				_fullDateFormatter: Object
 			},
 			behaviors: [
 				window.D2L.MyCourses.LocalizeBehavior,

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -195,7 +195,9 @@ the user has in that organization - student, teacher, TA, etc.
 				// The JSON string of the telemetry event that will be sent on the opening of the change image UI */
 				_telemetryEvent: String,
 				_dateFormatter: Object,
-				_fullDateFormatter: Object
+				_fullDateFormatter: Object,
+				_notificationTitle: String,
+				_notificationDate: String
 			},
 			behaviors: [
 				window.D2L.MyCourses.LocalizeBehavior,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -109,7 +109,6 @@
 		<div id="allCoursesPlaceholder">
 		</div>
 
-
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
 			title-name="{{localize('changeImage')}}"

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -108,6 +108,8 @@
 
 		<div id="allCoursesPlaceholder">
 		</div>
+			show-course-code="[[showCourseCode]]"
+			advanced-search-url="[[advancedSearchUrl]]">
 
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
@@ -173,7 +175,9 @@
 				// URL used by the search widget to fetch department-type organizations
 				_departmentsUrl: String,
 				// Size the tile should render with respect to vw
-				_tileSizes: Object
+				_tileSizes: Object,
+				// URL that directs to the advanced search page
+				advancedSearchUrl: String
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -108,8 +108,7 @@
 
 		<div id="allCoursesPlaceholder">
 		</div>
-			show-course-code="[[showCourseCode]]"
-			advanced-search-url="[[advancedSearchUrl]]">
+
 
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
@@ -327,6 +326,7 @@
 					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
 					allCourses.locale = this.locale;
 					allCourses.showCourseCode = this.showCourseCode;
+					allCourses.advancedSearchUrl = this.advancedSearchUrl;
 					this.$$('d2l-all-courses').load();
 				}.bind(this), 600);
 			},

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -105,7 +105,6 @@
 				border-color: var(--d2l-color-pressicus);
 				border-radius: 0.3rem;
 			}
-
 		</style>
 
 		<d2l-ajax

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -105,6 +105,20 @@
 				border-color: var(--d2l-color-pressicus);
 				border-radius: 0.3rem;
 			}
+
+			.advancedSearch-link {
+				font-size: 0.8rem;
+				padding-top: 3px;
+			}
+
+			@media only screen and (max-width: 767px){
+				.advancedSearch-link {
+					font-size: 0.8rem;
+					padding-top: 3px;
+					text-align: right;
+				}
+			}
+
 		</style>
 
 		<d2l-ajax
@@ -187,6 +201,12 @@
 				</div>
 			</d2l-search-dropdown-content>
 		</d2l-dropdown>
+
+		<template is="dom-if" if="[[advancedSearchUrl]]">
+			<div class="advancedSearch-link">
+				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
+			</div>
+		</template>
 	</template>
 	<script>
 		'use strict';
@@ -246,7 +266,10 @@
 					value: function() {
 						return [];
 					}
-				}
+				},
+
+				// URL that directs to the advanced search page
+				advancedSearchUrl: String
 			},
 
 			listeners: {

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -106,19 +106,6 @@
 				border-radius: 0.3rem;
 			}
 
-			.advancedSearch-link {
-				font-size: 0.8rem;
-				padding-top: 3px;
-			}
-
-			@media only screen and (max-width: 767px){
-				.advancedSearch-link {
-					font-size: 0.8rem;
-					padding-top: 3px;
-					text-align: right;
-				}
-			}
-
 		</style>
 
 		<d2l-ajax
@@ -201,12 +188,6 @@
 				</div>
 			</d2l-search-dropdown-content>
 		</d2l-dropdown>
-
-		<template is="dom-if" if="[[advancedSearchUrl]]">
-			<div class="advancedSearch-link">
-				<a is="d2l-link" href="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
-			</div>
-		</template>
 	</template>
 	<script>
 		'use strict';
@@ -266,10 +247,7 @@
 					value: function() {
 						return [];
 					}
-				},
-
-				// URL that directs to the advanced search page
-				advancedSearchUrl: String
+				}
 			},
 
 			listeners: {

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -29,6 +29,7 @@
 					value: function() {
 						var langs = {
 							'en': {
+								'advancedSearch' : 'Advanced Search',
 								'viewAllCourses' : 'View All Courses',
 								'allCourses' : 'All Courses',
 								'pinnedCourses' : 'Pinned',

--- a/localize-behavior.html
+++ b/localize-behavior.html
@@ -87,6 +87,7 @@
 								'error.settingImage': 'Sorry, we\'re unable to change your image right now. Please try again later.'
 							},
 							'ar': {
+								'advancedSearch' : 'البحث المتقدم',
 								'viewAllCourses' : 'عرض كل المقررات التعليمية',
 								'allCourses' : 'كل المقررات التعليمية',
 								'pinnedCourses' : 'مُثبّت',
@@ -140,6 +141,7 @@
 
 							},
 							'es': {
+								'advancedSearch' : 'Búsqueda avanzada',
 								'viewAllCourses' : 'Ver todos los cursos',
 								'allCourses' : 'Todos los cursos',
 								'pinnedCourses' : 'Anclado',
@@ -192,6 +194,7 @@
 								'error.settingImage': 'Lo sentimos, no es posible cambiar su imagen en este momento. Vuelva a intentarlo más tarde.'
 							},
 							'fr': {
+								'advancedSearch' : 'Recherche avancée',
 								'viewAllCourses' : 'Afficher tous les cours',
 								'allCourses' : 'Tous les cours',
 								'pinnedCourses' : 'Épinglé',
@@ -244,6 +247,7 @@
 								'error.settingImage': 'Désolé, nous ne sommes pas en mesure de modifier votre image pour le moment. Veuillez essayer plus tard.'
 							},
 							'ja': {
+								'advancedSearch' : '詳細検索',
 								'viewAllCourses' : 'すべてのコースの表示',
 								'allCourses' : 'すべてのコース',
 								'pinnedCourses' : '固定',
@@ -296,6 +300,7 @@
 								'error.settingImage': '申し訳ありません。現在イメージを変更することはできません。後でもう一度試してください。'
 							},
 							'ko': {
+								'advancedSearch' : '고급 검색',
 								'viewAllCourses' : '모든 강의 보기',
 								'allCourses' : '모든 강의',
 								'pinnedCourses' : '고정됨',
@@ -348,6 +353,7 @@
 								'error.settingImage': '지금은 이미지를 변경할 수 없습니다. 나중에 다시 시도하십시오.'
 							},
 							'pt': {
+								'advancedSearch' : 'Pesquisa Avançada',
 								'viewAllCourses' : 'Exibir Todos os Cursos',
 								'allCourses' : 'Todos os Cursos',
 								'pinnedCourses' : 'Fixado',
@@ -400,6 +406,7 @@
 								'error.settingImage': 'Desculpe, não é possível alterar a sua imagem agora. Tente novamente mais tarde.'
 							},
 							'sv': {
+								'advancedSearch' : 'Avancerad sökning',
 								'viewAllCourses' : 'Visa alla kurser',
 								'allCourses' : 'Alla kurser',
 								'pinnedCourses' : 'Fäst',
@@ -452,6 +459,7 @@
 								'error.settingImage': 'Vi kan tyvärr inte ändra din bild just nu. Försök igen senare.'
 							},
 							'tr': {
+								'advancedSearch' : 'Gelişmiş Arama',
 								'viewAllCourses' : 'Tüm Dersleri Görüntüle',
 								'allCourses' : 'Tüm Dersler',
 								'pinnedCourses' : 'Sabitlenmiş',
@@ -504,6 +512,7 @@
 								'error.settingImage': 'Üzgünüz, şu anda görüntünüzü değiştiremiyoruz. Lütfen daha sonra tekrar deneyin.'
 							},
 							'zh': {
+								'advancedSearch' : '高级搜索',
 								'viewAllCourses' : '查看所有课程',
 								'allCourses' : '所有课程',
 								'pinnedCourses' : '已锁定',
@@ -556,6 +565,7 @@
 								'error.settingImage': '抱歉，目前我们无法更改您的图像。请稍候重试。'
 							},
 							'zh-tw': {
+								'advancedSearch' : '進階搜尋',
 								'viewAllCourses' : '檢視所有課程',
 								'allCourses' : '所有課程',
 								'pinnedCourses' : '置頂',

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -13,11 +13,18 @@
 			<template>
 				<d2l-all-courses
 					pinned-enrollments='[]'
-					unpinned-enrollments='[]'>
+					unpinned-enrollments='[]'
+					advanced-search-url="/test/url/">
 				</d2l-all-courses>
 			</template>
 		</test-fixture>
 
+		<test-fixture id="d2l-all-courses-without-advanced-search-fixture">
+			<template>
+				<d2l-all-courses>
+				</d2l-all-courses>
+			</template>
+		</test-fixture>
 		<script src="d2l-all-courses.js"></script>
 	</body>
 </html>

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -4,6 +4,7 @@
 
 describe('d2l-all-courses', function() {
 	var widget,
+		widgetAdvancedSearch,
 		pinnedEnrollmentEntity,
 		unpinnedEnrollmentEntity,
 		clock;
@@ -36,10 +37,22 @@ describe('d2l-all-courses', function() {
 		clock = sinon.useFakeTimers();
 
 		widget = fixture('d2l-all-courses-fixture');
+
+		widgetAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});
 
 	afterEach(function() {
 		clock.restore();
+	});
+
+	it('should not render the advanced search link', function() {
+		expect(widgetAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
+	});
+
+	it('should render the advanced search link', function() {
+		var link = widget.querySelector('.advanced-search-link > a');
+		expect(link.getAttribute('href')).equals('/test/url/');
+		expect(widget.$.advancedSearchLink.getAttribute('class')).to.not.contain('d2l-all-courses-hidden');
 	});
 
 	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -38,22 +38,26 @@ describe('d2l-all-courses', function() {
 
 		widget = fixture('d2l-all-courses-fixture');
 		sinon.stub(widget.$['search-widget'], '_search');
-    
-    widgetAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
+
+		widgetAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});
 
 	afterEach(function() {
 		clock.restore();
 	});
 
-	it('should not render the advanced search link', function() {
-		expect(widgetAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
+	describe('when the advancedSearchUrl property has not been set then', function() {
+		it('should not render the advanced search link', function() {
+			expect(widgetAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
+		});
 	});
 
-	it('should render the advanced search link', function() {
-		var link = widget.querySelector('.advanced-search-link > a');
-		expect(link.getAttribute('href')).equals('/test/url/');
-		expect(widget.$.advancedSearchLink.getAttribute('class')).to.not.contain('d2l-all-courses-hidden');
+	describe('when the advancedSearchUrl property has been set then', function() {
+		it('should render the advanced search link', function() {
+			var link = widget.querySelector('.advanced-search-link > a');
+			expect(link.getAttribute('href')).equals('/test/url/');
+			expect(widget.$.advancedSearchLink.getAttribute('class')).to.not.contain('d2l-all-courses-hidden');
+		});
 	});
 
 	it('should return the correct value from getCourseTileItemCount (should be maximum of pinned or unpinned course count)', function() {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -4,7 +4,7 @@
 
 describe('d2l-all-courses', function() {
 	var widget,
-		widgetAdvancedSearch,
+		widgetNoAdvancedSearch,
 		pinnedEnrollmentEntity,
 		unpinnedEnrollmentEntity,
 		clock;
@@ -39,7 +39,7 @@ describe('d2l-all-courses', function() {
 		widget = fixture('d2l-all-courses-fixture');
 		sinon.stub(widget.$['search-widget'], '_search');
 
-		widgetAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
+		widgetNoAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});
 
 	afterEach(function() {
@@ -48,14 +48,16 @@ describe('d2l-all-courses', function() {
 
 	describe('when the advancedSearchUrl property has not been set then', function() {
 		it('should not render the advanced search link', function() {
-			expect(widgetAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
+			var link = widgetNoAdvancedSearch.querySelector('.advanced-search-link > a');
+			expect(link.getAttribute('href')).to.equal(null);
+			expect(widgetNoAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
 		});
 	});
 
 	describe('when the advancedSearchUrl property has been set then', function() {
 		it('should render the advanced search link', function() {
 			var link = widget.querySelector('.advanced-search-link > a');
-			expect(link.getAttribute('href')).equals('/test/url/');
+			expect(link.getAttribute('href')).length.to.be.above(0);
 			expect(widget.$.advancedSearchLink.getAttribute('class')).to.not.contain('d2l-all-courses-hidden');
 		});
 	});


### PR DESCRIPTION
US80239

Renders an advanced search url link under the search bar in the all courses view, that redirects to the legacy advanced search page.

To test:
checkout branch: add-advanced-search-url in repo: le/mangeCourses

Has not been tested in Edge