### PR TITLE
Check for courseUpdatesConfig

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -323,7 +323,7 @@ the user has in that organization - student, teacher, TA, etc.
 				this._organizationRequest.generateRequest();
 			},
 			_generateNotificationsRequest: function() {
-				if (!this._notificationsUrl) {
+				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
 					return;
 				}
 


### PR DESCRIPTION
If this attribute wasn't set on the widget, things would blow up in the `onNotificationsResponse` handler. Instead, just don't do the notifications HM request if we don't have the config, since it means it's not turned on anyway.