### PR TITLE
switching to use the new homepage subentity, which has a relative path

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -458,7 +458,11 @@ the user has in that organization - student, teacher, TA, etc.
 					this._courseInfoUrl = (courseInfoUrl) ? courseInfoUrl.href : null;
 
 					this._setCourseImageSrc();
-					this._organizationHomepageUrl = (organization.getLinkByRel(/\/organization-homepage$/) || {}).href;
+
+					var homepageEntity = organization.getSubEntityByRel(/\/organization-homepage$/);
+					if (homepageEntity !== null) {
+						this._organizationHomepageUrl = homepageEntity.properties.path;
+					}
 					if (!this._organizationHomepageUrl) {
 						var tileContainer = this.$$('.tile-container');
 						this.toggleClass('d2l-no-access', true, tileContainer);

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -93,7 +93,7 @@
 						<div class="search-results-listbox-page" data-page-name="search-results-page">
 							<d2l-search-listbox>
 								<template id="courseSearchResultsTemplate" is="dom-repeat" items="[[_liveSearchResults]]">
-									<div class="d2l-search-widget-custom-item" selectable data-text$="[[item.name]]" data-href$="[[item.href]]" role="option">
+									<div class="d2l-search-widget-custom-item" selectable data-text$="[[item.name]]" role="option">
 										[[item.name]]
 									</div>
 								</template>
@@ -381,8 +381,7 @@
 									// Polymer's splice method causes empty results to show up for an
 									// unknown reason, so use a normal Array.prototype.splice...
 									self._liveSearchResults.splice(index, 0, {
-										name: organization.properties.name,
-										href: (organization.getLinkByRel(/\/organization-homepage$/) || {}).href
+										name: organization.properties.name
 									});
 									// ...then, if this is the last result to get spliced in, manually
 									// call notifySplices with the changes.

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -54,6 +54,12 @@ describe('<d2l-course-tile>', function() {
 					rel: ['alternate'],
 					href: ''
 				}]
+			}, {
+				class: ['relative-uri'],
+				rel: ['item', 'https://api.brightspace.com/rels/organization-homepage'],
+				properties: {
+					path: 'http://example.com/2/home'
+				}
 			}]
 		},
 		enrollmentEntity,
@@ -110,8 +116,8 @@ describe('<d2l-course-tile>', function() {
 
 		it('should have the correct href', function() {
 			var anchor = widget.$$('a');
-			var homepageLink = organizationEntity.getLinkByRel('https://api.brightspace.com/rels/organization-homepage');
-			expect(anchor.href).to.equal(homepageLink.href);
+			var homepageLink = organizationEntity.getSubEntityByRel('https://api.brightspace.com/rels/organization-homepage');
+			expect(anchor.href).to.equal(homepageLink.properties.path);
 		});
 
 		it('should update the course name', function() {


### PR DESCRIPTION
Corresponds with this PR in the monolith:
https://git.dev.d2l/projects/CORE/repos/lp/pull-requests/5967/overview

Main motivation here is to use a relative path instead of one that includes the full hostname, since the hostname (which comes from the WebServerName config) may not be the same as the host the user is accessing the site from. Some clients have multiple vanity domains.