### PR TITLE
DE23848 - Update tile sizes when the enrollments are updated

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -282,7 +282,7 @@
 					value: function() {
 						return [];
 					},
-					observer: '_setFilteredPinnedEnrollments'
+					observer: '_updatePinnedEnrollmentsEvent'
 				},
 				// filtered pinned enrollment entities
 				filteredPinnedEnrollments: {
@@ -297,7 +297,7 @@
 					value: function() {
 						return [];
 					},
-					observer: '_setFilteredUnpinnedEnrollments'
+					observer: '_updateUnpinnedEnrollmentsEvent'
 				},
 				filteredUnpinnedEnrollments: {
 					type: Array,
@@ -540,16 +540,19 @@
 						this.filteredPinnedEnrollments = newPinnedEnrollments;
 						this.filteredUnpinnedEnrollments = newUnpinnedEnrollments;
 					}
-					var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.filteredPinnedEnrollments.length);
-					this._tileSizes = (colNum === 2) ?
-						{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
-						{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
-					this.fire('recalculate-columns');
 					this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
 					this.$['all-courses-scroll-threshold'].clearTriggers();
 					this.lastEnrollmentsSearchResponse = enrollments;
 				}
+			},
+			_updatePinnedEnrollmentsEvent: function() {
+				this._updateTileSizes();
+				this._setFilteredPinnedEnrollments();
+			},
+			_updateUnpinnedEnrollmentsEvent: function() {
+				this._updateTileSizes();
+				this._setFilteredUnpinnedEnrollments();
 			},
 			ready: function() {
 				this._updateEnrollmentAlerts(this._hasFilteredPinnedEnrollments);
@@ -584,7 +587,8 @@
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
 			},
 			getCourseTileItemCount: function() {
-				var itemCount = Math.max(this.pinnedEnrollments.length, this.unpinnedEnrollments.length);
+				var itemCount = Math.max(this.pinnedEnrollments ? this.pinnedEnrollments.length : 0,
+					this.unpinnedEnrollments ? this.unpinnedEnrollments.length : 0);
 				return itemCount;
 			},
 			_setFilteredPinnedEnrollments: function() {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -282,7 +282,7 @@
 					value: function() {
 						return [];
 					},
-					observer: '_updatePinnedEnrollmentsEvent'
+					observer: '_pinnedEnrollmentsChanged'
 				},
 				// filtered pinned enrollment entities
 				filteredPinnedEnrollments: {
@@ -297,7 +297,7 @@
 					value: function() {
 						return [];
 					},
-					observer: '_updateUnpinnedEnrollmentsEvent'
+					observer: '_unpinnedEnrollmentsChanged'
 				},
 				filteredUnpinnedEnrollments: {
 					type: Array,
@@ -546,11 +546,11 @@
 					this.lastEnrollmentsSearchResponse = enrollments;
 				}
 			},
-			_updatePinnedEnrollmentsEvent: function() {
+			_pinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();
 				this._setFilteredPinnedEnrollments();
 			},
-			_updateUnpinnedEnrollmentsEvent: function() {
+			_unpinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();
 				this._setFilteredUnpinnedEnrollments();
 			},


### PR DESCRIPTION
> **Problem description**
> 
> The All Courses page will always pull down the max-size image for the tiles that are displayed on first load, regardless of the size of the display. Causing a 'load more' action will result in new tiles getting images of the correct size.
> 
> **Steps to reproduce**
> 
> 1. Open chrome and open the dev tools
> 2. In the network tab, filter on the word 'density' and only requests of Img
> 3. Size the display portion of the window to approximately 700px in width (assuming no sidebars or other widgets are on the page with the my courses widget).
> 4. Refresh/Load the d2l home page
> 5. Note the file names of the images being pulled down for the tiles. If they are 'mid-size' or 'min-size' you are good to continue. If not you need to resize the display window and reload until you see the tiles pulling down min or mid sizes.
> 6. Click the View All Courses link and note the images being pulled down for the all courses tiles. They will be 'max-size', and because of this they will pull down new images for pinned tiles that shouldn't need a download at all because they were on the previous screen.
> 7. Scroll down to cause a 'load more' and note that the tiles that get loaded from this point on are of the same 'min' or 'mid' size as the initial my courses tiles were from step 5.
> 
> **Acceptance Criteria**
> 
> When loading the all courses page it should:
> a) use the same image sizes as the my courses page (assuming you aren't re-sizing the screen); and
> b) re-use already downloaded tile images

Turns out the `tileSize` was being set before the enrollments were loaded. The tile size is calculated based on the number of columns which is calculated based on the number of enrollments.