### PR TITLE
Bump d2l-search-widget to 1.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "d2l-menu": "~0.3.0",
     "d2l-offscreen": "^2.2.2",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#~0.7.2",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^1.0.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#~0.0.4",
     "d2l-siren-parser": "git://github.com/Brightspace/d2l-siren-parser-ui.git#^1.1.2",
     "d2l-typography": "^5.2.2",


### PR DESCRIPTION
This doesn't have any changes from 0.7.2, but it means one less 0.x.y dependency, which means one less thing to get annoyed at.