### PR TITLE
US77135 - Added query parameter for autopinning

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -265,7 +265,8 @@
 						pageSize: 25,
 						embedDepth: 1,
 						sortField: 'pinDate',
-						sortDescending: true
+						sortDescending: true,
+						autoPinCourses: true
 					};
 					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, pinDateQuery);
 					this.$.enrollmentsSearchRequest.generateRequest();


### PR DESCRIPTION
Part of [US77135 - Implement the 20 if statement pin/unpin logic in the LMS](https://rally1.rallydev.com/#/51191528503d/detail/userstory/6330741512).

Added a query parameter to the enrollments call for auto-pinning. Should only auto-pin on initial load of the My Courses widget.

Most of the work is in [this lp pull request](https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/4297/overview)