### PR TITLE
DE23798 - Switch from sortField/sortDescending to sort

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -161,7 +161,7 @@
 							id="search-widget"
 							my-enrollments-entity="[[myEnrollmentsEntity]]"
 							parent-organizations="[[_parentOrganizations]]"
-							sort-field="[[_sortField]]">
+							sort="[[_sortParameter]]">
 						</d2l-search-widget-custom>
 
 						<div id="filterAndSort" class="d2l-all-courses-hidden">
@@ -205,10 +205,10 @@
 										<div class="dropdown-content-header">
 											<span>{{localize('sorting.sortBy')}}</span>
 										</div>
-										<d2l-menu-item-radio class="d2l-body-small dropdown-content-gradient" value="courseCode" text="{{localize('sorting.courseCode')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio class="d2l-body-small" value="courseName" text="{{localize('sorting.courseName')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio class="d2l-body-small" value="pinDate" text="{{localize('sorting.datePinned')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio class="d2l-body-small" value="lastAccessed" text="{{localize('sorting.lastAccessed')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio class="d2l-body-small dropdown-content-gradient" value="OrgUnitName" text="{{localize('sorting.sortCourseName')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="d2l-body-small OrgUnitCode" text="{{localize('sorting.sortCourseCode')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="d2l-body-small PinDate" text="{{localize('sorting.sortDatePinned')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="d2l-body-small LastAccessed" text="{{localize('sorting.sortLastAccessed')}}"></d2l-menu-item-radio>
 									</d2l-menu>
 								</d2l-dropdown-menu>
 							</d2l-dropdown>
@@ -371,9 +371,12 @@
 				_filterText: String,
 				defaultSortValue: {
 					type: String,
-					value: 'pinDate'
+					value: 'PinDate'
 				},
-				_sortField: String,
+				_sortParameter: {
+					type: String,
+					value: '-PinDate,OrgUnitName,OrgUnitId'
+				},
 				_tileSizes: Object,
 				_parentOrganizations: {
 					type: Array,
@@ -564,7 +567,7 @@
 
 				this._filterText = this.localize('filtering.filter');
 				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').selected = true;
-				this._sortField = this.defaultSortValue;
+				this._sortParameter = this._sortOptions[this.defaultSortValue].queryParameter;
 			},
 			attached: function() {
 				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
@@ -643,11 +646,24 @@
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
-			_sortTextOptions: {
-				'courseCode': 'sorting.sortCourseCode',
-				'courseName': 'sorting.sortCourseName',
-				'pinDate': 'sorting.sortDatePinned',
-				'lastAccessed': 'sorting.sortLastAccessed'
+			_sortOptions: {
+				OrgUnitCode: {
+					text: 'sorting.sortCourseCode',
+					queryParameter: '-PinDate,OrgUnitCode,OrgUnitId'
+				},
+				OrgUnitName: {
+					text: 'sorting.sortCourseName',
+					queryParameter: '-PinDate,OrgUnitName,OrgUnitId'
+				},
+				PinDate: {
+					text: 'sorting.sortDatePinned',
+					queryParameter: '-PinDate,OrgUnitId'
+				},
+				LastAccessed: {
+					text: 'sorting.sortLastAccessed',
+					// Note: Sorting by LastAccessed is done differently LMS-side, hence this being different
+					queryParameter: 'LastAccessed'
+				}
 			},
 			_blurFilterText: function() {
 				// Only de-highlight text if focus has moved AND we're not hovering over the opener button anymore
@@ -696,8 +712,8 @@
 				}
 			},
 			_updateSortBy: function(e) {
-				this.set('_sortField', e.detail.value);
-				this.$.sortText.textContent = this.localize(this._sortTextOptions[this._sortField] || '');
+				this.set('_sortParameter', this._sortOptions[e.detail.value].queryParameter);
+				this.$.sortText.textContent = this.localize(this._sortOptions[e.detail.value].text || '');
 				this.$.sortDropdown.toggleOpen();
 			},
 			_updateEnrollmentAlerts: function(hasPinnedEnrollments) {
@@ -725,9 +741,9 @@
 			_resetSortDropdown: function() {
 				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').click();
 
-				//the click will not fire an event if the the value is already selected, so need to update the sortField manually incase
-				if (this._sortField !== this.defaultSortValue) {
-					this._sortField = this.defaultSortValue;
+				// The click will not fire an event if the value is already selected, so need to update the sort manually
+				if (this._sortParameter !== this._sortOptions[this.defaultSortValue].queryParameter) {
+					this._sortParameter = this._sortOptions[this.defaultSortValue].queryParameter;
 				}
 
 				var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -197,7 +197,7 @@
 								<button
 									class="d2l-dropdown-opener dropdown-button"
 									aria-labelledby="sortText">
-									<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDatePinned')}}</span>
+									<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortCourseName')}}</span>
 									<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 								</button>
 								<d2l-dropdown-menu no-padding min-width="350">
@@ -371,7 +371,7 @@
 				_filterText: String,
 				defaultSortValue: {
 					type: String,
-					value: 'PinDate'
+					value: 'OrgUnitName'
 				},
 				_sortParameter: {
 					type: String,

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -502,6 +502,8 @@ the user has in that organization - student, teacher, TA, etc.
 					this._setOverlayStartedInactive();
 				} else if (inactive) {
 					this._setOverlayInactive();
+				} else {
+					this._clearOverlayContent();
 				}
 			},
 			_setOverlayContent: function(type, date, inactive) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -265,14 +265,13 @@
 					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
 					this.fetchEnrollmentUrl = searchAction.href + '/organizations/';
 
-					var pinDateQuery = {
+					var query = {
 						pageSize: 25,
 						embedDepth: 1,
-						sortField: 'pinDate',
-						sortDescending: true,
+						sort: '-PinDate,OrgUnitId',
 						autoPinCourses: true
 					};
-					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, pinDateQuery);
+					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 					this.$.enrollmentsSearchRequest.generateRequest();
 				} else {
 					this._showContent();

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -268,7 +268,7 @@
 					var query = {
 						pageSize: 25,
 						embedDepth: 1,
-						sort: '-PinDate,OrgUnitId',
+						sort: '-PinDate,OrgUnitName,OrgUnitId',
 						autoPinCourses: true
 					};
 					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -181,8 +181,8 @@
 					observer: '_myEnrollmentsEntityChanged'
 				},
 
-				// Value to send for the `sortField` parameter in the search query
-				sortField: String,
+				// Value to send for the `sort` parameter in the search query
+				sort: String,
 
 				// Array of parent organization IDs (self links) by which to limit the search results
 				parentOrganizations: {
@@ -243,7 +243,7 @@
 			],
 
 			observers: [
-				'_onSearchDependencyChanged(sortField, parentOrganizations)'
+				'_onSearchDependencyChanged(sort, parentOrganizations)'
 			],
 
 			ready: function() {
@@ -295,8 +295,7 @@
 					page: 1,
 					pageSize: pageSize,
 					parentOrganizations: this.parentOrganizations.join(','),
-					sortField: this.sortField,
-					sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
+					sort: this.sort
 				};
 
 				this.set(path, this.createActionUrl(this._searchAction, queryParams));

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -254,19 +254,19 @@ describe('d2l-all-courses', function() {
 
 			var event = {
 				selected: true,
-				value: 'courseCode'
+				value: 'OrgUnitCode'
 			};
 
 			var defaultValue = widget.defaultSortValue;
 
 			widget.load();
-			expect(widget._sortField).to.equal(defaultValue);
+			expect(widget._sortParameter).to.equal(widget._sortOptions[defaultValue].queryParameter);
 			widget.$$('d2l-dropdown-menu').fire('d2l-menu-item-change', event);
-			expect(widget._sortField).to.equal(event.value);
+			expect(widget._sortParameter).to.equal(widget._sortOptions[event.value].queryParameter);
 
 			widget.$$('d2l-simple-overlay')._renderOpened();
 			expect(spy.called).to.be.true;
-			expect(widget._sortField).to.equal(defaultValue);
+			expect(widget._sortParameter).to.equal(widget._sortOptions[defaultValue].queryParameter);
 		});
 	});
 });

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -27,13 +27,9 @@ describe('d2l-my-courses', function() {
 					type: 'number',
 					value: 0
 				}, {
-					name: 'sortField',
-					type: 'radio',
+					name: 'sort',
+					type: 'text',
 					value: ''
-				}, {
-					name: 'sortDescending',
-					type: 'checkbox',
-					value: false
 				}]
 			}],
 			links: [{
@@ -250,7 +246,7 @@ describe('d2l-my-courses', function() {
 			});
 		});
 
-		it('should set the request URL for pinned courses, sortDescending', function(done) {
+		it('should set the request URL for pinned courses', function(done) {
 			server.respondWith(
 				'GET',
 				widget.enrollmentsUrl,
@@ -262,8 +258,7 @@ describe('d2l-my-courses', function() {
 			widget.$.enrollmentsRootRequest.generateRequest();
 
 			widget.$.enrollmentsRootRequest.addEventListener('iron-ajax-response', function() {
-				expect(widget._enrollmentsSearchUrl).to.match(/sortField=pinDate/);
-				expect(widget._enrollmentsSearchUrl).to.match(/sortDescending=true/);
+				expect(widget._enrollmentsSearchUrl).to.match(/sort=-PinDate/);
 				done();
 			});
 		});

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.html
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.html
@@ -11,8 +11,8 @@
 	<body>
 		<test-fixture id="d2l-search-widget-custom-fixture">
 			<template>
-				<d2l-search-widget-custom 
-					sort-field="pinDate"
+				<d2l-search-widget-custom
+					sort="OrgUnitName,OrgUnitId"
 					parent-organizations="[]">
 				</d2l-search-widget-custom>
 			</template>

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.js
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.js
@@ -26,13 +26,9 @@ describe('<d2l-search-widget-custom>', function() {
 					type: 'number',
 					value: 0
 				}, {
-					name: 'sortField',
-					type: 'radio',
-					value: ''
-				}, {
-					name: 'sortDescending',
-					type: 'checkbox',
-					value: false
+					name: 'sort',
+					type: 'text',
+					value: 'OrgUnitName,OrgUnitId'
 				}, {
 					name: 'parentOrganizations',
 					type: 'hidden',
@@ -76,7 +72,7 @@ describe('<d2l-search-widget-custom>', function() {
 			done();
 		});
 
-		widget.set('sortField', 'courseName');
+		widget.set('sort', '-PinDate,OrgUnitName,OrgUnitId');
 
 		clock.tick(501);
 	});
@@ -139,11 +135,11 @@ describe('<d2l-search-widget-custom>', function() {
 
 	it('should apply current search parameters when search button is clicked', function(done) {
 		// Set new values for sort/filter fields and prevent auto-search observer from firing
-		widget.sortField = 'newSortField';
+		widget.sort = 'NewSort';
 		widget.parentOrganizations = [3, 2, 1];
 
 		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._fullSearchUrl).to.contain('sortField=newSortField');
+			expect(widget._fullSearchUrl).to.contain('sort=NewSort');
 			expect(widget._fullSearchUrl).to.contain('parentOrganizations=3,2,1');
 			done();
 		});
@@ -155,7 +151,7 @@ describe('<d2l-search-widget-custom>', function() {
 		var spy = sandbox.spy(widget, '__search');
 
 		for (var i = 0; i < 20; i++) {
-			widget.set('sortField', 'sortField' + i);
+			widget.set('sort', 'sort' + i);
 			clock.tick(200);
 		}
 


### PR DESCRIPTION
See LP PR here - https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/4485/overview

Using this new `sort` query parameter allows us to specify multiple sort fields with different sort orders, which is what we want to do in the all courses overlay. When the user sorts by course code, what they're actually getting is enrollments sorted by descending pin date, then sorted by ascending course code. This ensures that pinned courses are always at the top, for any given sort order. This fixes the problem that was found when pinning an alphabetically-low-named course, sorting by course name, then searching for something with a lot of results wouldn't show the pinned course, as it wasn't coming back in the first page.

The exception to this is LastAccessed - due to technical limitations, it is not currently feasible to have multiple sorting. Instead, the results will be sorted only by LastAccessed date.