### PR TITLE
Fix clearing filter search bars and also no results text

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -723,7 +723,7 @@
 			_updateEnrollmentAlerts: function(hasPinnedEnrollments, hasUnpinnedEnrollments) {
 				this._noPinnedCoursesInSearch = false;
 				this._noUnpinnedCoursesInSearch = false;
-				var isSearched = this.$['search-widget']._isSearched,
+				var isSearched = this.$['search-widget']._showClearIcon,
 					hasAlert = this._hasAlert('noPinnedCourses');
 				this._clearAlerts();
 				if (!hasPinnedEnrollments) {

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -260,8 +260,8 @@
 					this.$.semesterListButton.focus();
 				}
 
-				this.$.semesterSearchWidget._setSearchIcon();
-				this.$.departmentSearchWidget._setSearchIcon();
+				this.$.semesterSearchWidget.clear();
+				this.$.departmentSearchWidget.clear();
 
 				this.set('_currentFilters', []);
 				this.set('_numSemesterFilters', 0);

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -231,38 +231,38 @@ describe('d2l-all-courses', function() {
 	describe('searching messages', function() {
 		it('should show no pinned courses in search message when no pinned courses in search', function() {
 			widget._clearAlerts();
-			widget.$['search-widget']._isSearched = true;
+			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(false, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.true;
 		});
 		it('should show no unpinned courses in search message when no pinned courses in search', function() {
 			widget._clearAlerts();
-			widget.$['search-widget']._isSearched = true;
+			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, false);
 			expect(widget._noUnpinnedCoursesInSearch).to.be.true;
 		});
 		it('should not show message when there are pinned courses in search', function() {
 			widget._clearAlerts();
-			widget.$['search-widget']._isSearched = true;
+			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show message when there are unpinned courses in search', function() {
 			widget._clearAlerts();
-			widget.$['search-widget']._isSearched = true;
+			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noUnpinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show message if there is already an alert for no pinned courses', function() {
 			widget._clearAlerts();
 			widget._addAlert('call-to-action', 'noPinnedCourses', 'no pinned courses bruh');
-			widget.$['search-widget']._isSearched = true;
+			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(false, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show messages if not searching', function() {
 			widget._clearAlerts();
-			widget.$['search-widget']._isSearched = false;
+			widget.$['search-widget']._showClearIcon = false;
 			widget._updateEnrollmentAlerts(false, false);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;
 			expect(widget._noUnpinnedCoursesInSearch).to.be.false;


### PR DESCRIPTION
Missed this in #313. Also broke the "No search results"-type text in there, as `_isSearched` is no longer a thing. #PrivateVariableProblems