### PR TITLE
Adjust timing of tile size calc in all courses overlay

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -537,7 +537,6 @@
 				for (var i = 0; i < courseTileGrids.length; i++) {
 					courseTileGrids[i].getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
 				}
-				this._updateTileSizes();
 
 				this._filterText = this.localize('filtering.filter');
 			},
@@ -660,6 +659,7 @@
 				this._updateTileSizes();
 			},
 			_onSimpleOverlayOpening: function() {
+				this._updateTileSizes();
 				this._removeAlert('setCourseImageFailure');
 			},
 			_toggleFilterDropdown: function() {


### PR DESCRIPTION
This is to fix the issue logged in [DE23848](https://rally1.rallydev.com/#/51191528503d/detail/defect/82992915720) in which the all courses overlay incorrectly pulls down the `max-size` tiles for all of the tiles it displays the first time it is opened. Now that the tiles are not loaded until the overlay is requested for opening this fix was quite simple.

From the defect:

**Problem description**

The All Courses page will always pull down the max-size image for the tiles that are displayed on first load, regardless of the size of the display. Causing a 'load more' action will result in new tiles getting images of the correct size.

**Steps to reproduce**

1. Open chrome and open the dev tools
2. In the network tab, filter on the word 'density' and only requests of Img
3. Size the display portion of the window to approximately 700px in width (assuming no sidebars or other widgets are on the page with the my courses widget).
4. Refresh/Load the d2l home page
5. Note the file names of the images being pulled down for the tiles. If they are 'mid-size' or 'min-size' you are good to continue. If not you need to resize the display window and reload until you see the tiles pulling down min or mid sizes.
6. Click the View All Courses link and note the images being pulled down for the all courses tiles. They will be 'max-size', and because of this they will pull down new images for pinned tiles that shouldn't need a download at all because they were on the previous screen.
7. Scroll down to cause a 'load more' and note that the tiles that get loaded from this point on are of the same 'min' or 'mid' size as the initial my courses tiles were from step 5.

**Acceptance Criteria**

When loading the all courses page it should:
a) use the same image sizes as the my courses page (assuming you aren't re-sizing the screen); and
b) re-use already downloaded tile images