### PR TITLE
US83010 - Add error message when images aren't available

### DIFF
--- a/d2l-alert-behavior.html
+++ b/d2l-alert-behavior.html
@@ -24,6 +24,7 @@
 			},
 			_addAlert: function(type, name, message) {
 				if (this._alerts) {
+					this._removeAlert(name);
 					this.push('_alerts', {
 						alertType: type,
 						alertName: name,
@@ -40,12 +41,9 @@
 				});
 			},
 			_removeAlert: function(name) {
-				if (this._alerts && this._alerts.length > 0 && this._hasAlert(name)) {
-					this.splice('_alerts', this._alerts.map(function(alert) { return alert.name; }).indexOf(name), 1);
+				if (this._alerts && this._alerts.length > 0) {
+					this.set('_alerts', this._alerts.filter(function(alert) { return alert.alertName !== name; }));
 				}
-			},
-			_clearAlerts: function() {
-				this._alerts = [];
 			}
 		};
 	})();

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -359,9 +359,17 @@
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this._filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._pinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
+
+					if (!enrollment.hasLinkByRel(/organization-image/)) {
+						this._addAlert('warning', 'displayCourseImageFailure', this.localize('error.displayingImages'));
+					}
 				}, this);
-				this._filteredPinnedEnrollments.forEach(function(enrollment) {
+				this._filteredUnpinnedEnrollments.forEach(function(enrollment) {
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
+
+					if (!enrollment.hasLinkByRel(/organization-image/)) {
+						this._addAlert('warning', 'displayCourseImageFailure', this.localize('error.displayingImages'));
+					}
 				}, this);
 				this.set('delayLoad', false);
 				// Only make the call to load the filter menu contents if user has many enrollments
@@ -545,7 +553,8 @@
 				this._noUnpinnedCoursesInSearch = false;
 				var isSearched = this.$['search-widget']._showClearIcon,
 					hasAlert = this._hasAlert('noPinnedCourses');
-				this._clearAlerts();
+
+				this._removeAlert('noPinnedCourses');
 				if (!hasPinnedEnrollments) {
 					if (isSearched && !hasAlert) {
 						this._noPinnedCoursesInSearch = true;
@@ -658,6 +667,10 @@
 							newUnpinnedEnrollments.push(enrollment);
 							this._unpinnedCoursesMap[enrollmentId] = true;
 						}
+					}
+
+					if (!enrollment.hasLinkByRel(/organization-image/)) {
+						this._addAlert('warning', 'displayCourseImageFailure', this.localize('error.displayingImages'));
 					}
 				}, this);
 				this.getUpdates(orgUnitIds.join(','));

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -300,6 +300,12 @@
 							}
 						}
 
+						if (newPinnedEnrollments.length > 0
+							&& !enrollment.hasLinkByRel(/organization-image/)
+						) {
+							this._addAlert('warning', 'displayCourseImageFailure', this.localize('error.displayingImages'));
+						}
+
 						this._enrollmentIdMap[orgUnitId] = enrollmentId;
 					}, this);
 					this.getUpdates(Object.keys(this._enrollmentIdMap).join(','));
@@ -410,15 +416,13 @@
 				}
 			},
 			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
-				this._clearAlerts();
-
-				if (hasEnrollments) {
-					if (!hasPinnedEnrollments) {
-						this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
-					}
-				} else {
+				hasEnrollments ?
+					this._removeAlert('noCourses') :
 					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
-				}
+
+				hasPinnedEnrollments ?
+					this._removeAlert('noPinnedCourses') :
+					this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
 			},
 			_setStartedInactive: function(e) {
 				var type = e && e.detail && e.detail.type;

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -189,14 +189,6 @@ describe('d2l-all-courses', function() {
 			sandbox.restore();
 		});
 
-		it('should remove all existing alerts when enrollment alerts are updated', function() {
-			widget._addAlert('error', 'testError', 'this is a test');
-			widget._addAlert('warning', 'testWarning', 'this is another test');
-			expect(widget._alerts).to.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-			widget._updateEnrollmentAlerts(true);
-			expect(widget._alerts).to.not.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-		});
-
 		it('should add a setCourseImageFailure warning alert when a request to set the image fails', function() {
 			var setCourseImageEvent = { detail: { status: 'failure'} };
 			widget.setCourseImage(setCourseImageEvent);
@@ -229,39 +221,34 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('searching messages', function() {
-		it('should show no pinned courses in search message when no pinned courses in search', function() {
-			widget._clearAlerts();
+		beforeEach(function() {
+			widget._alerts = [];
 			widget.$['search-widget']._showClearIcon = true;
+		});
+
+		it('should show no pinned courses in search message when no pinned courses in search', function() {
 			widget._updateEnrollmentAlerts(false, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.true;
 		});
 		it('should show no unpinned courses in search message when no pinned courses in search', function() {
-			widget._clearAlerts();
-			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, false);
 			expect(widget._noUnpinnedCoursesInSearch).to.be.true;
 		});
 		it('should not show message when there are pinned courses in search', function() {
-			widget._clearAlerts();
-			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show message when there are unpinned courses in search', function() {
-			widget._clearAlerts();
-			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noUnpinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show message if there is already an alert for no pinned courses', function() {
-			widget._clearAlerts();
 			widget._addAlert('call-to-action', 'noPinnedCourses', 'no pinned courses bruh');
-			widget.$['search-widget']._showClearIcon = true;
 			widget._updateEnrollmentAlerts(false, true);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;
 		});
 		it('should not show messages if not searching', function() {
-			widget._clearAlerts();
+			widget._alerts = [];
 			widget.$['search-widget']._showClearIcon = false;
 			widget._updateEnrollmentAlerts(false, false);
 			expect(widget._noPinnedCoursesInSearch).to.be.false;

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -365,14 +365,6 @@ describe('d2l-my-courses', function() {
 				done();
 			});
 		});
-
-		it('should remove all existing alerts when enrollment alerts are updated', function() {
-			widget._addAlert('error', 'testError', 'this is a test');
-			widget._addAlert('warning', 'testWarning', 'this is another test');
-			expect(widget._alerts).to.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-			widget._updateEnrollmentAlerts(true, true);
-			expect(widget._alerts).to.not.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-		});
 	});
 
 	describe('With enrollments', function() {


### PR DESCRIPTION
Couple things here

- if no pinned courses, don't display the message on the home screen (only in the overlay)
- if > 0 pinned courses, display the messsage on the home screen and in the overlay
- _removeAlert wasn't actually working properly, so fixed it
- also slightly changed alert behaviour so that only one alert of a particular name can be shown at a time
- update tests
- remove _clearAlerts, as it's no longer really appropriate to use in any cases (should remove your own alerts)

TODO:

- [ ] Add unit test(s)