### PR TITLE
de23942-patch

### DIFF
--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -294,18 +294,16 @@
 			},
 
 			__search: function(pageSize, path) {
-				if (this._searchAction) {
-					var queryParams = {
-						search: encodeURIComponent(this._searchInput),
-						page: 1,
-						pageSize: pageSize,
-						parentOrganizations: this.parentOrganizations.join(','),
-						sortField: this.sortField,
-						sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
-					};
+				var queryParams = {
+					search: encodeURIComponent(this._searchInput),
+					page: 1,
+					pageSize: pageSize,
+					parentOrganizations: this.parentOrganizations.join(','),
+					sortField: this.sortField,
+					sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
+				};
 
-					this.set(path, this.createActionUrl(this._searchAction, queryParams));
-				}
+				this.set(path, this.createActionUrl(this._searchAction, queryParams));
 			},
 
 			// Called by various key/mouse interactions

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -294,16 +294,18 @@
 			},
 
 			__search: function(pageSize, path) {
-				var queryParams = {
-					search: encodeURIComponent(this._searchInput),
-					page: 1,
-					pageSize: pageSize,
-					parentOrganizations: this.parentOrganizations.join(','),
-					sortField: this.sortField,
-					sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
-				};
+				if (this._searchAction) {
+					var queryParams = {
+						search: encodeURIComponent(this._searchInput),
+						page: 1,
+						pageSize: pageSize,
+						parentOrganizations: this.parentOrganizations.join(','),
+						sortField: this.sortField,
+						sortDescending: this.sortField !== 'courseName' && this.sortField !== 'courseCode'
+					};
 
-				this.set(path, this.createActionUrl(this._searchAction, queryParams));
+					this.set(path, this.createActionUrl(this._searchAction, queryParams));
+				}
 			},
 
 			// Called by various key/mouse interactions

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -15,6 +15,7 @@
 		// Creates a URL with a query from an Action and an object of required parameters
 		createActionUrl: function(action, parameters) {
 			parameters = parameters || {};
+			action = action || {};
 			action.fields = action.fields || [];
 			var query = {};
 


### PR DESCRIPTION
Check if `_searchAction` is defined before searching - preventing console errors the first time the `_clearSearch` is called, which happens on overlay open