### PR TITLE
Update d2l-simple-overlay

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.4.2",
-    "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.2",
+    "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.3",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",
     "iron-a11y-announcer": "^1.0.5",
@@ -49,7 +49,7 @@
     "iron-overlay-behavior": "^1.10.1",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
     "iron-pages": "^1.0.8",
-    "neon-animation": "^1.2.4",
-    "polymer": "^1.7.0"
+    "polymer": "^1.7.0",
+    "web-animations-js": "^2.2.2"
   }
 }

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -8,6 +8,8 @@
 <link rel="import" href="d2l-touch-menu.html">
 <link rel="import" href="d2l-touch-menu-item.html">
 
+<script src="../web-animations-js/web-animations-next-lite.min.js"></script>
+
 <dom-module id="d2l-course-tile-grid">
 	<template>
 		<style include="d2l-course-tile-grid-styles"></style>


### PR DESCRIPTION
Previously, we were "accidentally" getting access to the web animation API as the simple overlay used neon animation, which used the web animation polyfill. The new version removes the dependency on neon-animation, so we no longer get it for free. Should have been explicitly including it in the first place anyway, really.

Checked that without this, pinning/unpinning in IE11 was hella broke with the new overlay. With this, it's still janky as always, but it works at least.