### PR TITLE
making course name wrapping consistent across all browsers

### DIFF
--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -125,13 +125,12 @@
 				text-transform: uppercase;
 			}
 			.course-text {
-				position: relative;
 				margin-top: 0.6rem;
 				float: left;
 				flex: 1;
-				white-space: pre-wrap;
-				word-break: break-all;
-				word-break: break-word;
+				overflow: hidden;
+				word-wrap: break-word; /* IE/Edge */
+				overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
 			}
 			.course-info {
 				display: flex;


### PR DESCRIPTION
This fixes a subtle issue (`DE25712`) with course name wrapping in Firefox, IE and Edge. This screenshot demonstrates it:

![screen shot 2017-05-03 at 11 08 54 am](https://cloud.githubusercontent.com/assets/5491151/25667249/ecf8686c-2ff0-11e7-9ea9-dc2d18c96820.png)

There are 2 important test cases here:
- "Coursewithalongnamethatwilltest the overflowing things": a long word without spaces that we'd ideally like it to break part-way through if necessary
- "Course3 - The Science of Nature": normal-length words that have lots of good break points

Notice how in the "Science of Nature" course, it's breaking after the "N" in "Nature", even though there was a perfectly good break point right before that.

After doing lots of research and trial & error, there are many ways to control wrapping/breaking in CSS, and each browser has varying levels of support for each of them:
- [`overflow-wrap`](https://developer.mozilla.org/en/docs/Web/CSS/overflow-wrap?v=example): this is the newest and preferred method -- it has "normal" and "break-word". Supported in Chrome, Firefox and Safari.
- [`word-wrap`](https://www.w3schools.com/cssref/css3_pr_word-wrap.asp): was replaced by `overflow-wrap` -- also has "normal" and "break-word". Supported in all browsers.
- [`word-break`](https://developer.mozilla.org/en-US/docs/Web/CSS/word-break): older, it has "normal", "break-word", "break-all". Firefox and IE/Edge only support "break-all". Chrome and Safari support both.

Basically, previously we had `word-break: break-all; word-break: break-word;`, which is no good because Firefox, IE and Edge don't understand "break-word" so will fall back to "break-all" -- which has the effect of breaking words partway through, hence the bug.

Instead, using a combination of `word-wrap: break-word` for IE/Edge and `overflow-wrap: break-word` for Chrome, Firefox and Safari does the trick!

Here's the result:

![screen shot 2017-05-03 at 11 22 03 am](https://cloud.githubusercontent.com/assets/5491151/25667839/c2262c44-2ff2-11e7-932b-d3a16e847866.png)
