### PR TITLE
DE24521 - Navigation of course tiles and course settings on screen readers

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -68,12 +68,12 @@ the user has in that organization - student, teacher, TA, etc.
 				</div>
 			</a>
 
-			<template is="dom-if" if="[[_showHoverMenu]]">
-				<div class="hover-menu no-tap-interaction">
-					<d2l-dropdown>
-						<button	class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[_courseSettingsLabel]]">
-							<d2l-icon icon="d2l-tier1:more"></d2l-icon>
-						</button>
+			<div class="hover-menu no-tap-interaction">
+				<d2l-dropdown>
+					<button	class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[_courseSettingsLabel]]">
+						<d2l-icon icon="d2l-tier1:more"></d2l-icon>
+					</button>
+					<template is="dom-if" if="[[_showHoverMenu]]">
 						<d2l-dropdown-menu id="overflow-dropdown">
 							<d2l-menu label$="[[_courseSettingsLabel]]">
 								<template is="dom-if" if="{{_courseInfoUrl}}" restamp="true">
@@ -98,9 +98,9 @@ the user has in that organization - student, teacher, TA, etc.
 								</d2l-menu-item>
 							</d2l-menu>
 						</d2l-dropdown-menu>
-					</d2l-dropdown>
-				</div>
-			</template>
+					</template>
+				</d2l-dropdown>
+			</div>
 		</div>
 	</template>
 


### PR DESCRIPTION
Moved the template dom-if to the actual dropdown-menu so that the settings menu can be focused on safari