### PR TITLE
Fix orgUnitId parsing to be a bit less sketch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,6 +51,7 @@
     "iron-overlay-behavior": "^1.10.1",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.2",
     "iron-pages": "^1.0.8",
-    "polymer": "^1.7.0"
+    "polymer": "^1.7.0",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^1.0.14"
   }
 }

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -650,7 +650,12 @@
 				var orgUnitIds = [];
 				enrollmentEntities.forEach(function(enrollment) {
 					var enrollmentId = this.getEntityIdentifier(enrollment);
-					orgUnitIds.push(this.getOrgUnitId(enrollmentId));
+
+					var orgUnitId = this.getOrgUnitId(enrollment);
+					if (orgUnitId) {
+						orgUnitIds.push(orgUnitId);
+					}
+
 					if (enrollment.hasClass('pinned')) {
 						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
 							newPinnedEnrollments.push(enrollment);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -470,21 +470,24 @@ the user has in that organization - student, teacher, TA, etc.
 					this._canChangeCourseImage = this._getCanChangeCourseImage(organization);
 					this._pinnedChanged();
 					this._courseSettingsLabel = this.localize('courseSettings', 'course', this._organization.properties.name);
-					var organizationLink = organization.getLinkByRel('self');
 					if (this.updateCountMap) {
-						var orgUnitId = this.getOrgUnitId(organizationLink.href);
-						var update = this.updateCountMap[orgUnitId];
-						if (update) {
-							this.setCourseUpdates(update);
+						var orgUnitId = this.getOrgUnitId(this.enrollment);
+						if (orgUnitId) {
+							var update = this.updateCountMap[orgUnitId];
+							if (update) {
+								this.setCourseUpdates(update);
+							}
 						}
 					}
 				}
 			},
 			_onUpdatesChange: function(updateChange) {
-				var orgUnitId = this.getOrgUnitId(this.enrollmentId);
-				var update = updateChange.base[orgUnitId];
-				if (update) {
-					this.setCourseUpdates(update);
+				var orgUnitId = this.getOrgUnitId(this.enrollment);
+				if (orgUnitId) {
+					var update = updateChange.base[orgUnitId];
+					if (update) {
+						this.setCourseUpdates(update);
+					}
 				}
 			},
 			_checkDateBounds: function(organization, response) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -323,7 +323,6 @@
 					enrollmentEntities.forEach(function(enrollment) {
 						var enrollmentId = this.getEntityIdentifier(enrollment);
 
-						var orgUnitId = this.getOrgUnitId(enrollmentId);
 						if (enrollment.hasClass('pinned')) {
 							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
 								newPinnedEnrollments.push(enrollment);
@@ -336,7 +335,10 @@
 							}
 						}
 
-						this._enrollmentIdMap[orgUnitId] = enrollmentId;
+						var orgUnitId = this.getOrgUnitId(enrollment);
+						if (orgUnitId) {
+							this._enrollmentIdMap[orgUnitId] = enrollmentId;
+						}
 					}, this);
 					this.getUpdates(Object.keys(this._enrollmentIdMap).join(','));
 					this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+
 
 <script src="https://s.brightspace.com/lib/siren-parser/6.0.0/siren-parser.js"></script>
 <script>
@@ -11,7 +13,7 @@
 	* General utility functions that can be used in many places.
 	* @polymerBehavior window.D2L.MyCourses.UtilityBehavior
 	*/
-	window.D2L.MyCourses.UtilityBehavior = {
+	var behavior = {
 		// Creates a URL with a query from an Action and an object of required parameters
 		createActionUrl: function(action, parameters) {
 			parameters = parameters || {};
@@ -38,14 +40,23 @@
 			var selfLink = entity.getLinkByRel('self');
 			return selfLink.href;
 		},
-		getOrgUnitId: function(enrollmentId) {
-			if (enrollmentId && typeof enrollmentId === 'string') {
-				return /organizations.*?\/([0-9]+)/
-							.exec(enrollmentId)[1];
+		getOrgUnitId: function(enrollment) {
+			if (!enrollment) {
+				return;
+			}
+
+			var organizationLink = enrollment.getLinkByRel(this.HypermediaRels.organization);
+			if (organizationLink && organizationLink.href) {
+				return /\/([0-9]+$)/.exec(organizationLink.href)[1];
 			}
 		},
 		parseEntity: function(entity) {
 			return window.D2L.Hypermedia.Siren.Parse(entity);
 		}
 	};
+
+	window.D2L.MyCourses.UtilityBehavior = [
+		window.D2L.Hypermedia.HMConstantsBehavior,
+		behavior
+	];
 </script>

--- a/test/d2l-utility-behavior/d2l-utility-behavior.js
+++ b/test/d2l-utility-behavior/d2l-utility-behavior.js
@@ -72,19 +72,35 @@ describe('d2l-utility-behavior', function() {
 
 	describe('getOrgunitId', function() {
 
-		it('should parse orgunitid from enrollment id', function() {
-			var enrollmentid = '/enrollments/users/169/organizations/1';
-			expect(component.getOrgUnitId(enrollmentid)).to.equal('1');
+		it('should parse orgunitid from enrollment', function() {
+			var enrollment = window.D2L.Hypermedia.Siren.Parse({
+				links: [{
+					rel: ['https://api.brightspace.com/rels/organization'],
+					href: '/enrollments/users/169/organizations/1'
+				}]
+			});
+			expect(component.getOrgUnitId(enrollment)).to.equal('1');
 		});
 
 		it('should parse orgunitid from non-canonical namespaced url', function() {
-			var enrollmentid = 'https://blah.whatever.d2l/d2l/api/hm/organizations/121535';
-			expect(component.getOrgUnitId(enrollmentid)).to.equal('121535');
+			var enrollment = window.D2L.Hypermedia.Siren.Parse({
+				links: [{
+					rel: ['https://api.brightspace.com/rels/organization'],
+					href: 'https://blah.whatever.d2l/d2l/api/hm/organizations/121535'
+				}]
+			});
+			expect(component.getOrgUnitId(enrollment)).to.equal('121535');
 		});
 
 		it('should parse orgunit from canonical namespaced urls', function() {
-			var enrollmentid = 'https://f41cc6fe-7210-423b-8436-7ad7b0444453.organizations.api.proddev.d2l/121535';
-			expect(component.getOrgUnitId(enrollmentid)).to.equal('121535');
+
+			var enrollment = window.D2L.Hypermedia.Siren.Parse({
+				links: [{
+					rel: ['https://api.brightspace.com/rels/organization'],
+					href: 'https://f41cc6fe-7210-423b-8436-7ad7b0444453.organizations.api.proddev.d2l/121535'
+				}]
+			});
+			expect(component.getOrgUnitId(enrollment)).to.equal('121535');
 		});
 
 		it('should return nothing if nothing is passed in', function() {


### PR DESCRIPTION
The enrolledUser stuff changed the format of enrollment self links, which broke updates things since we need the orgUnitId. We shouldn't be parsing any links, so really this is just calling out a problem more than breaking something. Short-term fix is to grab the organization link rather than the enrollment one (which I guess would have made more sense in the first place anyway); hopefully I'll get back to this with a better fix sooner rather than later.