### PR TITLE
Refactor d2l-course-management-behavior

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -12,6 +12,7 @@
 <link rel="import" href="../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
+<link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-filter-menu-content/d2l-filter-menu-content.html">
@@ -299,6 +300,7 @@
 			behaviors: [
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				window.D2L.MyCourses.LocalizeBehavior,
+				window.D2L.MyCourses.CourseManagementBehavior,
 				window.D2L.MyCourses.UtilityBehavior,
 				window.D2L.Hypermedia.OrganizationHMBehavior,
 				window.D2L.MyCourses.AlertBehavior,
@@ -618,23 +620,6 @@
 				var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');
 				if (content) {
 					content.close();
-				}
-			},
-			_setEnrollmentPinData: function(entity, isPinned) {
-				// HACK: Because the course tiles are being removed and re-created in the DOM, we have to effectively
-				// manually update them, rather than updating them with the received enrollment from the API call.
-				if (isPinned) {
-					entity.class.splice(entity.class.indexOf('unpinned'));
-					entity.class.push('pinned');
-					entity.actions[0].name = 'unpin-course';
-					entity.actions[0].fields[0].value = false;
-					entity._actionsByName['unpin-course'] = entity.actions[0];
-				} else {
-					entity.class.splice(entity.class.indexOf('pinned'));
-					entity.class.push('unpinned');
-					entity.actions[0].name = 'pin-course';
-					entity.actions[0].fields[0].value = true;
-					entity._actionsByName['pin-course'] = entity.actions[0];
 				}
 			},
 			_setFilteredPinnedEnrollments: function() {

--- a/d2l-course-management-behavior.html
+++ b/d2l-course-management-behavior.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="d2l-utility-behavior.html">
 
 <script>
 	'use strict';
@@ -8,15 +7,8 @@
 		window.D2L = window.D2L || {};
 		window.D2L.MyCourses = window.D2L.MyCourses || {};
 
-		/*
-		* Behavior that allows for course management
-		*
-		* "Management" in this case means having a pinned and unpinned list, and supporting switching an enrollment between the
-		* two.
-		*
-		* @polymerBehavior window.D2L.MyCourses.CourseManagementBehavior
-		*/
-		window.D2L.MyCourses.CourseManagementBehaviorImpl = {
+		/* @polymerBehavior window.D2L.MyCourses.CourseManagementBehavior */
+		window.D2L.MyCourses.CourseManagementBehavior = {
 			properties: {
 				// Set of pinned enrollment Entities
 				pinnedEnrollments: {
@@ -33,86 +25,6 @@
 						return [];
 					},
 					notify: true
-				},
-				// True when there are pinned enrollments (i.e. `pinnedEnrollments.length > 0`)
-				_hasPinnedEnrollments: {
-					type: Boolean,
-					value: false
-				},
-				// True when there are any enrollments (pinned or unpinned)
-				_hasEnrollments: {
-					type: Boolean,
-					value: false
-				}
-			},
-			_enrollmentIdMap: {},
-			listeners: {
-				'tile-remove-complete': '_onTileRemoveComplete'
-			},
-			observers: [
-				'_enrollmentsChanged(pinnedEnrollments.length, unpinnedEnrollments.length)'
-			],
-			_enrollmentsChanged: function() {
-				this.set('_hasPinnedEnrollments', this.pinnedEnrollments.length > 0);
-				this.set('_hasEnrollments', this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0);
-			},
-			_addEnrollmentToList: function(pinned, enrollmentEntity) {
-				var listName = (pinned ? 'pinned' : 'unpinned') + 'Enrollments';
-
-				this._setEnrollmentPinData(enrollmentEntity, pinned);
-				this.unshift(listName, enrollmentEntity);
-			},
-			_moveEnrollmentToPinnedList: function(enrollment) {
-				var enrollmentId, enrollmentEntity;
-
-				if (typeof enrollment === 'string') {
-					enrollmentId = enrollment;
-				} else {
-					enrollmentEntity = enrollment;
-					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
-				}
-
-				for (var index = 0; index < this.unpinnedEnrollments.length; index++) {
-					var pinnedEnrollmentId = this.getEntityIdentifier(this.unpinnedEnrollments[index]);
-					if (pinnedEnrollmentId === enrollmentId) {
-						enrollmentEntity = enrollmentEntity || this.unpinnedEnrollments[index];
-						this.splice('unpinnedEnrollments', index, 1);
-						break;
-					}
-				}
-
-				if (enrollmentEntity) {
-					this._addEnrollmentToList(true, enrollmentEntity);
-				}
-			},
-			_moveEnrollmentToUnpinnedList: function(enrollment) {
-				var enrollmentId, enrollmentEntity;
-
-				if (typeof enrollment === 'string') {
-					enrollmentId = enrollment;
-				} else {
-					enrollmentEntity = enrollment;
-					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
-				}
-
-				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
-					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
-					if (unpinnedEnrollmentId === enrollmentId) {
-						enrollmentEntity = enrollmentEntity || this.pinnedEnrollments[index];
-						this.splice('pinnedEnrollments', index, 1);
-						break;
-					}
-				}
-
-				if (enrollmentEntity) {
-					this._addEnrollmentToList(false, enrollmentEntity);
-				}
-			},
-			_onTileRemoveComplete: function(e) {
-				if (e.detail.pinned) {
-					this._moveEnrollmentToPinnedList(e.detail.enrollment);
-				} else {
-					this._moveEnrollmentToUnpinnedList(e.detail.enrollment);
 				}
 			},
 			_setEnrollmentPinData: function(entity, isPinned) {
@@ -131,47 +43,7 @@
 					entity.actions[0].fields[0].value = true;
 					entity._actionsByName['pin-course'] = entity.actions[0];
 				}
-			},
-			_fetchEnrollmentEntity: function(orgUnitId, pinned) {
-				if (!this._fetchEnrollmentAjaxPinned) {
-					this._fetchEnrollmentAjaxPinned = document.createElement('d2l-ajax');
-					this._fetchEnrollmentAjaxPinned.onResponse =
-						this._onFetchEnrollmentEntityResponse.bind(this, true);
-				}
-
-				if (!this._fetchEnrollmentAjaxUnpinned) {
-					this._fetchEnrollmentAjaxUnpinned = document.createElement('d2l-ajax');
-					this._fetchEnrollmentAjaxUnpinned.onResponse =
-						this._onFetchEnrollmentEntityResponse.bind(this, false);
-				}
-
-				var ajax = pinned
-					? this._fetchEnrollmentAjaxPinned
-					: this._fetchEnrollmentAjaxUnpinned;
-
-				ajax.url = this.fetchEnrollmentUrl + orgUnitId;
-				ajax.method = 'GET';
-				ajax.generateRequest();
-			},
-			_onFetchEnrollmentEntityResponse: function(pinned, response) {
-				if (response.detail.status === 200 || response.detail.status === 304) {
-					var enrollmentEntity = this.parseEntity(response.detail.xhr.response);
-
-					// Enforce specific pin state
-					this._setEnrollmentPinData(enrollmentEntity, pinned);
-
-					if (pinned) {
-						this._moveEnrollmentToPinnedList(enrollmentEntity);
-					} else {
-						this._moveEnrollmentToUnpinnedList(enrollmentEntity);
-					}
-				}
 			}
 		};
-
-		window.D2L.MyCourses.CourseManagementBehavior = [
-			window.D2L.MyCourses.CourseManagementBehaviorImpl,
-			window.D2L.MyCourses.UtilityBehavior
-		];
 	})();
 </script>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -168,6 +168,16 @@
 				_departmentsUrl: String,
 				// URL constructed to fetch a user's enrollments with the enrollments search Action
 				_enrollmentsSearchUrl: String,
+				// True when there are any enrollments (pinned or unpinned)
+				_hasEnrollments: {
+					type: Boolean,
+					value: false
+				},
+				// True when there are pinned enrollments (i.e. `pinnedEnrollments.length > 0`)
+				_hasPinnedEnrollments: {
+					type: Boolean,
+					value: false
+				},
 				// Object containing the last response from an enrollments search request
 				_lastEnrollmentsSearchResponse: Object,
 				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
@@ -206,6 +216,7 @@
 				'enrollment-unpinned': '_onEnrollmentPinAction'
 			},
 			observers: [
+				'_enrollmentsChanged(pinnedEnrollments.length, unpinnedEnrollments.length)',
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
@@ -238,6 +249,7 @@
 			*/
 
 			_allCoursesCreated: false,
+			_enrollmentIdMap: {},
 
 			/*
 			* Listeners
@@ -282,6 +294,20 @@
 						setTimeout(this._onStartedInactiveAlert.bind(this), 50);
 					} else {
 						this._fetchEnrollmentEntity(e.detail.orgUnitId, e.detail.isPinned);
+					}
+				}
+			},
+			_onFetchEnrollmentEntityResponse: function(pinned, response) {
+				if (response.detail.status === 200 || response.detail.status === 304) {
+					var enrollmentEntity = this.parseEntity(response.detail.xhr.response);
+
+					// Enforce specific pin state
+					this._setEnrollmentPinData(enrollmentEntity, pinned);
+
+					if (pinned) {
+						this._moveEnrollmentToPinnedList(enrollmentEntity);
+					} else {
+						this._moveEnrollmentToUnpinnedList(enrollmentEntity);
 					}
 				}
 			},
@@ -380,6 +406,10 @@
 			* Observers
 			*/
 
+			_enrollmentsChanged: function() {
+				this.set('_hasPinnedEnrollments', this.pinnedEnrollments.length > 0);
+				this.set('_hasEnrollments', this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0);
+			},
 			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
 				this._clearAlerts();
 
@@ -396,6 +426,12 @@
 			* Utility/helper functions
 			*/
 
+			_addEnrollmentToList: function(pinned, enrollmentEntity) {
+				var listName = (pinned ? 'pinned' : 'unpinned') + 'Enrollments';
+
+				this._setEnrollmentPinData(enrollmentEntity, pinned);
+				this.unshift(listName, enrollmentEntity);
+			},
 			_createAllCourses: function() {
 				if (!this._allCoursesCreated) {
 					var allCourses = document.createElement('d2l-all-courses');
@@ -403,9 +439,76 @@
 					this._allCoursesCreated = true;
 				}
 			},
+			_fetchEnrollmentEntity: function(orgUnitId, pinned) {
+				if (!this._fetchEnrollmentAjaxPinned) {
+					this._fetchEnrollmentAjaxPinned = document.createElement('d2l-ajax');
+					this._fetchEnrollmentAjaxPinned.onResponse =
+						this._onFetchEnrollmentEntityResponse.bind(this, true);
+				}
+
+				if (!this._fetchEnrollmentAjaxUnpinned) {
+					this._fetchEnrollmentAjaxUnpinned = document.createElement('d2l-ajax');
+					this._fetchEnrollmentAjaxUnpinned.onResponse =
+						this._onFetchEnrollmentEntityResponse.bind(this, false);
+				}
+
+				var ajax = pinned
+					? this._fetchEnrollmentAjaxPinned
+					: this._fetchEnrollmentAjaxUnpinned;
+
+				ajax.url = this.fetchEnrollmentUrl + orgUnitId;
+				ajax.method = 'GET';
+				ajax.generateRequest();
+			},
 			_keypressOpenAllCoursesView: function(e) {
 				if ( e.code === 'Space' || e.code === 'Enter' ) {
 					return this._openAllCoursesView(e);
+				}
+			},
+			_moveEnrollmentToPinnedList: function(enrollment) {
+				var enrollmentId, enrollmentEntity;
+
+				if (typeof enrollment === 'string') {
+					enrollmentId = enrollment;
+				} else {
+					enrollmentEntity = enrollment;
+					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
+				}
+
+				for (var index = 0; index < this.unpinnedEnrollments.length; index++) {
+					var pinnedEnrollmentId = this.getEntityIdentifier(this.unpinnedEnrollments[index]);
+					if (pinnedEnrollmentId === enrollmentId) {
+						enrollmentEntity = enrollmentEntity || this.unpinnedEnrollments[index];
+						this.splice('unpinnedEnrollments', index, 1);
+						break;
+					}
+				}
+
+				if (enrollmentEntity) {
+					this._addEnrollmentToList(true, enrollmentEntity);
+				}
+			},
+			_moveEnrollmentToUnpinnedList: function(enrollment) {
+				var enrollmentId, enrollmentEntity;
+
+				if (typeof enrollment === 'string') {
+					enrollmentId = enrollment;
+				} else {
+					enrollmentEntity = enrollment;
+					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
+				}
+
+				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
+					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
+					if (unpinnedEnrollmentId === enrollmentId) {
+						enrollmentEntity = enrollmentEntity || this.pinnedEnrollments[index];
+						this.splice('pinnedEnrollments', index, 1);
+						break;
+					}
+				}
+
+				if (enrollmentEntity) {
+					this._addEnrollmentToList(false, enrollmentEntity);
 				}
 			},
 			_openAllCoursesView: function(e) {


### PR DESCRIPTION
The vast majority of the functionality contained within this behavior was either only used in one of d2l-my-courses/d2l-all-courses, or it was overridden in one or both anyway. So, moved things up a level to make it clearer (aside from the few things that actually _are_ common to both).

Found this while doing #370, but twas unrelated so gets its own PR. Tested it and all seems to work - pinning/unpinning courses moves the tiles as expected. If this didn't work, that wouldn't work, so seems like adequate testing to me 😛 