### PR TITLE
Only animate pin/unpin

### DIFF
--- a/d2l-course-tile-sliding-grid-behavior.html
+++ b/d2l-course-tile-sliding-grid-behavior.html
@@ -65,9 +65,9 @@
 				diff.count
 			).row;
 
-			if (diff.pos === oldTiles.length) {
-				// tiles were added/removed at the end, so only container
-				// needs to be resized
+			if (diff.pos === oldTiles.length || diff.count > 1) {
+				// tiles were added/removed at the end, so only container needs to be resized
+				// also, don't animate anything other than pin/unpin
 				this.__slide_resizeContainer(0);
 				return;
 			}


### PR DESCRIPTION
For mass changes to the number of courses, i.e. changing the filter or sort, don't animate it. Since we're really just replacing the entire backing data set in this case, ultimately we are (generally) removing everything then inserting everything, so no real need to animate that change.