### PR TITLE
DE24238 - Use two columns for skinny screen + 2 or 3 pinned courses

### DIFF
--- a/d2l-course-tile-responsive-grid-behavior.html
+++ b/d2l-course-tile-responsive-grid-behavior.html
@@ -40,7 +40,7 @@ s		*/
 				var numCols = 1;
 
 				if (width < 768) {
-					if (itemCount >= 4) {
+					if (itemCount >= 2) {
 						numCols = 2;
 					}
 				} else if (width < 992) {

--- a/test/d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.js
+++ b/test/d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.js
@@ -48,7 +48,7 @@ describe('d2l-course-tile-responsive-grid-behavior', function() {
 			}, {
 				width: 767,
 				itemCount: 3,
-				expectedColumns: 1
+				expectedColumns: 2
 			}, {
 				width: 767,
 				itemCount: 4,


### PR DESCRIPTION
Without this, having 3 pinned courses would give a really weird display, where there was only one column on skinny screens, which resulted in huge course tiles. Only case with one column now is if you're on a skinny screen, and also only have one pinned course; otherwise it's at least two.