### PR TITLE
DE24225 - Force filter menu to resize after opening

### DIFF
--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -341,12 +341,22 @@
 				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, false);
 				this.$.departmentSearchWidget.clear();
 				this.$.departmentList.querySelector('d2l-menu').resize();
+
+				setTimeout(function() {
+					// DE24225 - force dropdown to resize after opening
+					window.dispatchEvent(new Event('resize'));
+				}.bind(this), 200);
 			},
 			_selectSemesterList: function() {
 				this.__toggleSelectedList(this.$.semesterList, this.$.semesterListButton, this.$.semesterListHighlight, true);
 				this.__toggleSelectedList(this.$.departmentList, this.$.departmentListButton, this.$.departmentListHighlight, false);
 				this.$.semesterSearchWidget.clear();
 				this.$.semesterList.querySelector('d2l-menu').resize();
+
+				setTimeout(function() {
+					// DE24225 - force dropdown to resize after opening
+					window.dispatchEvent(new Event('resize'));
+				}.bind(this), 200);
 			},
 			__updateFilter: function(e, path) {
 				if (e.detail.selected) {


### PR DESCRIPTION
If the list of semesters or departments is long, for some reason it will just extend past the bottom of the viewport rather than resizing correctly. To force it to size correctly, we can just fake-trigger a resize event, which causes magic to happen deep within d2l-menu (or maybe d2l-dropdown (or maybe both)) and it resizes to the right size. This isn't a hack, it's more just a... suboptimal solution, but I've spent hours trying to figure out another way, and not been able to really identify a "cleaner" way to do it.

Fixes #168.