### PR TITLE
US82482 - Use d2l-search-widget-behavior

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.6.0",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.7.1",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.4",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.4.2",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.5.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.4",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.5.0",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.6.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.4",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",

--- a/bower.json
+++ b/bower.json
@@ -39,7 +39,7 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.7.1",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.7.2",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.4",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -149,7 +149,9 @@
 					<div class="search-and-filter-row">
 						<d2l-search-widget-custom
 							id="search-widget"
-							my-enrollments-entity="[[myEnrollmentsEntity]]"
+							search-action="[[_enrollmentsSearchAction]]"
+							search-field-name="search"
+							cache-responses
 							parent-organizations="[[_parentOrganizations]]"
 							sort="[[_sortParameter]]">
 						</d2l-search-widget-custom>
@@ -361,7 +363,8 @@
 					type: Object,
 					value: function() {
 						return {};
-					}
+					},
+					observer: '_myEnrollmentsEntityChanged'
 				},
 				// Object containing the last response from an enrollments search request
 				lastEnrollmentsSearchResponse: Object,
@@ -399,7 +402,8 @@
 				// Determines if the filter menu can be shown (The number of enrollments >= enrollments required)
 				_hasManyEnrollments: false,
 				_noPinnedCoursesInSearch: false,
-				_noUnpinnedCoursesInSearch: false
+				_noUnpinnedCoursesInSearch: false,
+				_enrollmentsSearchAction: Object
 			},
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
@@ -413,8 +417,7 @@
 				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening',
 				'tile-remove-complete': '_onTileRemoveComplete',
 				'enrollment-pin-complete': '_onEnrollmentPinComplete',
-				'enrollment-unpin-complete': '_onEnrollmentUnpinComplete',
-				'd2l-search-enrollment-response': '_updateFilteredEnrollmentsEvent'
+				'enrollment-unpin-complete': '_onEnrollmentUnpinComplete'
 			},
 			observers: [
 				'_updateEnrollmentAlerts(_hasFilteredPinnedEnrollments, _hasFilteredUnpinnedEnrollments)',
@@ -502,50 +505,50 @@
 					entity._actionsByName['pin-course'] = entity.actions[0];
 				}
 			},
-			_updateFilteredEnrollmentsEvent: function(e, detail) {
+			_updateFilteredEnrollmentsEvent: function(e) {
 				this._pinnedCoursesMap = {};
 				this._unpinnedCoursesMap = {};
-				this._updateFilteredEnrollments(detail, false);
+				this._updateFilteredEnrollments(e.detail, false);
 			},
 			_enrollmentsSearchResponse: function(response) {
-				this._updateFilteredEnrollments(response, true);
-			},
-			_updateFilteredEnrollments: function(response, append) {
 				if (response.detail.status === 200) {
 					var parser = document.createElement('d2l-siren-parser');
 					var enrollments = parser.parse(response.detail.xhr.response);
-					var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
-					var newPinnedEnrollments = [];
-					var newUnpinnedEnrollments = [];
-					var orgUnitIds = [];
-					enrollmentEntities.forEach(function(enrollment) {
-						var enrollmentId = this.getEntityIdentifier(enrollment);
-						orgUnitIds.push(this.getOrgUnitId(enrollmentId));
-						if (enrollment.hasClass('pinned')) {
-							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newPinnedEnrollments.push(enrollment);
-								this._pinnedCoursesMap[enrollmentId] = true;
-							}
-						} else {
-							if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newUnpinnedEnrollments.push(enrollment);
-								this._unpinnedCoursesMap[enrollmentId] = true;
-							}
-						}
-					}, this);
-					this.getUpdates(orgUnitIds.join(','));
-					if (append) {
-						this.filteredPinnedEnrollments = this.filteredPinnedEnrollments.concat(newPinnedEnrollments);
-						this.filteredUnpinnedEnrollments = this.filteredUnpinnedEnrollments.concat(newUnpinnedEnrollments);
-					} else {
-						this.filteredPinnedEnrollments = newPinnedEnrollments;
-						this.filteredUnpinnedEnrollments = newUnpinnedEnrollments;
-					}
-
-					this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
-					this.$['all-courses-scroll-threshold'].clearTriggers();
-					this.lastEnrollmentsSearchResponse = enrollments;
+					this._updateFilteredEnrollments(enrollments, true);
 				}
+			},
+			_updateFilteredEnrollments: function(enrollments, append) {
+				var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
+				var newPinnedEnrollments = [];
+				var newUnpinnedEnrollments = [];
+				var orgUnitIds = [];
+				enrollmentEntities.forEach(function(enrollment) {
+					var enrollmentId = this.getEntityIdentifier(enrollment);
+					orgUnitIds.push(this.getOrgUnitId(enrollmentId));
+					if (enrollment.hasClass('pinned')) {
+						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newPinnedEnrollments.push(enrollment);
+							this._pinnedCoursesMap[enrollmentId] = true;
+						}
+					} else {
+						if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newUnpinnedEnrollments.push(enrollment);
+							this._unpinnedCoursesMap[enrollmentId] = true;
+						}
+					}
+				}, this);
+				this.getUpdates(orgUnitIds.join(','));
+				if (append) {
+					this.filteredPinnedEnrollments = this.filteredPinnedEnrollments.concat(newPinnedEnrollments);
+					this.filteredUnpinnedEnrollments = this.filteredUnpinnedEnrollments.concat(newUnpinnedEnrollments);
+				} else {
+					this.filteredPinnedEnrollments = newPinnedEnrollments;
+					this.filteredUnpinnedEnrollments = newUnpinnedEnrollments;
+				}
+
+				this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
+				this.$['all-courses-scroll-threshold'].clearTriggers();
+				this.lastEnrollmentsSearchResponse = enrollments;
 			},
 			_pinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();
@@ -575,6 +578,7 @@
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
+				this.listen(this.$['search-widget'], 'd2l-search-widget-results-changed', '_updateFilteredEnrollmentsEvent');
 
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 
@@ -586,6 +590,7 @@
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
+				this.unlisten(this.$['search-widget'], 'd2l-search-widget-results-changed', '_updateFilteredEnrollmentsEvent');
 			},
 			getCourseTileItemCount: function() {
 				var itemCount = Math.max(this.pinnedEnrollments ? this.pinnedEnrollments.length : 0,
@@ -646,6 +651,7 @@
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
+			_parser: null,
 			_sortOptions: {
 				OrgUnitCode: {
 					text: 'sorting.sortCourseCode',
@@ -663,6 +669,20 @@
 					text: 'sorting.sortLastAccessed',
 					// Note: Sorting by LastAccessed is done differently LMS-side, hence this being different
 					queryParameter: 'LastAccessed'
+				}
+			},
+			_myEnrollmentsEntityChanged: function(entity) {
+				if (entity) {
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					var enrollmentsRoot = this._parser.parse(entity);
+
+					if (!enrollmentsRoot.hasAction('search-my-enrollments')) {
+						return;
+					}
+
+					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
+
+					this.set('_enrollmentsSearchAction', searchAction);
 				}
 			},
 			_onFilterChanged: function(e) {
@@ -731,8 +751,7 @@
 				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			},
 			_clearSearchWidget: function() {
-				this.$['search-widget']._clearSearch();
-				this.$['search-widget']._setSearchIcon();
+				this.$['search-widget'].clear();
 				this._clearFilteredCourses();
 			},
 			_clearFilteredCourses: function() {

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -149,6 +149,8 @@
 					<div class="search-and-filter-row">
 						<d2l-search-widget-custom
 							id="search-widget"
+							search-button-label="{{localize('search')}}"
+							clear-button-label="{{localize('search.clearSearch')}}"
 							search-action="[[_enrollmentsSearchAction]]"
 							search-field-name="search"
 							cache-responses

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -101,6 +101,8 @@
 			<d2l-search-widget
 				id="semesterSearchWidget"
 				placeholder-text="{{localize('filtering.searchSemesters')}}"
+				search-button-label="{{localize('search')}}"
+				clear-button-label="{{localize('search.clearSearch')}}"
 				search-action="[[_searchSemestersAction]]"
 				search-field-name="search"
 				cache-responses></d2l-search-widget>
@@ -117,6 +119,8 @@
 			<d2l-search-widget
 				id="departmentSearchWidget"
 				placeholder-text="{{localize('filtering.searchDepartments')}}"
+				search-button-label="{{localize('search')}}"
+				clear-button-label="{{localize('search.clearSearch')}}"
 				search-action="[[_searchDepartmentsAction]]"
 				search-field-name="search"
 				cache-responses></d2l-search-widget>
@@ -280,6 +284,7 @@
 				this.$.departmentListButton.textContent = this.localize('filtering.filterLabel', 'filterLabel', label, 'num', numDepartmentFilters);
 
 				this.$.departmentSearchWidget.placeholderText = this.localize('filtering.searchBy', 'filter', departmentFilterName);
+				this.$.departmentSearchWidget.searchButtonLabel = this.localize('filtering.searchBy', 'filter', departmentFilterName);
 
 				this.fire('d2l-filter-menu-content-filters-changed', {
 					filters: this._currentFilters
@@ -291,6 +296,7 @@
 				this.$.semesterListButton.textContent = this.localize('filtering.filterLabel', 'filterLabel', label, 'num', numSemesterFilters);
 
 				this.$.semesterSearchWidget.placeholderText = this.localize('filtering.searchBy', 'filter', semesterFilterName);
+				this.$.semesterSearchWidget.searchButtonLabel = this.localize('filtering.searchBy', 'filter', semesterFilterName);
 
 				this.fire('d2l-filter-menu-content-filters-changed', {
 					filters: this._currentFilters

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -314,10 +314,22 @@
 			_onDepartmentSearchResults: function(e) {
 				this.set('_departments', e.detail.entities);
 				this.__onSearchResults(e.detail, '_moreDepartmentsUrl', '_hasMoreDepartments');
+				this.$.departmentList.querySelector('d2l-menu').resize();
+
+				setTimeout(function() {
+					// DE24225 - force dropdown to resize after opening
+					window.dispatchEvent(new Event('resize'));
+				}.bind(this), 200);
 			},
 			_onSemesterSearchResults: function(e) {
 				this.set('_semesters', e.detail.entities);
 				this.__onSearchResults(e.detail, '_moreSemestersUrl', '_hasMoreSemesters');
+				this.$.semesterList.querySelector('d2l-menu').resize();
+
+				setTimeout(function() {
+					// DE24225 - force dropdown to resize after opening
+					window.dispatchEvent(new Event('resize'));
+				}.bind(this), 200);
 			},
 			__onMoreResponse: function(response, organizationsPath, moreUrlPath, hasMorePath) {
 				if (response.detail.status === 200 || response.detail.status === 304) {

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -5,6 +5,8 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
+<link rel="import" href="../d2l-search-widget/d2l-search-widget-behavior.html">
+<link rel="import" href="../d2l-search-widget/d2l-search-widget-styles.html">
 <link rel="import" href="../d2l-typography/d2l-typography.html">
 <link rel="import" href="d2l-search-listbox.html">
 <link rel="import" href="d2l-search-dropdown-content.html">
@@ -13,51 +15,10 @@
 
 <dom-module id="d2l-search-widget-custom">
 	<template>
-		<style include="d2l-typography">
+		<style include="d2l-typography"></style>
+		<style include="d2l-search-widget-styles">
 			:host {
-				position: relative;
-				display: block;
-				min-width: 100px;
-				min-height: 60px;
-				padding: 0;
-				margin: 0;
-			}
-
-			input {
-				width: 100%;
-				height: 60px;
-				background-color: var(--d2l-color-white);
-				border-color: var(--d2l-color-titanius);
-				border-width: 1px;
-				box-shadow: inset 0 2px 0 0 rgba(185,194,208,.2);
-				padding: .4rem 1rem;
-				border-radius: .3rem;
-				border-style: solid;
-				vertical-align: middle;
-				box-sizing: border-box;
-				-webkit-transition-duration: .5s;
-				transition-duration: .5s;
-				-webkit-transition-timing-function: ease;
-				transition-timing-function: ease;
-				-webkit-transition-property: background-color,border-color;
-				transition-property: background-color,border-color;
-				padding-left: 10px;
-				padding-right: 65px;
-			}
-
-			input:focus,
-			input:hover {
-				border-color: var(--d2l-color-celestine);
-				border-width: 2px;
-				outline-width: 0;
-				padding: -webkit-calc(.4rem - 1px) -webkit-calc(1rem - 1px);
-				padding: calc(.4rem - 1px) calc(1rem - 1px);
-				padding-left: 9px;
-				padding-right: 64px;
-			}
-
-			input::-ms-clear {
-				display: none;
+				--d2l-search-widget-height: 60px;
 			}
 
 			.dropdown-content {
@@ -71,41 +32,20 @@
 			d2l-search-listbox {
 				border-radius: 6px;
 			}
-
-			:host button {
-				position: absolute;
-				top: 0px;
-				right: 0px;
-				background: none;
-				border: 1px solid transparent;
-				border-radius: 0.3rem;
-				margin: 10px;
-				cursor: pointer;
-				height: calc(100% - 20px);
-			}
-			:host button:hover,
-			:host button:focus {
-				border-color: var(--d2l-color-pressicus);
-				border-radius: 0.3rem;
-			}
-			d2l-icon {
-				--d2l-icon-height: 22px;
-				--d2l-icon-width: 22px;
-			}
 		</style>
+
+		<d2l-ajax
+			id="fullSearchRequest"
+			url="[[_searchUrl]]"
+			headers='{ "Accept": "application/vnd.siren+json" }'
+			on-iron-ajax-response="_onSearchResponse">
+		</d2l-ajax>
 
 		<d2l-ajax
 			id="liveSearchRequest"
 			url="[[_liveSearchUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
 			on-iron-ajax-response="_onLiveSearchResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="fullSearchRequest"
-			url="[[_fullSearchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onFullSearchResponse">
 		</d2l-ajax>
 
 		<d2l-dropdown no-auto-open>
@@ -124,7 +64,7 @@
 				<button
 					type="button"
 					aria-label$="{{localize('search.searchCourses')}}"
-					on-tap="_clearOrSearch">
+					on-tap="_onButtonClick">
 					<d2l-icon icon="d2l-tier1:search"></d2l-icon>
 				</button>
 			</div>
@@ -150,7 +90,7 @@
 
 						<div class="search-results-listbox-page" data-page-name="search-results-page">
 							<d2l-search-listbox>
-								<template id="courseSearchResultsTemplate" is="dom-repeat" items="[[_searchResults]]">
+								<template id="courseSearchResultsTemplate" is="dom-repeat" items="[[_liveSearchResults]]">
 									<div selectable data-text$="[[item.name]]" data-href$="[[item.href]]" role="option">
 										[[item.name]]
 									</div>
@@ -175,16 +115,10 @@
 			is: 'd2l-search-widget-custom',
 
 			properties: {
-				// Entity returned by the "my-enrollments" link on the /enrollments root
-				myEnrollmentsEntity: {
-					type: String,
-					observer: '_myEnrollmentsEntityChanged'
-				},
-
 				// Value to send for the `sort` parameter in the search query
 				sort: String,
 
-				// Array of parent organization IDs (self links) by which to limit the search results
+				// Value to send for the `parentOrganizations` parameter in the search query
 				parentOrganizations: {
 					type: Array,
 					value: function() {
@@ -200,14 +134,8 @@
 					}
 				},
 
-				// The search string updated by the course search input
-				_searchInput: {
-					type: String,
-					observer: '_onSearchInputChanged'
-				},
-
 				// An array of objects containing the results of the search-my-enrollments action
-				_searchResults: {
+				_liveSearchResults: {
 					type: Array,
 					value: function() {
 						return [];
@@ -217,10 +145,6 @@
 				_liveSearchUrl: {
 					type: String,
 					observer: '_onLiveSearchUrlChanged'
-				},
-				_fullSearchUrl: {
-					type: String,
-					observer: '_onFullSearchUrlChanged'
 				},
 
 				// List of strings containing previously searched terms/selected courses
@@ -239,7 +163,8 @@
 
 			behaviors: [
 				window.D2L.MyCourses.LocalizeBehavior,
-				window.D2L.MyCourses.UtilityBehavior
+				window.D2L.MyCourses.UtilityBehavior,
+				window.D2L.PolymerBehaviors.SearchWidgetBehavior
 			],
 
 			observers: [
@@ -269,74 +194,32 @@
 			},
 
 			_isSearched: false,
-			_fullSearchPageSize: 20,
+			_searchPageSize: 20,
 			_liveSearchPageSize: 5,
-			_searchResultsCache: {},
+			_keyCodes: {
+				DOWN: 40,
+				UP: 38,
+				ENTER: 13
+			},
 
-			// Retrieves previous searches from local storage to populate listbox
-			_initializePreviousSearches: function() {
-				if (window.localStorage.getItem('myCourses.previousSearches')) {
-					try {
-						var prevSearchObject = JSON.parse(window.localStorage.getItem('myCourses.previousSearches'));
-
-						if (prevSearchObject.hasOwnProperty('searches') && prevSearchObject.searches instanceof Array) {
-							this._previousSearches = prevSearchObject.searches;
-						}
-					} catch (exception) {
-						window.localStorage.removeItem('myCourses.previousSearches');
-						this._previousSearches = [];
-					}
+			_onSearchDependencyChanged: function() {
+				if (this.isAttached) {
+					this.debounce('_onSearchDependencyChanged', this.search, 500);
 				}
 			},
 
-			__search: function(pageSize, path) {
-				if (this._searchAction) {
-					var queryParams = {
-						search: encodeURIComponent(this._searchInput),
-						page: 1,
-						pageSize: pageSize,
-						parentOrganizations: this.parentOrganizations.join(','),
-						sort: this.sort
-					};
+			/*
+			* SearchWidgetBehavior overrides
+			*/
 
-					this.set(path, this.createActionUrl(this._searchAction, queryParams));
-				}
-			},
-
-			// Called by various key/mouse interactions
-			_fullSearch: function() {
+			search: function() {
 				this._isSearched = true;
-				this.__search(this._fullSearchPageSize, '_fullSearchUrl');
+				this._setSearchUrl(this._searchPageSize, '_searchUrl');
 			},
-			_liveSearch: function() {
-				this.__search(this._liveSearchPageSize, '_liveSearchUrl');
-			},
-
-			// Handlers called when full/live search URLs are changed by __search
-			_onFullSearchUrlChanged: function(newUrl) {
-				if (this._searchResultsCache[newUrl]) {
-					// If we've cached this response already, return it immediately
-					this.fire('d2l-search-enrollment-response', this._searchResultsCache[newUrl]);
-					return;
-				}
-				this.$.fullSearchRequest.generateRequest();
-				this.$.dropdown.close();
-			},
-			_onLiveSearchUrlChanged: function() {
-				this._organizationRequests.forEach(function(req) {
-					if (req.abort) {
-						req.abort();
-					}
-				});
-				this.set('_organizationRequests', []);
-
-				this.$.liveSearchRequest.generateRequest();
-			},
-
-			_clearSearch: function() {
+			clear: function() {
 				this.cancelDebouncer('liveSearchJob');
 				this._searchInput = '';
-				this.set('_searchResults', []);
+				this.set('_liveSearchResults', []);
 
 				if (this._previousSearches.length > 0) {
 					this.$$('iron-pages').select('recent-searches-page');
@@ -345,31 +228,20 @@
 				}
 
 				this._isSearched = false;
-				this.__search(this._fullSearchPageSize, '_fullSearchUrl');
-			},
-
-			_clearOrSearch: function() {
-				if (this._isSearched) {
-					this._clearSearch();
-				} else {
-					this._fullSearch();
-				}
 				this._updateIcon();
+				this._setSearchUrl(this._searchPageSize, '_searchUrl');
 			},
+			_setSearchUrl: function(pageSize, path) {
+				var queryParams = {
+					page: 1,
+					pageSize: pageSize,
+					parentOrganizations: this.parentOrganizations.join(','),
+					sort: this.sort
+				};
+				queryParams[this.searchFieldName] = encodeURIComponent(this._searchInput);
 
-			_updateIcon: function() {
-				this._isSearched ? this._setClearIcon() : this._setSearchIcon();
+				this.set(path, this.createActionUrl(this._searchAction, queryParams));
 			},
-			_setClearIcon: function() {
-				this.$$('.search-bar > button > d2l-icon').setAttribute('icon', 'd2l-tier1:close-default');
-				this.$$('.search-bar > button').setAttribute('aria-label', this.localize('search.clearSearch'));
-			},
-			_setSearchIcon: function() {
-				this.$$('.search-bar > button > d2l-icon').setAttribute('icon', 'd2l-tier1:search');
-				this.$$('.search-bar > button').setAttribute('aria-label', this.localize('search.searchCourses'));
-			},
-
-			// Observer for search input field text, calls debounced live search
 			_onSearchInputChanged: function(newSearchString) {
 				if (newSearchString.length === 0) {
 					// Don't live search for empty inputs
@@ -389,11 +261,11 @@
 					this.debounce('liveSearchJob', this._liveSearch, 750);
 				}
 			},
-
 			_onSearchInputKeyPressed: function(e) {
 				switch (e.keyCode) {
 					case this._keyCodes.ENTER:
-						this._fullSearch();
+						this._addSearchToHistory(this._searchInput);
+						this.search();
 						this._updateIcon();
 						e.preventDefault();
 						break;
@@ -412,6 +284,24 @@
 				}
 			},
 
+			/*
+			* Recent searches functionality
+			*/
+
+			_initializePreviousSearches: function() {
+				if (window.localStorage.getItem('myCourses.previousSearches')) {
+					try {
+						var prevSearchObject = JSON.parse(window.localStorage.getItem('myCourses.previousSearches'));
+
+						if (prevSearchObject.hasOwnProperty('searches') && prevSearchObject.searches instanceof Array) {
+							this._previousSearches = prevSearchObject.searches;
+						}
+					} catch (exception) {
+						window.localStorage.removeItem('myCourses.previousSearches');
+						this._previousSearches = [];
+					}
+				}
+			},
 			_addSearchToHistory: function(searchTerm) {
 				var previousSearches = this._previousSearches.slice();
 
@@ -438,35 +328,31 @@
 				}
 			},
 
-			_myEnrollmentsEntityChanged: function(entity) {
-				if (entity) {
-					var parser = document.createElement('d2l-siren-parser');
-					var enrollmentsRoot = parser.parse(entity);
+			/*
+			* Live search funtionality
+			*/
 
-					if (!enrollmentsRoot.hasAction('search-my-enrollments')) {
-						return;
+			_liveSearch: function() {
+				this._setSearchUrl(this._liveSearchPageSize, '_liveSearchUrl');
+			},
+			_onLiveSearchUrlChanged: function() {
+				this._organizationRequests.forEach(function(req) {
+					if (req.abort) {
+						req.abort();
 					}
+				});
+				this.set('_organizationRequests', []);
 
-					var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
-
-					this.set('_searchAction', searchAction);
-				}
+				this.$.liveSearchRequest.generateRequest();
 			},
-
-			_onSearchDependencyChanged: function() {
-				if (this.isAttached) {
-					this.debounce('_onSearchDependencyChanged', this._fullSearch, 500);
-				}
-			},
-
 			_onLiveSearchResponse: function(response) {
 				if (response.detail.status === 200 && this._searchInput) {
-					var parser = document.createElement('d2l-siren-parser');
-					var searchResponse = parser.parse(response.detail.xhr.response);
+					this._parser = this._parser || document.createElement('d2l-siren-parser');
+					var searchResponse = this._parser.parse(response.detail.xhr.response);
 					var enrollmentEntities = searchResponse.entities;
 					this.$$('iron-pages').select(enrollmentEntities.length > 0 ? 'search-results-page' : 'no-results-page');
 
-					this._searchResults = [];
+					this._liveSearchResults = [];
 					for (var i = 0; i < enrollmentEntities.length; i++) {
 						// Fetch each search result's organization's information
 						(function(enrollment, index, numEntities, self, parser) {
@@ -478,18 +364,18 @@
 									var organization = parser.parse(response.detail.response);
 									// Polymer's splice method causes empty results to show up for an
 									// unknown reason, so use a normal Array.prototype.splice...
-									self._searchResults.splice(index, 0, {
+									self._liveSearchResults.splice(index, 0, {
 										name: organization.properties.name,
 										href: (organization.getLinkByRel(/\/organization-homepage$/) || {}).href
 									});
 									// ...then, if this is the last result to get spliced in, manually
 									// call notifySplices with the changes.
-									if (self._searchResults.length >= numEntities) {
-										self.notifySplices('_searchResults', [{
+									if (self._liveSearchResults.length >= numEntities) {
+										self.notifySplices('_liveSearchResults', [{
 											index: 0,
 											removed: [],
 											addedCount: numEntities,
-											object: self._searchResults,
+											object: self._liveSearchResults,
 											type: 'splice'
 										}]);
 									}
@@ -497,16 +383,15 @@
 							};
 							ajax.generateRequest();
 							self.push('_organizationRequests', ajax);
-						})(enrollmentEntities[i], i, enrollmentEntities.length, this, parser);
+						})(enrollmentEntities[i], i, enrollmentEntities.length, this, this._parser);
 					}
 				}
 			},
-			_onFullSearchResponse: function(response) {
-				if (response.detail.status === 200) {
-					this._searchResultsCache[response.detail.url] = response;
-					this.fire('d2l-search-enrollment-response', response);
-				}
-			},
+
+			/*
+			* Dropdown functionality
+			*/
+
 			_onIronSelect: function() {
 				var ironPages = this.$$('iron-pages');
 				var pageIndex = ironPages.indexOf(ironPages.selectedItem);
@@ -518,17 +403,10 @@
 				if (text) {
 					this._addSearchToHistory(text);
 					this._searchInput = text;
-					this._fullSearch();
+					this.search();
 				}
 				e.stopPropagation();
 			},
-
-			_keyCodes: {
-				DOWN: 40,
-				UP: 38,
-				ENTER: 13
-			},
-
 			// Called when an element within the search bar gains focus, to open the dropdown if required
 			_onSearchInputFocused: function() {
 				if (this.$.dropdown.opened) {
@@ -548,21 +426,17 @@
 				// depending on what was last selected).
 				this.$.dropdown.open();
 			},
-
 			_handleFocus: function() {
 				this._checkFocusLost(document.activeElement);
 			},
-
 			_handleClick: function(e) {
 				this._checkFocusLost(Polymer.dom(e).rootTarget);
 			},
-
 			_checkFocusLost: function(focusedElement) {
 				if (this.$.dropdown.opened && !this._isDescendant(focusedElement)) {
 					this.$.dropdown.close();
 				}
 			},
-
 			// Determines whether the given element is a descendant of this element.
 			_isDescendant: function(element) {
 				var parentNode = element.parentNode;

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -193,7 +193,6 @@
 				document.body.removeEventListener('click', this._handleClickBound, true);
 			},
 
-			_isSearched: false,
 			_searchPageSize: 20,
 			_liveSearchPageSize: 5,
 			_keyCodes: {
@@ -213,12 +212,15 @@
 			*/
 
 			search: function() {
-				this._isSearched = true;
+				this.set('_showClearIcon', true);
 				this._setSearchUrl(this._searchPageSize, '_searchUrl');
 			},
 			clear: function() {
+				// Triggers _onSearchInputChanged to call _setSearchUrl with empty query
+				this.set('_searchInput', '');
+				this.set('_showClearIcon', false);
+
 				this.cancelDebouncer('liveSearchJob');
-				this._searchInput = '';
 				this.set('_liveSearchResults', []);
 
 				if (this._previousSearches.length > 0) {
@@ -226,31 +228,28 @@
 				} else {
 					this.$.dropdown.close();
 				}
-
-				this._isSearched = false;
-				this._updateIcon();
-				this._setSearchUrl(this._searchPageSize, '_searchUrl');
 			},
 			_setSearchUrl: function(pageSize, path) {
+				if (!this._searchAction) {
+					return;
+				}
+
 				var queryParams = {
 					page: 1,
 					pageSize: pageSize,
 					parentOrganizations: this.parentOrganizations.join(','),
 					sort: this.sort
 				};
-				queryParams[this.searchFieldName] = encodeURIComponent(this._searchInput);
+				queryParams[this.searchFieldName] = encodeURIComponent(this._searchInput.trim());
 
 				this.set(path, this.createActionUrl(this._searchAction, queryParams));
 			},
 			_onSearchInputChanged: function(newSearchString) {
 				if (newSearchString.length === 0) {
-					// Don't live search for empty inputs
-					return;
+					this._setSearchUrl(this._searchPageSize, '_searchUrl');
+				} else {
+					this.set('_showClearIcon', false);
 				}
-
-				// Search term no longer matches results, so consider it "not searched"
-				this._isSearched = false;
-				this._updateIcon();
 
 				// Checking for _searchAction required here to avoid problems on init
 				if (this._searchAction && !this.$.dropdown.opened) {
@@ -266,7 +265,6 @@
 					case this._keyCodes.ENTER:
 						this._addSearchToHistory(this._searchInput);
 						this.search();
-						this._updateIcon();
 						e.preventDefault();
 						break;
 					case this._keyCodes.DOWN:

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -37,7 +37,7 @@ describe('d2l-all-courses', function() {
 		clock = sinon.useFakeTimers();
 
 		widget = fixture('d2l-all-courses-fixture');
-		sinon.stub(widget.$['search-widget'], '__search');
+		sinon.stub(widget.$['search-widget'], '_setSearchUrl');
 
 		widgetNoAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.html
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.html
@@ -13,7 +13,8 @@
 			<template>
 				<d2l-search-widget-custom
 					sort="OrgUnitName,OrgUnitId"
-					parent-organizations="[]">
+					parent-organizations="[]"
+					cache-responses>
 				</d2l-search-widget-custom>
 			</template>
 		</test-fixture>

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.js
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.js
@@ -7,39 +7,33 @@ describe('<d2l-search-widget-custom>', function() {
 		server,
 		widget,
 		clock,
-		myEnrollmentsEntity = {
-			class: ['enrollments', 'root'],
-			actions: [{
-				name: 'search-my-enrollments',
-				method: 'GET',
-				href: '/enrollments/users/169',
-				fields: [{
-					name: 'search',
-					type: 'search',
-					value: ''
-				}, {
-					name: 'pageSize',
-					type: 'number',
-					value: 20
-				}, {
-					name: 'embedDepth',
-					type: 'number',
-					value: 0
-				}, {
-					name: 'sort',
-					type: 'text',
-					value: 'OrgUnitName,OrgUnitId'
-				}, {
-					name: 'parentOrganizations',
-					type: 'hidden',
-					value: ''
-				}]
-			}],
-			links: [{
-				rel: ['self'],
-				href: '/enrollments'
+		searchAction = {
+			name: 'search-my-enrollments',
+			method: 'GET',
+			href: '/enrollments/users/169',
+			fields: [{
+				name: 'search',
+				type: 'search',
+				value: ''
+			}, {
+				name: 'pageSize',
+				type: 'number',
+				value: 20
+			}, {
+				name: 'embedDepth',
+				type: 'number',
+				value: 0
+			}, {
+				name: 'sort',
+				type: 'text',
+				value: 'OrgUnitName,OrgUnitId'
+			}, {
+				name: 'parentOrganizations',
+				type: 'hidden',
+				value: ''
 			}]
-		};
+		},
+		searchFieldName = 'search';
 
 	beforeEach(function() {
 		sandbox = sinon.sandbox.create();
@@ -54,7 +48,8 @@ describe('<d2l-search-widget-custom>', function() {
 
 		widget = fixture('d2l-search-widget-custom-fixture');
 		widget._searchResultsCache = {};
-		widget.myEnrollmentsEntity = myEnrollmentsEntity;
+		widget.searchAction = searchAction;
+		widget.searchFieldName = searchFieldName;
 	});
 
 	afterEach(function() {
@@ -139,8 +134,8 @@ describe('<d2l-search-widget-custom>', function() {
 		widget.parentOrganizations = [3, 2, 1];
 
 		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._fullSearchUrl).to.contain('sort=NewSort');
-			expect(widget._fullSearchUrl).to.contain('parentOrganizations=3,2,1');
+			expect(widget._searchUrl).to.contain('sort=NewSort');
+			expect(widget._searchUrl).to.contain('parentOrganizations=3,2,1');
 			done();
 		});
 
@@ -148,7 +143,7 @@ describe('<d2l-search-widget-custom>', function() {
 	});
 
 	it('only performs one search per debounce period', function() {
-		var spy = sandbox.spy(widget, '__search');
+		var spy = sandbox.spy(widget, '_setSearchUrl');
 
 		for (var i = 0; i < 20; i++) {
 			widget.set('sort', 'sort' + i);
@@ -163,21 +158,21 @@ describe('<d2l-search-widget-custom>', function() {
 	it('should fetch the content for a given URL the first time', function() {
 		var stub = sandbox.stub(widget.$.fullSearchRequest, 'generateRequest');
 
-		widget.set('_fullSearchUrl', 'foo');
+		widget.set('_searchUrl', 'foo');
 
 		expect(stub.callCount).to.equal(1);
 	});
 
 	it('should cache search responses for a given URL', function(done) {
-		var spy = sandbox.spy(widget, '__search');
+		var spy = sandbox.spy(widget, '_setSearchUrl');
 		widget._searchResultsCache['foo'] = { test: 'bar' };
 
-		document.addEventListener('d2l-search-enrollment-response', function(e) {
+		document.addEventListener('d2l-search-widget-results-changed', function(e) {
 			expect(e.detail.test).to.equal('bar');
 			expect(spy.callCount).to.equal(0);
 			done();
 		});
 
-		widget.set('_fullSearchUrl', 'foo');
+		widget.set('_searchUrl', 'foo');
 	});
 });

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.js
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.js
@@ -58,92 +58,22 @@ describe('<d2l-search-widget-custom>', function() {
 		clock.restore();
 	});
 
-	it('loads element', function() {
-		expect(widget).to.exist;
-	});
-
-	it('should perform a search when sort changes', function(done) {
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			done();
-		});
-
+	it('should perform a search when sort changes', function() {
+		var spy = sandbox.spy(widget, 'search');
 		widget.set('sort', '-PinDate,OrgUnitName,OrgUnitId');
-
 		clock.tick(501);
+		expect(spy.called).to.be.true;
 	});
 
-	it('should perform a search when filter changes', function(done) {
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			done();
-		});
-
+	it('should perform a search when filter changes', function() {
+		var spy = sandbox.spy(widget, 'search');
 		widget.set('parentOrganizations', [1, 2, 3]);
-
 		clock.tick(501);
-	});
-
-	it('should perform a search and change icon when the search icon is clicked', function(done) {
-		expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
-
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._isSearched).to.be.true;
-			expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
-			done();
-		});
-
-		widget.$$('button').click();
-	});
-
-	it('should perform a (clearing) search and change icon when the clear icon is clicked', function(done) {
-		// Put widget into "searched" state
-		widget._isSearched = true;
-		widget._updateIcon();
-		expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
-
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._isSearched).to.be.false;
-			expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
-			done();
-		});
-
-		widget.$$('button').click();
-	});
-
-	it('should switch back to search icon when search string is updated, even if in the searched state', function(done) {
-		// Don't open the dropdown when search input changes for this test rather than mocking everything
-		sandbox.stub(widget.$.dropdown, 'open');
-
-		expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
-
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._isSearched).to.be.true;
-			expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('close-default');
-
-			widget._searchInput = 'foo';
-			expect(widget._isSearched).to.be.false;
-			expect(widget.$$('button > d2l-icon').getAttribute('icon')).to.contain('search');
-			done();
-		});
-
-		widget.$$('button').click();
-	});
-
-	it('should apply current search parameters when search button is clicked', function(done) {
-		// Set new values for sort/filter fields and prevent auto-search observer from firing
-		widget.sort = 'NewSort';
-		widget.parentOrganizations = [3, 2, 1];
-
-		widget.$.fullSearchRequest.addEventListener('iron-ajax-response', function() {
-			expect(widget._searchUrl).to.contain('sort=NewSort');
-			expect(widget._searchUrl).to.contain('parentOrganizations=3,2,1');
-			done();
-		});
-
-		widget.$$('button').click();
+		expect(spy.called).to.be.true;
 	});
 
 	it('only performs one search per debounce period', function() {
-		var spy = sandbox.spy(widget, '_setSearchUrl');
+		var spy = sandbox.spy(widget, 'search');
 
 		for (var i = 0; i < 20; i++) {
 			widget.set('sort', 'sort' + i);
@@ -153,26 +83,5 @@ describe('<d2l-search-widget-custom>', function() {
 		clock.tick(501);
 
 		expect(spy.callCount).to.equal(1);
-	});
-
-	it('should fetch the content for a given URL the first time', function() {
-		var stub = sandbox.stub(widget.$.fullSearchRequest, 'generateRequest');
-
-		widget.set('_searchUrl', 'foo');
-
-		expect(stub.callCount).to.equal(1);
-	});
-
-	it('should cache search responses for a given URL', function(done) {
-		var spy = sandbox.spy(widget, '_setSearchUrl');
-		widget._searchResultsCache['foo'] = { test: 'bar' };
-
-		document.addEventListener('d2l-search-widget-results-changed', function(e) {
-			expect(e.detail.test).to.equal('bar');
-			expect(spy.callCount).to.equal(0);
-			done();
-		});
-
-		widget.set('_searchUrl', 'foo');
 	});
 });


### PR DESCRIPTION
The intent here is to simplify `d2l-search-widget-custom` by relying on the existing behaviour. A few things are overriden from the behaviour (as we have more complex behaviour with this version of it), but it did significantly reduce overlap, and means future updates and changes will generally only have to happen in one place.

Note that a lot of this diff's nastiness is just moving functions around, so that things were easier to find...

TODO:

- [x] Merge https://github.com/Brightspace/d2l-search-widget-ui/pull/20
- [x] Use `clearButtonLabel` and `searchButtonLabel` from above
- [x] Merge https://github.com/Brightspace/d2l-search-widget-ui/pull/21
- [x] Update to use changes from above
- [x] Merge https://github.com/Brightspace/d2l-search-widget-ui/pull/23
- [x] Update to use changes from above... again.