### PR TITLE
restore-focus-on-close

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -38,7 +38,8 @@
 			title-name="{{localize('allCourses')}}"
 			locale="[[locale]]"
 			close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}"
-			with-backdrop>
+			with-backdrop
+			restore-focus-on-close>
 
 			<div
 				id="overlayContent"


### PR DESCRIPTION
This ensures that when the overlay is closed, focus goes back to where it was before - in this case, back to the View All Courses link.

Probably has been like this forever, but it was noticed in testing of #349.