### PR TITLE
always use department & semester links

### DIFF
--- a/d2l-filter-menu-content/d2l-filter-menu-content.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content.html
@@ -179,19 +179,14 @@
 				this.toggleClass('d2l-filter-menu-content-hidden', false, this.$.filterHeader);
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
-				// Set up search URLs and search Actions for filter dropdown
-				if (entity && entity.actions) {
+				// Set up search URLs for filter dropdown
+				if (entity) {
 					var myEnrollmentsEntity = this.parseEntity(entity);
 					if (myEnrollmentsEntity.hasLinkByRel('https://api.brightspace.com/rels/departments')) {
 						this.set('_departmentsUrl', myEnrollmentsEntity.getLinkByRel('https://api.brightspace.com/rels/departments').href);
-					} else if (myEnrollmentsEntity.hasAction('add-department-filter'))	{
-						this.set('_departmentsUrl', this.createActionUrl(myEnrollmentsEntity.getActionByName('add-department-filter')));
 					}
-
 					if (myEnrollmentsEntity.hasLinkByRel('https://api.brightspace.com/rels/semesters')) {
 						this.set('_semestersUrl', myEnrollmentsEntity.getLinkByRel('https://api.brightspace.com/rels/semesters').href);
-					} else if (myEnrollmentsEntity.hasAction('add-semester-filter')) {
-						this.set('_semestersUrl', this.createActionUrl(myEnrollmentsEntity.getActionByName('add-semester-filter')));
 					}
 				}
 			},

--- a/test/d2l-filter-menu-content/d2l-filter-menu-content.js
+++ b/test/d2l-filter-menu-content/d2l-filter-menu-content.js
@@ -8,13 +8,16 @@ describe('d2l-filter-menu-content', function() {
 
 	beforeEach(function() {
 		myEnrollmentsEntity = window.D2L.Hypermedia.Siren.Parse({
-			actions: [{
-				name: 'add-semester-filter',
-				href: '/enrollments/semesters'
-			}, {
-				name: 'add-department-filter',
-				href: '/enrollments/departments'
-			}]
+			links: [
+				{
+					rel: ['https://api.brightspace.com/rels/semesters'],
+					href: '/enrollments/semesters'
+				},
+				{
+					rel: ['https://api.brightspace.com/rels/departments'],
+					href: '/enrollments/departments'
+				}
+			]
 		});
 		component = fixture('d2l-filter-menu-content-fixture');
 	});


### PR DESCRIPTION
The "departments" and "semesters" links are now always present in the hypermedia response as the feature flag that controls them has been removed -- so no need for a special fallback.

I couldn't find any other code that could be removed/optimized based on this change, but let me know if you notice something.