### PR TITLE
DE27525 Fix unpinning enrollment in main screen

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -214,7 +214,8 @@
 				'clear-image-scroll-threshold': '_onClearImageScrollThreshold',
 				'd2l-simple-overlay-closed': '_onSimpleOverlayClosed',
 				'enrollment-pinned': '_onEnrollmentPinAction',
-				'enrollment-unpinned': '_onEnrollmentPinAction'
+				'enrollment-unpinned': '_onEnrollmentPinAction',
+				'tile-remove-complete': '_onTileRemoveComplete'
 			},
 			observers: [
 				'_enrollmentsChanged(pinnedEnrollments.length, unpinnedEnrollments.length)',
@@ -258,9 +259,13 @@
 			},
 			_onEnrollmentPinAction: function(e) {
 				var isPinned = e.type === 'enrollment-pinned';
-				var orgUnitId = /organizations\/([0-9]+)/
-					.exec(this.getEntityIdentifier(e.detail.enrollment))[1];
+				var match = /[0-9]+$/.exec(this.getEntityIdentifier(e.detail.organization));
 
+				if (!match) {
+					return;
+				}
+
+				var orgUnitId = match[0];
 				this.fire(
 					'd2l-course-pinned-change', {
 						orgUnitId: orgUnitId,
@@ -360,6 +365,13 @@
 					this.$$('d2l-all-courses').setCourseImage(e);
 				}
 				this.$$('d2l-course-tile-grid').setCourseImage(e);
+			},
+			_onTileRemoveComplete: function(e) {
+				if (e.detail.pinned) {
+					this._moveEnrollmentToPinnedList(e.detail.enrollment);
+				} else {
+					this._moveEnrollmentToUnpinnedList(e.detail.enrollment);
+				}
 			},
 
 			/*

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -376,12 +376,15 @@ describe('d2l-my-courses', function() {
 	});
 
 	describe('With enrollments', function() {
-		var pinnedEnrollmentEntity,
-			unpinnedEnrollmentEntity;
+		var organizationEntity;
 
 		beforeEach(function(done) {
-			pinnedEnrollmentEntity = window.D2L.Hypermedia.Siren.Parse(enrollmentsSearchResponse.entities[0]);
-			unpinnedEnrollmentEntity = window.D2L.Hypermedia.Siren.Parse(noPinnedEnrollmentsResponse.entities[0]);
+			organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+				links: [{
+					rel: ['self'],
+					href: '/organizations/1'
+				}]
+			});
 			server.respondWith(
 				'GET',
 				widget.enrollmentsUrl,
@@ -449,7 +452,7 @@ describe('d2l-my-courses', function() {
 				var enrollmentPinEvent = new CustomEvent(
 					'enrollment-pinned', {
 						detail: {
-							enrollment: pinnedEnrollmentEntity,
+							organization: organizationEntity,
 							isPinned: true
 						}
 					}
@@ -476,7 +479,7 @@ describe('d2l-my-courses', function() {
 				var enrollmentUnpinEvent = new CustomEvent(
 					'enrollment-unpinned', {
 						detail: {
-							enrollment: unpinnedEnrollmentEntity,
+							organization: organizationEntity,
 							isPinned: true
 						}
 					}


### PR DESCRIPTION
This issue was actually two problems - first, the console error was happening as we changed to the enrolledUser HM API a while back, but that broke the extraction of the org unit ID here. Switched to use the organization instead.

Second, the animation was failing to complete. This I cannot explain, as there was never a handler for this event here as far as I can recall, but adding the handler does fix it. Not sure how it was working before...