### PR TITLE
specify border-box on elements with a width and padding/border

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -97,6 +97,7 @@
 				color: var(--d2l-color-ferrite);
 			}
 			.dropdown-content-header {
+				box-sizing: border-box;
 				display: flex;
 				align-items: center;
 				justify-content: space-between;

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -417,6 +417,7 @@
 		}
 
 		.overlay-date-container {
+			box-sizing: border-box;
 			display: flex;
 			flex-direction: column;
 			justify-content: center;

--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -42,6 +42,7 @@
 				padding: 0;
 			}
 			.dropdown-content-header {
+				box-sizing: border-box;
 				display: flex;
 				align-items: center;
 				justify-content: space-between;

--- a/d2l-search-listbox.html
+++ b/d2l-search-listbox.html
@@ -17,6 +17,7 @@
 			}
 
 			::content > * {
+				box-sizing: border-box;
 				border: 1px solid var(--d2l-color-titanius);
 				border-top-color: var(--d2l-color-gypsum);
 				border-bottom-color: transparent;

--- a/d2l-simple-overlay-styles.html
+++ b/d2l-simple-overlay-styles.html
@@ -71,6 +71,7 @@
 		}
 
 		.max-width {
+			box-sizing: border-box;
 			padding: 0 30px;
 			margin-left: auto;
 			margin-right: auto;


### PR DESCRIPTION
Found some issues when trying to enable native shadow dom in the LMS.

_homepages-ui_ has a `* { box-sizing: border-box; }` which my courses was inadvertently relying on. It was noticeable in the All Courses filter dropdown header, but I grepped for a few other cases as well. Not necessarily comprehensive. Could consider doing a similar `*` dealio within my-courses, by `*` isn't great.