### PR TITLE
Clean up d2l-all-courses

### DIFF
--- a/d2l-all-courses-styles.html
+++ b/d2l-all-courses-styles.html
@@ -1,0 +1,100 @@
+<dom-module id="d2l-all-courses-styles">
+	<template>
+		<style>
+			:host {
+				display: block;
+			}
+			h2 {
+				margin: 20px 0 10px 0 !important;
+			}
+			d2l-alert {
+				display: block;
+				margin-bottom: 20px;
+			}
+			d2l-icon {
+				--d2l-icon-height: 15px;
+				--d2l-icon-width: 15px;
+				margin-top: -0.35rem;
+			}
+			d2l-loading-spinner {
+				margin-bottom: 30px;
+				padding-bottom: 30px;
+				display: block;
+				margin: auto;
+			}
+			.d2l-all-courses-hidden {
+				display: none !important;
+			}
+			#search-and-filter {
+				margin-bottom: 50px;
+			}
+			.search-and-filter-row {
+				display: flex;
+				justify-content: space-between;
+			}
+			.advanced-search-link {
+				font-size: 0.8rem;
+				margin-top: 3px;
+				flex: 1;
+			}
+			d2l-search-widget-custom {
+				flex: 1;
+			}
+			#filterAndSort {
+				flex: 1.4;
+				display: flex;
+				justify-content: flex-end;
+				align-items: center;
+			}
+			@media screen and (max-width: 767px) {
+				#filterAndSort {
+					display: none;
+				}
+				.advanced-search-link {
+					text-align: right;
+					margin-top: 5px;
+				}
+			}
+			.dropdown-opener-text {
+				font-size: 0.95rem;
+				font-family: Lato;
+				cursor: pointer;
+				padding: 0;
+				margin-left: 1rem;
+			}
+			.dropdown-button {
+				background: none;
+				border: none;
+				cursor: pointer;
+				padding: 0;
+				color: var(--d2l-color-ferrite);
+			}
+			.dropdown-button > d2l-icon {
+				margin-left: 4px;
+			}
+			.dropdown-content-header {
+				box-sizing: border-box;
+				display: flex;
+				align-items: center;
+				justify-content: space-between;
+				border-bottom: 1px solid var(--d2l-color-titanius);
+				width: 100%;
+				padding: 20px;
+			}
+			.dropdown-content-gradient {
+				background: linear-gradient(to top, white, var(--d2l-color-regolith));
+			}
+			button[aria-pressed="true"] {
+				color: var(--d2l-color-celestine);
+			}
+			button:focus > d2l-icon,
+			button:hover > d2l-icon,
+			button:focus > span,
+			button:hover > span,
+			.focus {
+				text-decoration: underline;
+				color: var(--d2l-color-celestine);
+			}
+		</style>
+	</template>
+</dom-module>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -13,6 +13,7 @@
 <link rel="import" href="../d2l-siren-parser/d2l-siren-parser.html">
 <link rel="import" href="../d2l-typography/d2l-typography.html">
 <link rel="import" href="d2l-alert-behavior.html">
+<link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-filter-menu-content/d2l-filter-menu-content.html">
@@ -23,108 +24,14 @@
 
 <dom-module id="d2l-all-courses">
 	<template>
-		<style include="d2l-typography">
-			:host {
-				display: block;
-			}
-			h2 {
-				margin: 20px 0 10px 0 !important;
-			}
-			d2l-alert {
-				display: block;
-				margin-bottom: 20px;
-			}
-			d2l-icon {
-				--d2l-icon-height: 15px;
-				--d2l-icon-width: 15px;
-				margin-top: -0.35rem;
-			}
-			d2l-loading-spinner {
-				margin-bottom: 30px;
-				padding-bottom: 30px;
-				display: block;
-				margin: auto;
-			}
-			.d2l-all-courses-hidden {
-				display: none !important;
-			}
-			#search-and-filter {
-				margin-bottom: 50px;
-			}
-			.search-and-filter-row {
-				display: flex;
-				justify-content: space-between;
-			}
-			.advanced-search-link {
-				font-size: 0.8rem;
-				margin-top: 3px;
-				flex: 1;
-			}
-			d2l-search-widget-custom {
-				flex: 1;
-			}
-			#filterAndSort {
-				flex: 1.4;
-				display: flex;
-				justify-content: flex-end;
-				align-items: center;
-			}
-			@media screen and (max-width: 767px) {
-				#filterAndSort {
-					display: none;
-				}
-				.advanced-search-link {
-					text-align: right;
-					margin-top: 5px;
-				}
-			}
-			.dropdown-opener-text {
-				font-size: 0.95rem;
-				font-family: Lato;
-				cursor: pointer;
-				padding: 0;
-				margin-left: 1rem;
-			}
-			.dropdown-button {
-				background: none;
-				border: none;
-				cursor: pointer;
-				padding: 0;
-				color: var(--d2l-color-ferrite);
-			}
-			.dropdown-button > d2l-icon {
-				margin-left: 4px;
-			}
-			.dropdown-content-header {
-				box-sizing: border-box;
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-				border-bottom: 1px solid var(--d2l-color-titanius);
-				width: 100%;
-				padding: 20px;
-			}
-			.dropdown-content-gradient {
-				background: linear-gradient(to top, white, var(--d2l-color-regolith));
-			}
-			button[aria-pressed="true"] {
-				color: var(--d2l-color-celestine);
-			}
-			button:focus > d2l-icon,
-			button:hover > d2l-icon,
-			button:focus > span,
-			button:hover > span,
-			.focus {
-				text-decoration: underline;
-				color: var(--d2l-color-celestine);
-			}
-		</style>
+		<style include="d2l-typography"></style>
+		<style include="d2l-all-courses-styles"></style>
 
 		<d2l-ajax
 			id="enrollmentsSearchRequest"
 			url="[[_enrollmentsSearchUrl]]"
 			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_enrollmentsSearchResponse"
+			on-iron-ajax-response="_onEnrollmentsSearchResponse"
 			last-response="{{lastEnrollmentsSearchResponse}}">
 		</d2l-ajax>
 
@@ -142,7 +49,7 @@
 
 				<iron-scroll-threshold
 					id="all-courses-scroll-threshold"
-					on-lower-threshold="_loadNextEnrollmentsPage">
+					on-lower-threshold="_onAllCoursesLowerThreshold">
 				</iron-scroll-threshold>
 
 				<div id="search-and-filter">
@@ -175,7 +82,7 @@
 									</d2l-filter-menu-content>
 									<iron-scroll-threshold
 										id="scrollThreshold"
-										on-lower-threshold="_onLowerThreshold">
+										on-lower-threshold="_onFilterMenuLowerThreshold">
 									</iron-scroll-threshold>
 								</d2l-dropdown-content>
 							</d2l-dropdown>
@@ -222,7 +129,7 @@
 
 				<d2l-course-tile-grid
 					id="all-courses-pinned"
-					enrollments="[[filteredPinnedEnrollments]]"
+					enrollments="[[_filteredPinnedEnrollments]]"
 					enrollments-to-animate="[[_pinnedEnrollmentsToAnimate]]"
 					delay-load="[[delayLoad]]"
 					tile-sizes="[[_tileSizes]]"
@@ -242,7 +149,7 @@
 
 				<d2l-course-tile-grid
 					id="all-courses-unpinned"
-					enrollments="[[filteredUnpinnedEnrollments]]"
+					enrollments="[[_filteredUnpinnedEnrollments]]"
 					enrollments-to-animate="[[_unpinnedEnrollmentsToAnimate]]"
 					delay-load="[[delayLoad]]"
 					tile-sizes="[[_tileSizes]]"
@@ -273,134 +180,117 @@
 		Polymer({
 			is: 'd2l-all-courses',
 			properties: {
-				// URL constructed to fetch a user's enrollments with the enrollments search Action
-				_enrollmentsSearchUrl: String,
-				// Set of pinned enrollment Entities
-				pinnedEnrollments: {
-					type: Array,
-					value: function() {
-						return [];
-					},
-					observer: '_pinnedEnrollmentsChanged'
-				},
-				// filtered pinned enrollment entities
-				filteredPinnedEnrollments: {
-					type: Array,
-					value: function() {
-						return [];
-					}
-				},
-				// Set of unpinned enrollment Entities
-				unpinnedEnrollments: {
-					type: Array,
-					value: function() {
-						return [];
-					},
-					observer: '_unpinnedEnrollmentsChanged'
-				},
-				filteredUnpinnedEnrollments: {
-					type: Array,
-					value: function() {
-						return [];
-					}
-				},
-				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
-				_pinnedCoursesMap: {
-					type: Object,
-					value: function() {
-						return {};
-					}
-				},
-				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates
-				_unpinnedCoursesMap: {
-					type: Object,
-					value: function() {
-						return {};
-					}
-				},
+				/*
+				* Public Polymer properties
+				*/
 
-				// True when there are filtered pinned enrollments (i.e. `filteredPinnedEnrollments.length > 0`)
-				_hasFilteredPinnedEnrollments: {
-					type: Boolean,
-					value: false
+				// URL that directs to the advanced search page
+				advancedSearchUrl: {
+					type: String,
+					observer: '_advancedSearchUrlChanged'
 				},
-
-				// True when there are filtered unpinned enrollments (i.e. `filteredUnpinnedEnrollments.length > 0`)
-				_hasFilteredUnpinnedEnrollments: {
-					type: Boolean,
-					value: false
-				},
-
-				// True when there are any filtered enrollments (pinned or unpinned)
-				_hasFilteredEnrollments: {
-					type: Boolean,
-					value: false
+				// Default option in Sort menu
+				defaultSortValue: {
+					type: String,
+					value: 'OrgUnitName'
 				},
 				// Sets the delay-load property on the course tile grid
 				delayLoad: {
 					type: Boolean,
 					value: true
 				},
-				myEnrollmentsEntity: {
-					type: Object,
-					value: function() {
-						return {};
-					},
-					observer: '_myEnrollmentsEntityChanged'
-				},
-				// Object containing the last response from an enrollments search request
-				lastEnrollmentsSearchResponse: Object,
-				_filterText: String,
-				defaultSortValue: {
-					type: String,
-					value: 'OrgUnitName'
-				},
-				_sortParameter: {
-					type: String,
-					value: '-PinDate,OrgUnitName,OrgUnitId'
-				},
-				_tileSizes: Object,
-				_parentOrganizations: {
-					type: Array,
-					value: function() {
-						return [];
-					}
-				},
-				// URL that directs to the advanced search page
-				advancedSearchUrl: {
-					type: String,
-					observer: '_advancedSearchUrlChanged'
-				},
 				// Standard Semester OU Type name to be displayed in the filter dropdown
 				filterStandardSemesterName: String,
 				// Standard Department OU Type name to be displayed in the filter dropdown
 				filterStandardDepartmentName: String,
+				// Object containing the last response from an enrollments search request
+				lastEnrollmentsSearchResponse: Object,
+				// Entity returned from my-enrollments Link from the enrollments root
+				myEnrollmentsEntity: {
+					type: Object,
+					value: function() { return {}; },
+					observer: '_myEnrollmentsEntityChanged'
+				},
+				// Set of pinned enrollment Entities
+				pinnedEnrollments: {
+					type: Array,
+					value: function() { return []; },
+					observer: '_pinnedEnrollmentsChanged'
+				},
+				// the endpoint for the telemetry service
+				telemetryEndpoint: String,
+				// tenant ID sent with telemetry requests
+				tenantId: String,
+				// user ID sent with telemetry requests
+				userId: String,
+				// Set of unpinned enrollment Entities
+				unpinnedEnrollments: {
+					type: Array,
+					value: function() { return []; },
+					observer: '_unpinnedEnrollmentsChanged'
+				},
+
+				/*
+				* Private Polymer properties
+				*/
+
+				// search-my-enrollments Action
+				_enrollmentsSearchAction: Object,
+				// URL constructed to fetch a user's enrollments with the enrollments search Action
+				_enrollmentsSearchUrl: String,
+				// True when there are filtered pinned enrollments (i.e. `_filteredPinnedEnrollments.length > 0`)
+				_hasFilteredPinnedEnrollments: Boolean,
+				// True when there are filtered unpinned enrollments (i.e. `_filteredUnpinnedEnrollments.length > 0`)
+				_hasFilteredUnpinnedEnrollments: Boolean,
+				// True when there are any filtered enrollments (pinned or unpinned)
+				_hasFilteredEnrollments: Boolean,
+				// Determines if the filter menu can be shown (The number of enrollments >= enrollments required)
+				_hasManyEnrollments: false,
+				// Filter dropdown opener text
+				_filterText: String,
+				// filtered pinned enrollment entities
+				_filteredPinnedEnrollments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_filteredUnpinnedEnrollments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_noPinnedCoursesInSearch: false,
+				_noUnpinnedCoursesInSearch: false,
 				// The number of Enrollments required to show the filter menu
 				_numEnrollmentsRequiredToShowFilters: {
 					type: Number,
 					readonly: true,
 					value: 20
 				},
-				// Determines if the filter menu can be shown (The number of enrollments >= enrollments required)
-				_hasManyEnrollments: false,
-				_noPinnedCoursesInSearch: false,
-				_noUnpinnedCoursesInSearch: false,
-				_enrollmentsSearchAction: Object,
-				// the endpoint for the telemetry service
-				telemetryEndpoint: String,
-				userId: String,
-				tenantId: String,
+				_parentOrganizations: {
+					type: Array,
+					value: function() { return []; }
+				},
+				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
+				_pinnedCoursesMap: {
+					type: Object,
+					value: function() { return {}; }
+				},
 				_pinnedEnrollmentsToAnimate: {
 					type: Array,
-					value: function() {
-						return [];
-					}
+					value: function() { return []; }
+				},
+				_sortParameter: {
+					type: String,
+					value: '-PinDate,OrgUnitName,OrgUnitId'
+				},
+				_tileSizes: Object,
+				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates
+				_unpinnedCoursesMap: {
+					type: Object,
+					value: function() { return {}; }
 				},
 				_unpinnedEnrollmentsToAnimate: {
 					type: Array,
-					value: function() {
-						return [];
-					}
+					value: function() { return []; }
 				}
 			},
 			behaviors: [
@@ -413,142 +303,12 @@
 			],
 			listeners: {
 				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening',
-				'tile-remove-complete': '_onTileRemoveComplete',
-				'enrollment-pin-complete': '_onEnrollmentPinComplete',
-				'enrollment-unpin-complete': '_onEnrollmentUnpinComplete'
+				'tile-remove-complete': '_onTileRemoveComplete'
 			},
 			observers: [
 				'_updateEnrollmentAlerts(_hasFilteredPinnedEnrollments, _hasFilteredUnpinnedEnrollments)',
-				'_enrollmentsChanged(filteredPinnedEnrollments.length, filteredUnpinnedEnrollments.length)'
+				'_enrollmentsChanged(_filteredPinnedEnrollments.length, _filteredUnpinnedEnrollments.length)'
 			],
-			_loadNextEnrollmentsPage: function() {
-				if (this.$['all-courses'].opened && this.lastEnrollmentsSearchResponse) {
-					var parser = document.createElement('d2l-siren-parser');
-					var lastResponseEntity = parser.parse(this.lastEnrollmentsSearchResponse);
-
-					if (lastResponseEntity && lastResponseEntity.hasLink('next')) {
-						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
-						this.toggleClass('d2l-all-courses-hidden', false, this.$.lazyLoadSpinner);
-						this.$.lazyLoadSpinner.scrollIntoView();
-						this.$.enrollmentsSearchRequest.generateRequest();
-					}
-				}
-			},
-			_enrollmentsChanged: function() {
-				this._hasFilteredPinnedEnrollments = this.filteredPinnedEnrollments.length > 0;
-				this._hasFilteredUnpinnedEnrollments = this.filteredUnpinnedEnrollments.length > 0;
-				this._hasFilteredEnrollments = this._hasFilteredPinnedEnrollments || this._hasFilteredUnpinnedEnrollments;
-				this.$['all-courses-scroll-threshold'].clearTriggers();
-			},
-			_moveEnrollmentToPinnedList: function(enrollment) {
-				// Remove enrollment from unpinned list, add to pinned
-				var enrollmentId = this.getEntityIdentifier(enrollment);
-
-				for (var index = 0; index < this.filteredUnpinnedEnrollments.length; index++) {
-					var pinnedEnrollmentId = this.getEntityIdentifier(this.filteredUnpinnedEnrollments[index]);
-					if (pinnedEnrollmentId === enrollmentId) {
-						var foundEnrollment = this.filteredUnpinnedEnrollments[index];
-						this._setEnrollmentPinData(foundEnrollment, true);
-						this._pinnedEnrollmentsToAnimate.push(enrollmentId);
-						this.unshift('filteredPinnedEnrollments', foundEnrollment);
-						this.splice('filteredUnpinnedEnrollments', index, 1);
-						break;
-					}
-				}
-			},
-			_moveEnrollmentToUnpinnedList: function(enrollment) {
-				// Remove enrollment from pinned list, add to unpinned
-				var enrollmentId = this.getEntityIdentifier(enrollment);
-
-				for (var index = 0; index < this.filteredPinnedEnrollments.length; index++) {
-					var unpinnedEnrollmentId = this.getEntityIdentifier(this.filteredPinnedEnrollments[index]);
-					if (unpinnedEnrollmentId === enrollmentId) {
-						var foundEnrollment = this.filteredPinnedEnrollments[index];
-						this._setEnrollmentPinData(foundEnrollment, false);
-						this._unpinnedEnrollmentsToAnimate.push(enrollmentId);
-						this.unshift('filteredUnpinnedEnrollments', foundEnrollment);
-						this.splice('filteredPinnedEnrollments', index, 1);
-						break;
-					}
-				}
-			},
-			_onTileRemoveComplete: function(e) {
-				if (e.detail.pinned) {
-					this._moveEnrollmentToPinnedList(e.detail.enrollment);
-				} else {
-					this._moveEnrollmentToUnpinnedList(e.detail.enrollment);
-				}
-			},
-			_setEnrollmentPinData: function(entity, isPinned) {
-				// HACK: Because the course tiles are being removed and re-created in the DOM, we have to effectively
-				// manually update them, rather than updating them with the received enrollment from the API call.
-				if (isPinned) {
-					entity.class.splice(entity.class.indexOf('unpinned'));
-					entity.class.push('pinned');
-					entity.actions[0].name = 'unpin-course';
-					entity.actions[0].fields[0].value = false;
-					entity._actionsByName['unpin-course'] = entity.actions[0];
-				} else {
-					entity.class.splice(entity.class.indexOf('pinned'));
-					entity.class.push('unpinned');
-					entity.actions[0].name = 'pin-course';
-					entity.actions[0].fields[0].value = true;
-					entity._actionsByName['pin-course'] = entity.actions[0];
-				}
-			},
-			_updateFilteredEnrollmentsEvent: function(e) {
-				this._pinnedCoursesMap = {};
-				this._unpinnedCoursesMap = {};
-				this._updateFilteredEnrollments(e.detail, false);
-			},
-			_enrollmentsSearchResponse: function(response) {
-				if (response.detail.status === 200) {
-					var parser = document.createElement('d2l-siren-parser');
-					var enrollments = parser.parse(response.detail.xhr.response);
-					this._updateFilteredEnrollments(enrollments, true);
-				}
-			},
-			_updateFilteredEnrollments: function(enrollments, append) {
-				var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
-				var newPinnedEnrollments = [];
-				var newUnpinnedEnrollments = [];
-				var orgUnitIds = [];
-				enrollmentEntities.forEach(function(enrollment) {
-					var enrollmentId = this.getEntityIdentifier(enrollment);
-					orgUnitIds.push(this.getOrgUnitId(enrollmentId));
-					if (enrollment.hasClass('pinned')) {
-						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-							newPinnedEnrollments.push(enrollment);
-							this._pinnedCoursesMap[enrollmentId] = true;
-						}
-					} else {
-						if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-							newUnpinnedEnrollments.push(enrollment);
-							this._unpinnedCoursesMap[enrollmentId] = true;
-						}
-					}
-				}, this);
-				this.getUpdates(orgUnitIds.join(','));
-				if (append) {
-					this.filteredPinnedEnrollments = this.filteredPinnedEnrollments.concat(newPinnedEnrollments);
-					this.filteredUnpinnedEnrollments = this.filteredUnpinnedEnrollments.concat(newUnpinnedEnrollments);
-				} else {
-					this.filteredPinnedEnrollments = newPinnedEnrollments;
-					this.filteredUnpinnedEnrollments = newUnpinnedEnrollments;
-				}
-
-				this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
-				this.$['all-courses-scroll-threshold'].clearTriggers();
-				this.lastEnrollmentsSearchResponse = enrollments;
-			},
-			_pinnedEnrollmentsChanged: function() {
-				this._updateTileSizes();
-				this._setFilteredPinnedEnrollments();
-			},
-			_unpinnedEnrollmentsChanged: function() {
-				this._updateTileSizes();
-				this._setFilteredUnpinnedEnrollments();
-			},
 			ready: function() {
 				this._updateEnrollmentAlerts(this._hasFilteredPinnedEnrollments, this._hasFilteredUnpinnedEnrollments);
 
@@ -564,47 +324,43 @@
 				this._sortParameter = this._sortOptions[this.defaultSortValue].queryParameter;
 			},
 			attached: function() {
-				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_onMenuItemChange');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.listen(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
-				this.listen(this.$['search-widget'], 'd2l-search-widget-results-changed', '_updateFilteredEnrollmentsEvent');
+				this.listen(this.$['search-widget'], 'd2l-search-widget-results-changed', '_onSearchResultsChanged');
 
 				this.$.scrollThreshold.scrollTarget = this.$.filterDropdownContent.querySelector('.d2l-dropdown-content-container');
 
 				window.addEventListener('resize', this._onResize.bind(this));
 			},
 			detached: function() {
-				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_updateSortBy');
+				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_onMenuItemChange');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-change', '_onFilterChanged');
 				this.unlisten(this.$.filterMenuContent, 'd2l-filter-menu-content-hide', '_onFilterHideChanged');
-				this.unlisten(this.$['search-widget'], 'd2l-search-widget-results-changed', '_updateFilteredEnrollmentsEvent');
+				this.unlisten(this.$['search-widget'], 'd2l-search-widget-results-changed', '_onSearchResultsChanged');
 			},
+
+			/*
+			* Public API methods
+			*/
+
 			getCourseTileItemCount: function() {
 				var itemCount = Math.max(this.pinnedEnrollments ? this.pinnedEnrollments.length : 0,
 					this.unpinnedEnrollments ? this.unpinnedEnrollments.length : 0);
 				return itemCount;
 			},
-			_setFilteredPinnedEnrollments: function() {
-				this.filteredPinnedEnrollments = this.pinnedEnrollments.slice();
-			},
-			_setFilteredUnpinnedEnrollments: function() {
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
-			},
-			_advancedSearchUrlChanged: function() {
-				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
-			},
 			load: function() {
 				// Load course tile and filter contents. Called from d2l-my-courses.
 				this.$['all-courses-scroll-threshold'].scrollTarget = this.$['all-courses'].scrollRegion;
 				this.$['all-courses-scroll-threshold'].clearTriggers();
-				this.filteredPinnedEnrollments.forEach(function(enrollment) {
+				this._filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._pinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
-				this.filteredPinnedEnrollments.forEach(function(enrollment) {
+				this._filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
 				this.set('delayLoad', false);
@@ -642,6 +398,11 @@
 				this.$$('#all-courses-pinned').setCourseImage(details);
 				this.$$('#all-courses-unpinned').setCourseImage(details);
 			},
+
+			/*
+			* Non-Polymer properties
+			*/
+
 			_parser: null,
 			_sortOptions: {
 				OrgUnitCode: {
@@ -662,6 +423,101 @@
 					queryParameter: 'LastAccessed'
 				}
 			},
+
+			/*
+			* Listeners
+			*/
+
+			_onAllCoursesLowerThreshold: function() {
+				if (this.$['all-courses'].opened && this.lastEnrollmentsSearchResponse) {
+					var parser = document.createElement('d2l-siren-parser');
+					var lastResponseEntity = parser.parse(this.lastEnrollmentsSearchResponse);
+
+					if (lastResponseEntity && lastResponseEntity.hasLink('next')) {
+						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
+						this.toggleClass('d2l-all-courses-hidden', false, this.$.lazyLoadSpinner);
+						this.$.lazyLoadSpinner.scrollIntoView();
+						this.$.enrollmentsSearchRequest.generateRequest();
+					}
+				}
+			},
+			_onEnrollmentsSearchResponse: function(response) {
+				if (response.detail.status === 200) {
+					var parser = document.createElement('d2l-siren-parser');
+					var enrollments = parser.parse(response.detail.xhr.response);
+					this._updateFilteredEnrollments(enrollments, true);
+				}
+			},
+			_onFilterChanged: function(e) {
+				this._parentOrganizations = [];
+				this.set('_parentOrganizations', e.detail.filters);
+			},
+			_onFilterDropdownClose: function() {
+				var length = this.$.filterMenuContent.currentFilters.length;
+				var text;
+				if (length === 0) {
+					text = this.localize('filtering.filter');
+				} else if (length === 1) {
+					text = this.localize('filtering.filterSingle');
+				} else {
+					text = this.localize('filtering.filterMultiple', 'num', length);
+				}
+				this.set('_filterText', text);
+			},
+			_onFilterDropdownOpen: function() {
+				this.set('_filterText', this.localize('filtering.filter'));
+				this.$.filterMenuContent.open();
+			},
+			_onFilterHideChanged: function(e) {
+				this.toggleClass('d2l-all-courses-hidden', e.detail.hide, this.$.filterDropdown);
+			},
+			_onFilterMenuLowerThreshold: function() {
+				this.$.scrollThreshold.clearTriggers();
+				this.$.filterMenuContent.loadMore();
+			},
+			_onMenuItemChange: function(e) {
+				this.set('_sortParameter', this._sortOptions[e.detail.value].queryParameter);
+				this.$.sortText.textContent = this.localize(this._sortOptions[e.detail.value].text || '');
+				this.$.sortDropdown.toggleOpen();
+			},
+			_onResize: function() {
+				this._updateTileSizes();
+			},
+			_onSearchResultsChanged: function(e) {
+				this._pinnedCoursesMap = {};
+				this._unpinnedCoursesMap = {};
+				this._updateFilteredEnrollments(e.detail, false);
+			},
+			_onSimpleOverlayOpening: function() {
+				this._removeAlert('setCourseImageFailure');
+				this._clearSearchWidget();
+				if (this._hasManyEnrollments) {
+					this.$.filterMenuContent._clearFilters();
+				}
+				this._filterText = this.localize('filtering.filter');
+				this._resetSortDropdown();
+			},
+			_onTileRemoveComplete: function(e) {
+				if (e.detail.pinned) {
+					this._moveEnrollmentToPinnedList(e.detail.enrollment);
+				} else {
+					this._moveEnrollmentToUnpinnedList(e.detail.enrollment);
+				}
+			},
+
+			/*
+			* Observers
+			*/
+
+			_advancedSearchUrlChanged: function() {
+				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
+			},
+			_enrollmentsChanged: function() {
+				this._hasFilteredPinnedEnrollments = this._filteredPinnedEnrollments.length > 0;
+				this._hasFilteredUnpinnedEnrollments = this._filteredUnpinnedEnrollments.length > 0;
+				this._hasFilteredEnrollments = this._hasFilteredPinnedEnrollments || this._hasFilteredUnpinnedEnrollments;
+				this.$['all-courses-scroll-threshold'].clearTriggers();
+			},
 			_myEnrollmentsEntityChanged: function(entity) {
 				if (entity) {
 					this._parser = this._parser || document.createElement('d2l-siren-parser');
@@ -676,49 +532,13 @@
 					this.set('_enrollmentsSearchAction', searchAction);
 				}
 			},
-			_onFilterChanged: function(e) {
-				this._parentOrganizations = [];
-				this.set('_parentOrganizations', e.detail.filters);
-			},
-			_onFilterDropdownOpen: function() {
-				this.set('_filterText', this.localize('filtering.filter'));
-				this.$.filterMenuContent.open();
-			},
-			_onFilterDropdownClose: function() {
-				var length = this.$.filterMenuContent.currentFilters.length;
-				var text;
-				if (length === 0) {
-					text = this.localize('filtering.filter');
-				} else if (length === 1) {
-					text = this.localize('filtering.filterSingle');
-				} else {
-					text = this.localize('filtering.filterMultiple', 'num', length);
-				}
-				this.set('_filterText', text);
-			},
-			_onFilterHideChanged: function(e) {
-				this.toggleClass('d2l-all-courses-hidden', e.detail.hide, this.$.filterDropdown);
-			},
-			_onLowerThreshold: function() {
-				this.$.scrollThreshold.clearTriggers();
-				this.$.filterMenuContent.loadMore();
-			},
-			_onResize: function() {
+			_pinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();
+				this._setFilteredPinnedEnrollments();
 			},
-			_onSimpleOverlayOpening: function() {
-				this._removeAlert('setCourseImageFailure');
-				this._clearSearchWidget();
-				if (this._hasManyEnrollments) {
-					this.$.filterMenuContent._clearFilters();
-				}
-				this._filterText = this.localize('filtering.filter');
-				this._resetSortDropdown();
-			},
-			_updateSortBy: function(e) {
-				this.set('_sortParameter', this._sortOptions[e.detail.value].queryParameter);
-				this.$.sortText.textContent = this.localize(this._sortOptions[e.detail.value].text || '');
-				this.$.sortDropdown.toggleOpen();
+			_unpinnedEnrollmentsChanged: function() {
+				this._updateTileSizes();
+				this._setFilteredUnpinnedEnrollments();
 			},
 			_updateEnrollmentAlerts: function(hasPinnedEnrollments, hasUnpinnedEnrollments) {
 				this._noPinnedCoursesInSearch = false;
@@ -737,19 +557,52 @@
 					this._noUnpinnedCoursesInSearch = true;
 				}
 			},
-			_updateTileSizes: function() {
-				this._rescaleCourseTileRegions();
-				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
+
+			/*
+			* Utility/helper functions
+			*/
+
+			_clearFilteredCourses: function() {
+				this._pinnedCoursesMap = {};
+				this._unpinnedCoursesMap = {};
+				this._filteredPinnedEnrollments = this.pinnedEnrollments.slice();
+				this._filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
 			},
 			_clearSearchWidget: function() {
 				this.$['search-widget'].clear();
 				this._clearFilteredCourses();
 			},
-			_clearFilteredCourses: function() {
-				this._pinnedCoursesMap = {};
-				this._unpinnedCoursesMap = {};
-				this.filteredPinnedEnrollments = this.pinnedEnrollments.slice();
-				this.filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
+			_moveEnrollmentToPinnedList: function(enrollment) {
+				// Remove enrollment from unpinned list, add to pinned
+				var enrollmentId = this.getEntityIdentifier(enrollment);
+
+				for (var index = 0; index < this._filteredUnpinnedEnrollments.length; index++) {
+					var pinnedEnrollmentId = this.getEntityIdentifier(this._filteredUnpinnedEnrollments[index]);
+					if (pinnedEnrollmentId === enrollmentId) {
+						var foundEnrollment = this._filteredUnpinnedEnrollments[index];
+						this._setEnrollmentPinData(foundEnrollment, true);
+						this._pinnedEnrollmentsToAnimate.push(enrollmentId);
+						this.unshift('_filteredPinnedEnrollments', foundEnrollment);
+						this.splice('_filteredUnpinnedEnrollments', index, 1);
+						break;
+					}
+				}
+			},
+			_moveEnrollmentToUnpinnedList: function(enrollment) {
+				// Remove enrollment from pinned list, add to unpinned
+				var enrollmentId = this.getEntityIdentifier(enrollment);
+
+				for (var index = 0; index < this._filteredPinnedEnrollments.length; index++) {
+					var unpinnedEnrollmentId = this.getEntityIdentifier(this._filteredPinnedEnrollments[index]);
+					if (unpinnedEnrollmentId === enrollmentId) {
+						var foundEnrollment = this._filteredPinnedEnrollments[index];
+						this._setEnrollmentPinData(foundEnrollment, false);
+						this._unpinnedEnrollmentsToAnimate.push(enrollmentId);
+						this.unshift('_filteredUnpinnedEnrollments', foundEnrollment);
+						this.splice('_filteredPinnedEnrollments', index, 1);
+						break;
+					}
+				}
 			},
 			_resetSortDropdown: function() {
 				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').click();
@@ -763,6 +616,66 @@
 				if (content) {
 					content.close();
 				}
+			},
+			_setEnrollmentPinData: function(entity, isPinned) {
+				// HACK: Because the course tiles are being removed and re-created in the DOM, we have to effectively
+				// manually update them, rather than updating them with the received enrollment from the API call.
+				if (isPinned) {
+					entity.class.splice(entity.class.indexOf('unpinned'));
+					entity.class.push('pinned');
+					entity.actions[0].name = 'unpin-course';
+					entity.actions[0].fields[0].value = false;
+					entity._actionsByName['unpin-course'] = entity.actions[0];
+				} else {
+					entity.class.splice(entity.class.indexOf('pinned'));
+					entity.class.push('unpinned');
+					entity.actions[0].name = 'pin-course';
+					entity.actions[0].fields[0].value = true;
+					entity._actionsByName['pin-course'] = entity.actions[0];
+				}
+			},
+			_setFilteredPinnedEnrollments: function() {
+				this._filteredPinnedEnrollments = this.pinnedEnrollments.slice();
+			},
+			_setFilteredUnpinnedEnrollments: function() {
+				this._filteredUnpinnedEnrollments = this.unpinnedEnrollments.slice();
+			},
+			_updateFilteredEnrollments: function(enrollments, append) {
+				var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
+				var newPinnedEnrollments = [];
+				var newUnpinnedEnrollments = [];
+				var orgUnitIds = [];
+				enrollmentEntities.forEach(function(enrollment) {
+					var enrollmentId = this.getEntityIdentifier(enrollment);
+					orgUnitIds.push(this.getOrgUnitId(enrollmentId));
+					if (enrollment.hasClass('pinned')) {
+						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newPinnedEnrollments.push(enrollment);
+							this._pinnedCoursesMap[enrollmentId] = true;
+						}
+					} else {
+						if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newUnpinnedEnrollments.push(enrollment);
+							this._unpinnedCoursesMap[enrollmentId] = true;
+						}
+					}
+				}, this);
+				this.getUpdates(orgUnitIds.join(','));
+				if (append) {
+					this._filteredPinnedEnrollments = this._filteredPinnedEnrollments.concat(newPinnedEnrollments);
+					this._filteredUnpinnedEnrollments = this._filteredUnpinnedEnrollments.concat(newUnpinnedEnrollments);
+				} else {
+					this._filteredPinnedEnrollments = newPinnedEnrollments;
+					this._filteredUnpinnedEnrollments = newUnpinnedEnrollments;
+				}
+
+				this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
+				this.$['all-courses-scroll-threshold'].clearTriggers();
+				this.lastEnrollmentsSearchResponse = enrollments;
+			},
+			_updateTileSizes: function() {
+				this._rescaleCourseTileRegions();
+				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			}
 		});
 	</script>

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -199,10 +199,10 @@
 					type: Boolean,
 					value: true
 				},
-				// Standard Semester OU Type name to be displayed in the filter dropdown
-				filterStandardSemesterName: String,
 				// Standard Department OU Type name to be displayed in the filter dropdown
 				filterStandardDepartmentName: String,
+				// Standard Semester OU Type name to be displayed in the filter dropdown
+				filterStandardSemesterName: String,
 				// Object containing the last response from an enrollments search request
 				lastEnrollmentsSearchResponse: Object,
 				// Entity returned from my-enrollments Link from the enrollments root
@@ -238,14 +238,6 @@
 				_enrollmentsSearchAction: Object,
 				// URL constructed to fetch a user's enrollments with the enrollments search Action
 				_enrollmentsSearchUrl: String,
-				// True when there are filtered pinned enrollments (i.e. `_filteredPinnedEnrollments.length > 0`)
-				_hasFilteredPinnedEnrollments: Boolean,
-				// True when there are filtered unpinned enrollments (i.e. `_filteredUnpinnedEnrollments.length > 0`)
-				_hasFilteredUnpinnedEnrollments: Boolean,
-				// True when there are any filtered enrollments (pinned or unpinned)
-				_hasFilteredEnrollments: Boolean,
-				// Determines if the filter menu can be shown (The number of enrollments >= enrollments required)
-				_hasManyEnrollments: false,
 				// Filter dropdown opener text
 				_filterText: String,
 				// filtered pinned enrollment entities
@@ -257,8 +249,16 @@
 					type: Array,
 					value: function() { return []; }
 				},
-				_noPinnedCoursesInSearch: false,
-				_noUnpinnedCoursesInSearch: false,
+				// True when there are any filtered enrollments (pinned or unpinned)
+				_hasFilteredEnrollments: Boolean,
+				// True when there are filtered pinned enrollments (i.e. `_filteredPinnedEnrollments.length > 0`)
+				_hasFilteredPinnedEnrollments: Boolean,
+				// True when there are filtered unpinned enrollments (i.e. `_filteredUnpinnedEnrollments.length > 0`)
+				_hasFilteredUnpinnedEnrollments: Boolean,
+				// Determines if the filter menu can be shown (The number of enrollments >= enrollments required)
+				_hasManyEnrollments: Boolean,
+				_noPinnedCoursesInSearch: Boolean,
+				_noUnpinnedCoursesInSearch: Boolean,
 				// The number of Enrollments required to show the filter menu
 				_numEnrollmentsRequiredToShowFilters: {
 					type: Number,

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -178,8 +178,8 @@ describe('d2l-all-courses', function() {
 		it('should update enrollment alerts when an enrollment is pinned', function() {
 			var sandbox = sinon.sandbox.create();
 
-			widget.filteredPinnedEnrollments = [];
-			widget.filteredUnpinnedEnrollments = [unpinnedEnrollmentEntity];
+			widget._filteredPinnedEnrollments = [];
+			widget._filteredUnpinnedEnrollments = [unpinnedEnrollmentEntity];
 			expect(widget._hasFilteredPinnedEnrollments).to.equal(false);
 			expect(widget._alerts).to.include({ alertName: 'noPinnedCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any pinned courses. Pin your favorite courses to make them easier to find.' });
 			var updateEnrollmentAlertsSpy = sandbox.spy(widget, '_updateEnrollmentAlerts');


### PR DESCRIPTION
Been meaning to do this for a while, so [why not now](https://media.makeameme.org/created/Why-not-Zoidberg-vyotfu.jpg)? (Actual reason for now: tried to implement the two-call method, but this was just dizzying to constantly scroll through and try to find things. Now, it's organized! Yay!)

This is a strictly non-functional change, this component was just becoming rather unwieldly to work with. Broke the styles out into their own file, and rearranged all the functions and properties into more logical groupings (+ sub-grouped alphabetically yaaaay). Also renamed a couple private functions (so if that causes problems... they shouldn't be private...) and removed two mysterious `enrollment-pin/unpin-complete` listeners that don't exist anymore.

#sorrynotsorry