### PR TITLE
jklassen/de23942-followup

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -710,7 +710,8 @@
 				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			},
 			_clearSearchWidget: function() {
-				this.$['search-widget']._searchInput = '';
+				this.$['search-widget']._clearSearch();
+				this.$['search-widget']._setSearchIcon();
 				this._clearFilteredCourses();
 			},
 			_clearFilteredCourses: function() {

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -249,6 +249,9 @@
 					this.$.semesterListButton.focus();
 				}
 
+				this.$.semesterSearchWidget._setSearchIcon();
+				this.$.departmentSearchWidget._setSearchIcon();
+
 				this.set('_currentFilters', []);
 				this.set('_numSemesterFilters', 0);
 				this.set('_numDepartmentFilters', 0);


### PR DESCRIPTION
fix for the search-widget icon wasn't getting set back to the search icon when closing the overlay
