### PR TITLE
Fix sort fields to actually match MyOrgUnitSortField

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -203,10 +203,10 @@
 										<div class="dropdown-content-header">
 											<span class="dropdown-content-header-text">{{localize('sorting.sortBy')}}</span>
 										</div>
-										<d2l-menu-item-radio class="dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="pinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio class="dropdown-content-gradient" value="OrgUnitCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="OrgUnitName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="PinDate" text="{{localize('sorting.datePinned')}}" selected></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="LastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
 									</d2l-menu>
 								</d2l-dropdown-menu>
 							</d2l-dropdown>
@@ -369,7 +369,7 @@
 				_filterText: String,
 				_sortField: {
 					type: String,
-					value: 'pinDate'
+					value: 'PinDate'
 				},
 				_tileSizes: Object,
 				_parentOrganizations: {

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -300,7 +300,7 @@
 					pageSize: pageSize,
 					parentOrganizations: this.parentOrganizations.join(','),
 					sortField: this.sortField,
-					sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
+					sortDescending: this.sortField !== 'OrgUnitName' && this.sortField !== 'OrgUnitCode'
 				};
 
 				this.set(path, this.createActionUrl(this._searchAction, queryParams));


### PR DESCRIPTION
Tangentially related to DE23798, these don't actually match the names as defined in [MyOrgUnitSortField](https://git.dev.d2l/projects/CORE/repos/lp/browse/framework/core/D2L.LP/LP/Enrollments/MyOrgUnits/MyOrgUnitSortField.codegen). The disadvantage of this is that the values sent back have to be .ToLowerCase()'d then compared to hardcoded strings - if we use the correct values here, we can instead use the proper MyOrgUnitSortField.TryParse (generated by the codegen).