### PR TITLE
US90475 - Use d2l-fetch in favour of d2l-ajax

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -40,7 +40,7 @@
     "d2l-menu": "^0.3.5",
     "d2l-offscreen": "^2.2.4",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^1.1.3",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.0.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.1",
     "d2l-typography": "^5.4.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",
@@ -56,5 +56,8 @@
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0"
+  },
+  "resolutions": {
+    "d2l-search-widget": "^2.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,6 @@
   ],
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
-    "d2l-ajax": "^3.4.1",
     "d2l-alert": "git://github.com/Brightspace/alert.git#^1.0.2",
     "d2l-colors": "^2.3.0",
     "d2l-course-image": "git://github.com/Brightspace/course-image.git#^1.0.3",

--- a/bower.json
+++ b/bower.json
@@ -45,6 +45,7 @@
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.1",
     "d2l-typography": "^5.4.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",
+    "fetch": "whatwg-fetch#^2.0.3",
     "iron-a11y-announcer": "^1.0.5",
     "iron-a11y-keys": "^1.0.6",
     "iron-input": "^1.0.10",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -25,14 +25,6 @@
 	<template>
 		<style include="d2l-all-courses-styles"></style>
 
-		<d2l-ajax
-			id="enrollmentsSearchRequest"
-			url="[[_enrollmentsSearchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onEnrollmentsSearchResponse"
-			last-response="{{lastEnrollmentsSearchResponse}}">
-		</d2l-ajax>
-
 		<d2l-simple-overlay
 			id="all-courses"
 			title-name="{{localize('allCourses')}}"
@@ -297,11 +289,11 @@
 			},
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
+				window.D2L.Hypermedia.OrganizationHMBehavior,
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				window.D2L.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.CourseManagementBehavior,
 				window.D2L.MyCourses.UtilityBehavior,
-				window.D2L.Hypermedia.OrganizationHMBehavior,
 				window.D2L.MyCourses.AlertBehavior
 			],
 			listeners: {
@@ -424,14 +416,12 @@
 						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
 						this.toggleClass('d2l-all-courses-hidden', false, this.$.lazyLoadSpinner);
 						this.$.lazyLoadSpinner.scrollIntoView();
-						this.$.enrollmentsSearchRequest.generateRequest();
+
+						return this.fetchSirenEntity(this._enrollmentsSearchUrl)
+							.then(function(enrollmentsEntity) {
+								this._updateFilteredEnrollments(enrollmentsEntity, true);
+							}.bind(this));
 					}
-				}
-			},
-			_onEnrollmentsSearchResponse: function(response) {
-				if (response.detail.status === 200) {
-					var enrollments = this.parseEntity(response.detail.xhr.response);
-					this._updateFilteredEnrollments(enrollments, true);
 				}
 			},
 			_onFilterChanged: function(e) {

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -107,6 +107,8 @@ the user has in that organization - student, teacher, TA, etc.
 	<script>
 		'use strict';
 
+		/* global Promise */
+
 		Polymer({
 			is: 'd2l-course-tile',
 
@@ -234,7 +236,7 @@ the user has in that organization - student, teacher, TA, etc.
 					body[field.name] = field.value;
 				});
 
-				window.d2lfetch
+				var promise = window.d2lfetch
 					.fetch(new Request(pinAction.href, {
 						method: pinAction.method,
 						body: new URLSearchParams(body),
@@ -250,8 +252,7 @@ the user has in that organization - student, teacher, TA, etc.
 						this.enrollment = enrollment;
 						this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
 					}.bind(this))
-					.catch(function(e) {
-						console.error(e, body);
+					.catch(function() {
 						// Just revert back to whatever pin state we already had stored
 						this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
 					}.bind(this));
@@ -279,6 +280,8 @@ the user has in that organization - student, teacher, TA, etc.
 				}, { bubbles: true });
 
 				this._pendingPinAction = this.pinned;
+
+				return promise;
 			},
 			// Sets classes for this tile having the touch menu on it when it is opened/closed
 			setTouchMenuOpen: function(isOpen) {
@@ -329,16 +332,14 @@ the user has in that organization - student, teacher, TA, etc.
 							'pragma': 'no-cache'
 						}
 					}))
-					.then(this.responseToSirenEntity.bind(this))
-					.then(this._onOrganizationResponse.bind(this));
+					.then(this.responseToSirenEntity.bind(this));
 			},
 			_fetchNotifications: function() {
 				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
 					return;
 				}
 
-				return this.fetchSirenEntity(this._notificationsUrl)
-					.then(this._onNotificationsResponse.bind(this));
+				return this.fetchSirenEntity(this._notificationsUrl);
 			},
 			_enrollmentChanged: function() {
 				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
@@ -350,14 +351,18 @@ the user has in that organization - student, teacher, TA, etc.
 
 					if (!this.delayLoad) {
 						return this._fetchOrganization()
-							.then(this._fetchNotifications.bind(this));
+							.then(this._onOrganizationResponse.bind(this))
+							.then(this._fetchNotifications.bind(this))
+							.then(this._onNotificationsResponse.bind(this));
 					}
 				}
 			},
 			_delayLoadChanged: function(delayLoad) {
 				if (this.isAttached && !delayLoad && !this._organization) {
 					return this._fetchOrganization()
-						.then(this._fetchNotifications.bind(this));
+						.then(this._onOrganizationResponse.bind(this))
+						.then(this._fetchNotifications.bind(this))
+						.then(this._onNotificationsResponse.bind(this));
 				}
 			},
 			_displaySetImageResult: function(success) {
@@ -463,6 +468,8 @@ the user has in that organization - student, teacher, TA, etc.
 
 				var notificationsLink = organization && organization.getLinkByRel(this.HypermediaRels.organizationNotifications);
 				this._notificationsUrl = notificationsLink ? notificationsLink.href : null;
+
+				return Promise.resolve();
 			},
 			_onNotificationsResponse: function(notifications) {
 				var total = 0;

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-course-image/d2l-course-image.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
@@ -235,18 +234,27 @@ the user has in that organization - student, teacher, TA, etc.
 					body[field.name] = field.value;
 				});
 
-				this._enrollmentPinRequest = this._enrollmentPinRequest || document.createElement('d2l-ajax');
-				this._enrollmentPinRequest.url = pinAction.href;
-				this._enrollmentPinRequest.method = pinAction.method;
-				this._enrollmentPinRequest.body = body;
-				this._enrollmentPinRequest.headers = {
-					'accept':'application/vnd.siren+json',
-					'content-type':'application/x-www-form-urlencoded'
-				};
-				this.listen(this._enrollmentPinRequest, 'iron-ajax-response', '_onEnrollmentPinResponse');
-				this.listen(this._enrollmentPinRequest, 'iron-ajax-error', '_onEnrollmentPinError');
-
-				this._enrollmentPinRequest.generateRequest();
+				window.d2lfetch
+					.fetch(new Request(pinAction.href, {
+						method: pinAction.method,
+						body: new URLSearchParams(body),
+						headers: {
+							'accept':'application/vnd.siren+json',
+							'content-type':'application/x-www-form-urlencoded'
+						}
+					}))
+					.then(this.responseToSirenEntity.bind(this))
+					.then(function(enrollment) {
+						// The pin action returns the updated enrollment, so update
+						// this.enrollment with the modified one
+						this.enrollment = enrollment;
+						this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
+					}.bind(this))
+					.catch(function(e) {
+						console.error(e, body);
+						// Just revert back to whatever pin state we already had stored
+						this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
+					}.bind(this));
 
 				var eventName = this.pinned ? 'enrollment-pinned' : 'enrollment-unpinned';
 				this.fire(eventName, {
@@ -302,42 +310,35 @@ the user has in that organization - student, teacher, TA, etc.
 						break;
 				}
 			},
-			_enrollmentPinRequest: null,
-			_organizationRequest: null,
 			_organizationUrl: null,
-			_notificationsRequest: null,
 			_notificationsUrl: null,
 			_pendingPinAction: false,
 			_pinAnimationInProgress: false,
 			_telemetryRequest: null,
-			_generateOrganizationRequest: function() {
+			_fetchOrganization: function() {
 				if (!this._organizationUrl) {
 					return;
 				}
 
-				this._organizationRequest = this._organizationRequest || document.createElement('d2l-ajax');
-				this._organizationRequest.url = this._organizationUrl;
-				this._organizationRequest.headers = {
-					'accept': 'application/vnd.siren+json',
-					// Needs no-cache so that images refresh if the users here using the back button
-					'cache-control': 'no-cache',
-					'pragma': 'no-cache'
-				};
-				this.listen(this._organizationRequest, 'iron-ajax-response', '_onOrganizationResponse');
-				this._organizationRequest.generateRequest();
+				return window.d2lfetch
+					.fetch(new Request(this._organizationUrl, {
+						headers: {
+							'accept': 'application/vnd.siren+json',
+							// Needs no-cache so that images refresh if the users here using the back button
+							'cache-control': 'no-cache',
+							'pragma': 'no-cache'
+						}
+					}))
+					.then(this.responseToSirenEntity.bind(this))
+					.then(this._onOrganizationResponse.bind(this));
 			},
-			_generateNotificationsRequest: function() {
+			_fetchNotifications: function() {
 				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
 					return;
 				}
 
-				this._notificationsRequest = this._notificationsRequest || document.createElement('d2l-ajax');
-				this._notificationsRequest.url = this._notificationsUrl;
-				this._notificationsRequest.headers = {
-					'accept': 'application/vnd.siren+json'
-				};
-				this.listen(this._notificationsRequest, 'iron-ajax-response', '_onNotificationsResponse');
-				this._notificationsRequest.generateRequest();
+				return this.fetchSirenEntity(this._notificationsUrl)
+					.then(this._onNotificationsResponse.bind(this));
 			},
 			_enrollmentChanged: function() {
 				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
@@ -348,13 +349,15 @@ the user has in that organization - student, teacher, TA, etc.
 					this._organizationUrl = organizationLink.href + '?embedDepth=1';
 
 					if (!this.delayLoad) {
-						this._generateOrganizationRequest();
+						return this._fetchOrganization()
+							.then(this._fetchNotifications.bind(this));
 					}
 				}
 			},
 			_delayLoadChanged: function(delayLoad) {
 				if (this.isAttached && !delayLoad && !this._organization) {
-					this._generateOrganizationRequest();
+					return this._fetchOrganization()
+						.then(this._fetchNotifications.bind(this));
 				}
 			},
 			_displaySetImageResult: function(success) {
@@ -385,27 +388,26 @@ the user has in that organization - student, teacher, TA, etc.
 				}.bind(this), 1000);
 			},
 			_launchCourseTileImageSelector: function(e) {
-				this._telemetryRequest = this._telemetryRequest || document.createElement('d2l-ajax');
-				this._telemetryRequest.url = this.telemetryEndpoint;
-				this._telemetryRequest.method = 'POST';
-				this._telemetryRequest.headers = {
-					'content-type': 'application/json'
-				};
-				this._telemetryRequest.body = JSON.stringify({
-					name: 'LaunchChangeImage',
-					ts: Math.round(Date.now() / 1000),
-					userId: this.userId,
-					tenantId: this.tenantId
-				});
-
-				this._telemetryRequest.generateRequest();
-
 				e.preventDefault();
 				e.stopPropagation();
 
 				this.fire('open-change-image-view', {
 					organization: this._organization
 				});
+
+				return window.d2lfetch
+					.fetch(new Request(this.telemetryEndpoint, {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json'
+						},
+						body: JSON.stringify({
+							name: 'LaunchChangeImage',
+							ts: Math.round(Date.now() / 1000),
+							userId: this.userId,
+							tenantId: this.tenantId
+						})
+					}));
 			},
 			_hoverCourseTile: function() {
 				this._showHoverMenu = true;
@@ -438,77 +440,56 @@ the user has in that organization - student, teacher, TA, etc.
 					this.toggleClass('animate-insertion', true, this);
 				}
 			},
-			_onEnrollmentPinError: function() {
-				// Just revert back to whatever pin state we already had stored
-				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
-			},
-			_onEnrollmentPinResponse: function(response) {
-				if (response.detail.status === 200) {
-					// The pin action returns the updated enrollment, so update
-					// this.enrollment with the modified one
-					this.enrollment = this.parseEntity(response.detail.xhr.response);
-					this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
+			_onOrganizationResponse: function(organization) {
+				this._organization = organization;
+				this._checkDateBounds(organization);
+
+				var courseInfoUrl = organization && organization.getLinkByRel(this.HypermediaRels.courseOfferingInfoPage);
+				this._courseInfoUrl = courseInfoUrl ? courseInfoUrl.href : null;
+
+				this._setCourseImageSrc();
+
+				var homepageEntity = organization.getSubEntityByRel(this.HypermediaRels.organizationHomepage);
+				if (homepageEntity !== null) {
+					this._organizationHomepageUrl = homepageEntity.properties.path;
 				}
-			},
-			_onOrganizationResponse: function(response) {
-				if (response.detail.status === 200) {
-					var organization = this.parseEntity(response.detail.xhr.response);
-
-					this._organization = organization;
-					this._checkDateBounds(organization, response);
-
-					var courseInfoUrl = organization && organization.getLinkByRel(this.HypermediaRels.courseOfferingInfoPage);
-					this._courseInfoUrl = courseInfoUrl ? courseInfoUrl.href : null;
-
-					this._setCourseImageSrc();
-
-					var homepageEntity = organization.getSubEntityByRel(this.HypermediaRels.organizationHomepage);
-					if (homepageEntity !== null) {
-						this._organizationHomepageUrl = homepageEntity.properties.path;
-					}
-					if (!this._organizationHomepageUrl) {
-						var tileContainer = this.$$('.tile-container');
-						this.toggleClass('d2l-no-access', true, tileContainer);
-					}
-					this._canChangeCourseImage = this._getCanChangeCourseImage(organization);
-					this._pinnedChanged();
-					this._courseSettingsLabel = this.localize('courseSettings', 'course', this._organization.properties.name);
-
-					var notificationsLink = organization && organization.getLinkByRel(this.HypermediaRels.organizationNotifications);
-					this._notificationsUrl = notificationsLink ? notificationsLink.href : null;
-					this._generateNotificationsRequest();
+				if (!this._organizationHomepageUrl) {
+					var tileContainer = this.$$('.tile-container');
+					this.toggleClass('d2l-no-access', true, tileContainer);
 				}
-			},
-			_onNotificationsResponse: function(response) {
-				if (response.detail.status === 200) {
-					var notifications = this.parseEntity(response.detail.xhr.response);
+				this._canChangeCourseImage = this._getCanChangeCourseImage(organization);
+				this._pinnedChanged();
+				this._courseSettingsLabel = this.localize('courseSettings', 'course', this._organization.properties.name);
 
-					var total = 0;
-					if (this.courseUpdatesConfig.showUnattemptedQuizzes) {
-						total += notifications.properties.UnattemptedQuizzes;
-					}
-					if (this.courseUpdatesConfig.showDropboxUnreadFeedback) {
-						total += notifications.properties.UnreadAssignmentFeedback;
-					}
-					if (this.courseUpdatesConfig.showUngradedQuizAttempts) {
-						total += notifications.properties.UngradedQuizzes;
-					}
-					if (this.courseUpdatesConfig.showUnreadDiscussionMessages) {
-						total += notifications.properties.UnreadDiscussions + notifications.properties.UnapprovedDiscussions;
-					}
-					if (this.courseUpdatesConfig.showUnreadDropboxSubmissions) {
-						total += notifications.properties.UnreadAssignmentSubmissions;
-					}
-					this._setCourseUpdates(total);
+				var notificationsLink = organization && organization.getLinkByRel(this.HypermediaRels.organizationNotifications);
+				this._notificationsUrl = notificationsLink ? notificationsLink.href : null;
+			},
+			_onNotificationsResponse: function(notifications) {
+				var total = 0;
+				if (this.courseUpdatesConfig.showUnattemptedQuizzes) {
+					total += notifications.properties.UnattemptedQuizzes;
 				}
+				if (this.courseUpdatesConfig.showDropboxUnreadFeedback) {
+					total += notifications.properties.UnreadAssignmentFeedback;
+				}
+				if (this.courseUpdatesConfig.showUngradedQuizAttempts) {
+					total += notifications.properties.UngradedQuizzes;
+				}
+				if (this.courseUpdatesConfig.showUnreadDiscussionMessages) {
+					total += notifications.properties.UnreadDiscussions + notifications.properties.UnapprovedDiscussions;
+				}
+				if (this.courseUpdatesConfig.showUnreadDropboxSubmissions) {
+					total += notifications.properties.UnreadAssignmentSubmissions;
+				}
+				this._setCourseUpdates(total);
 			},
 			_setCourseUpdates: function(updates) {
 				this._courseUpdates = updates > 99 ? '99+' : Math.max(updates, 0);
 				this.toggleClass('d2l-updates-hidden', updates <= 0, this.$.courseUpdates);
 				this.$$('#courseUpdates').setAttribute( 'aria-hidden', updates === 0 ? 'true' : 'false' );
 			},
-			_checkDateBounds: function(organization, response) {
-				var serverDate = Date.parse(response.detail.xhr.getResponseHeader('Date'));
+			_checkDateBounds: function(organization) {
+				var serverDate = Date.now();
 				var endDate = Date.parse(organization.properties.endDate);
 				var startDate = Date.parse(organization.properties.startDate);
 				var inactive = !organization.properties.isActive;

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-colors/d2l-colors.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
@@ -14,7 +13,8 @@
 	<template>
 		<style>
 			:host {
-				display: block;
+				display: flex;
+				flex-direction: column;
 			}
 			:host([hidden]) {
 				display: none !important;
@@ -27,7 +27,6 @@
 			.dropdown-content-tabs {
 				display: flex;
 				align-items: center;
-				justify-content: space-between;
 			}
 			.dropdown-content-tab {
 				flex: 1;
@@ -58,9 +57,6 @@
 				@apply --d2l-body-compact-text;
 				margin: 10px;
 			}
-			d2l-loading-spinner {
-				align-self: center;
-			}
 			.clear-button {
 				@apply --d2l-body-small-text;
 				color: var(--d2l-color-celestine);
@@ -73,7 +69,6 @@
 			.dropdown-content-header {
 				box-sizing: border-box;
 				display: flex;
-				align-items: center;
 				justify-content: space-between;
 				border-bottom: 1px solid var(--d2l-color-titanius);
 				width: 100%;
@@ -83,18 +78,6 @@
 				background: linear-gradient(to top, white, var(--d2l-color-regolith));
 			}
 		</style>
-
-		<d2l-ajax
-			id="departmentsRequest"
-			url="[[_departmentsUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'>
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="semestersRequest"
-			url="[[_semestersUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'>
-		</d2l-ajax>
 
 		<d2l-loading-spinner
 			hidden=[[_showContent]]
@@ -278,27 +261,29 @@
 			},
 			load: function() {
 				if (this._departments.length > 0 || this._semesters.length > 0) {
+					// We've already loaded, don't load again
 					this.$.departmentSearchWidget.search();
 					this.$.semesterSearchWidget.search();
 					return;
 				}
 
 				var self = this;
-				Promise
-					.all([
-						this._departmentsUrl ? this.$.departmentsRequest.generateRequest() : Promise.resolve({}),
-						this._semestersUrl ? this.$.semestersRequest.generateRequest() : Promise.resolve({})
-					])
-					.then(function(values) {
-						var departmentsResponse = self.parseEntity(values[0].response);
-						var semestersResponse = self.parseEntity(values[1].response);
-
-						self.set('_departments', departmentsResponse.entities || []);
-						self.set('_semesters', semestersResponse.entities || []);
-
+				var fetchDepartments = this.fetchSirenEntity(this._departmentsUrl)
+					.then(function(departmentsEntity) {
+						self.set('_departments', departmentsEntity.entities || []);
 						self.$.departmentSearchWidget.search();
+					});
+				var fetchSemesters = this.fetchSirenEntity(this._semestersUrl)
+					.then(function(semestersEntity) {
+						self.set('_semesters', semestersEntity.entities || []);
 						self.$.semesterSearchWidget.search();
-					})
+					});
+
+				return Promise
+					.all([
+						fetchDepartments,
+						fetchSemesters
+					])
 					.then(function() {
 						self._showContent = true;
 					})
@@ -354,17 +339,25 @@
 					var myEnrollmentsEntity = this.parseEntity(entity);
 
 					this._searchSemestersAction = undefined;
+					this._semestersUrl = undefined;
 					if (myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.searchMySemesters)) {
 						this._searchSemestersAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMySemesters);
 					} else if (myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.addSemesterFilter)) {
 						this._searchSemestersAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.addSemesterFilter);
 					}
+					if (myEnrollmentsEntity.hasLinkByRel(this.HypermediaRels.semesters)) {
+						this._semestersUrl = myEnrollmentsEntity.getLinkByRel(this.HypermediaRels.semesters).href;
+					}
 
 					this._searchDepartmentsAction = undefined;
+					this._departmentsUrl = undefined;
 					if (myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyDepartments)) {
 						this._searchDepartmentsAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyDepartments);
 					} else if (myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.addDepartmentFilter)) {
 						this._searchDepartmentsAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.addDepartmentFilter);
+					}
+					if (myEnrollmentsEntity.hasLinkByRel(this.HypermediaRels.departments)) {
+						this._departmentsUrl = myEnrollmentsEntity.getLinkByRel(this.HypermediaRels.departments).href;
 					}
 				}
 			},

--- a/d2l-filter-menu-content/d2l-list-item-filter.html
+++ b/d2l-filter-menu-content/d2l-list-item-filter.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item-selectable-behavior.html">
@@ -25,12 +24,6 @@
 				margin-right: 0.5rem;
 			}
 		</style>
-		<d2l-ajax
-			auto
-			url="[[_organizationUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onOrganizationResponse">
-		</d2l-ajax>
 		<d2l-icon icon="d2l-tier2:check-box-unchecked" aria-hidden="true"></d2l-icon>
 		<span>[[text]]</span>
 	</template>
@@ -48,7 +41,10 @@
 					observer: '_onSelectedChanged',
 					reflectToAttribute: true
 				},
-				_organizationUrl: String
+				_organizationUrl: {
+					type: String,
+					observer: '_onOrganizationUrlChanged'
+				}
 			},
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
@@ -71,13 +67,13 @@
 					this.set('_organizationUrl', entity.getLinkByRel(this.HypermediaRels.organization).href);
 				}
 			},
-			_onOrganizationResponse: function(response) {
-				if (response.detail.status === 200 ) {
-					var entity = this.parseEntity(response.detail.xhr.response);
-
-					this.set('text', entity.properties.name);
-					this.set('value', entity.getLinkByRel('self').href);
-				}
+			_onOrganizationUrlChanged: function(organizationUrl) {
+				return this.fetchSirenEntity(organizationUrl)
+					.then(this._onOrganizationResponse.bind(this));
+			},
+			_onOrganizationResponse: function(entity) {
+				this.set('text', entity.properties.name);
+				this.set('value', entity.getLinkByRel('self').href);
 			},
 			_onSelect: function(e) {
 				this.set('selected', !this.selected);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -353,23 +353,16 @@
 				}
 			},
 			_fetchRoot: function() {
-				return window.d2lfetch
-					.fetch(new Request(this.enrollmentsUrl, {
-						headers: { Accept: 'application/vnd.siren+json' }
-					}))
-					.then(this._getJson)
+				return this.fetchSirenEntity(this.enrollmentsUrl)
 					.then(this._fetchEnrollments.bind(this))
 					.catch(this._showContent.bind(this));
 			},
-			_fetchEnrollments: function(response) {
-				var enrollmentsRoot = this.parseEntity(response);
-
-				if (!enrollmentsRoot.hasAction('search-my-enrollments')) {
+			_fetchEnrollments: function(enrollmentsRootEntity) {
+				if (!enrollmentsRootEntity.hasAction('search-my-enrollments')) {
 					return Promise.resolve();
 				}
 
-				var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
-				this.fetchEnrollmentUrl = searchAction.href + '/organizations/';
+				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
 
 				var query = {
 					pageSize: 25,
@@ -379,15 +372,13 @@
 				};
 				this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 
-				return window.d2lfetch
-					.fetch(new Request(this._enrollmentsSearchUrl))
-					.then(this._getJson)
+				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
 					.then(this._populateEnrollments.bind(this))
 					.catch(this._showContent.bind(this));
 			},
-			_populateEnrollments: function(response) {
-				var enrollments = this.parseEntity(response);
-				var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
+			_populateEnrollments: function(enrollmentsEntity) {
+				this._lastEnrollmentsSearchResponse = enrollmentsEntity;
+				var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 				var newPinnedEnrollments = [];
 				var newUnpinnedEnrollments = [];
 
@@ -418,12 +409,6 @@
 				this.fire('recalculate-columns');
 
 				this._showContent();
-			},
-			_getJson: function(response) {
-				if (response.ok) {
-					return response.json();
-				}
-				return Promise.reject(response.status + ' ' + response.statusText);
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				var enrollmentId, enrollmentEntity;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,6 +1,7 @@
+<script src="../fetch/fetch.js"></script>
+<script src="polyfill/Array.prototype.includes.js"></script>
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-alert/d2l-alert.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-link/d2l-link.html">
@@ -47,22 +48,6 @@
 				clear: both;
 			}
 		</style>
-
-		<d2l-ajax
-			id="enrollmentsRootRequest"
-			url="[[enrollmentsUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onEnrollmentsRootResponse">
-
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="enrollmentsSearchRequest"
-			url="[[_enrollmentsSearchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onEnrollmentsSearchResponse"
-			last-response="{{_lastEnrollmentsSearchResponse}}">
-		</d2l-ajax>
 
 		<div class="spinner-container">
 			<d2l-loading-spinner
@@ -129,8 +114,14 @@
 
 	</template>
 
+	<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
+	<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth.js"></script>
+	<script src="https://s.brightspace.com/lib/d2lfetch-dedupe/0.10.0/d2lfetch-dedupe.js"></script>
+	<script src="https://s.brightspace.com/lib/d2lfetch-simple-cache/0.3.0/d2lfetch-simple-cache.js"></script>
 	<script>
 		'use strict';
+
+		/* global Promise */
 
 		Polymer({
 			is: 'd2l-my-courses',
@@ -222,12 +213,16 @@
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
+				window.d2lfetch.use({name: 'auth', fn: window.d2lfetch.auth});
+				window.d2lfetch.use({name: 'dedupe', fn: window.d2lfetch.dedupe});
+				window.d2lfetch.use({name: 'simpleCache', fn: window.d2lfetch.simpleCache});
+
 				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
 				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseTiles);
 				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseList);
 			},
 			attached: function() {
-				this._rootEnrollmentRequest();
+				this._fetchRoot();
 
 				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
@@ -285,65 +280,6 @@
 				this._removeAlert('setCourseImageFailure');
 				// update the startedInactive alert in case the user changed the pinned states in the overlay
 				this._onStartedInactiveAlert();
-			},
-			_onEnrollmentsRootResponse: function(response) {
-				if (response.detail.status === 200) {
-					var enrollmentsRoot = this.parseEntity(response.detail.xhr.response);
-
-					if (!enrollmentsRoot.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
-						return;
-					}
-
-					var searchAction = enrollmentsRoot.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
-					this.fetchEnrollmentUrl = searchAction.href + '/organizations/';
-
-					var query = {
-						pageSize: 25,
-						embedDepth: 1,
-						sort: '-PinDate,OrgUnitName,OrgUnitId',
-						autoPinCourses: true
-					};
-					this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
-					this.$.enrollmentsSearchRequest.generateRequest();
-				} else {
-					this._showContent();
-				}
-			},
-			_onEnrollmentsSearchResponse: function(response) {
-				if (response.detail.status === 200) {
-					var enrollments = this.parseEntity(response.detail.xhr.response);
-					var enrollmentEntities = enrollments.getSubEntitiesByClass(this.HypermediaClasses.enrollments.enrollment);
-					var newPinnedEnrollments = [];
-					var newUnpinnedEnrollments = [];
-
-					enrollmentEntities.forEach(function(enrollment) {
-						var enrollmentId = this.getEntityIdentifier(enrollment);
-
-						if (enrollment.hasClass(this.HypermediaClasses.enrollments.pinned)) {
-							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newPinnedEnrollments.push(enrollment);
-								this._pinnedCoursesMap[enrollmentId] = true;
-							}
-						} else {
-							if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newUnpinnedEnrollments.push(enrollment);
-								this._unpinnedCoursesMap[enrollmentId] = true;
-							}
-						}
-					}, this);
-
-					this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);
-					this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
-
-					var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
-					this._tileSizes = (colNum === 2) ?
-						{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
-						{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
-
-					this.fire('recalculate-columns');
-				}
-
-				this._showContent();
 			},
 			_onOpenChangeImageView: function(e) {
 				if (e.detail.organization) {
@@ -415,6 +351,79 @@
 				if ( e.code === 'Space' || e.code === 'Enter' ) {
 					return this._openAllCoursesView(e);
 				}
+			},
+			_fetchRoot: function() {
+				return window.d2lfetch
+					.fetch(new Request(this.enrollmentsUrl, {
+						headers: { Accept: 'application/vnd.siren+json' }
+					}))
+					.then(this._getJson)
+					.then(this._fetchEnrollments.bind(this))
+					.catch(this._showContent.bind(this));
+			},
+			_fetchEnrollments: function(response) {
+				var enrollmentsRoot = this.parseEntity(response);
+
+				if (!enrollmentsRoot.hasAction('search-my-enrollments')) {
+					return Promise.resolve();
+				}
+
+				var searchAction = enrollmentsRoot.getActionByName('search-my-enrollments');
+				this.fetchEnrollmentUrl = searchAction.href + '/organizations/';
+
+				var query = {
+					pageSize: 25,
+					embedDepth: 1,
+					sort: '-PinDate,OrgUnitName,OrgUnitId',
+					autoPinCourses: true
+				};
+				this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
+
+				return window.d2lfetch
+					.fetch(new Request(this._enrollmentsSearchUrl))
+					.then(this._getJson)
+					.then(this._populateEnrollments.bind(this))
+					.catch(this._showContent.bind(this));
+			},
+			_populateEnrollments: function(response) {
+				var enrollments = this.parseEntity(response);
+				var enrollmentEntities = enrollments.getSubEntitiesByClass('enrollment');
+				var newPinnedEnrollments = [];
+				var newUnpinnedEnrollments = [];
+
+				enrollmentEntities.forEach(function(enrollment) {
+					var enrollmentId = this.getEntityIdentifier(enrollment);
+
+					if (enrollment.hasClass('pinned')) {
+						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newPinnedEnrollments.push(enrollment);
+							this._pinnedCoursesMap[enrollmentId] = true;
+						}
+					} else {
+						if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
+							newUnpinnedEnrollments.push(enrollment);
+							this._unpinnedCoursesMap[enrollmentId] = true;
+						}
+					}
+				}, this);
+
+				this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);
+				this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
+
+				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
+				this._tileSizes = (colNum === 2) ?
+					{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
+					{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
+
+				this.fire('recalculate-columns');
+
+				this._showContent();
+			},
+			_getJson: function(response) {
+				if (response.ok) {
+					return response.json();
+				}
+				return Promise.reject(response.status + ' ' + response.statusText);
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				var enrollmentId, enrollmentEntity;
@@ -494,17 +503,6 @@
 			},
 			_refreshPage: function() {
 				document.location.reload(true);
-			},
-			_rootEnrollmentRequest: function() {
-				this._pinnedCoursesMap = {};
-				this._unpinnedCoursesMap = {};
-				this.unpinnedEnrollments = [];
-				this.pinnedEnrollments = [];
-				this.debounce('d2l-root-request', this._rootRequest, 1000);
-			},
-			//encapsulates root enrollment request, the debounce method loses context when directly using this
-			_rootRequest: function() {
-				this.$.enrollmentsRootRequest.generateRequest();
 			},
 			_showContent: function() {
 				this.toggleClass('d2l-my-courses-hidden', true, this.$.initialLoadingSpinner);

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -1,7 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-input/iron-input.html">
 <link rel="import" href="../iron-pages/iron-pages.html">
-<link rel="import" href="../d2l-ajax/d2l-ajax.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
@@ -35,20 +34,6 @@
 				@apply --d2l-body-compact-text;
 			}
 		</style>
-
-		<d2l-ajax
-			id="fullSearchRequest"
-			url="[[_searchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onSearchResponse">
-		</d2l-ajax>
-
-		<d2l-ajax
-			id="liveSearchRequest"
-			url="[[_liveSearchUrl]]"
-			headers='{ "Accept": "application/vnd.siren+json" }'
-			on-iron-ajax-response="_onLiveSearchResponse">
-		</d2l-ajax>
 
 		<d2l-dropdown no-auto-open>
 			<div class="search-bar d2l-dropdown-opener" id="opener">
@@ -113,6 +98,8 @@
 	</template>
 	<script>
 		'use strict';
+
+		/* global Promise */
 
 		Polymer({
 			is: 'd2l-search-widget-custom',
@@ -362,47 +349,43 @@
 				});
 				this.set('_organizationRequests', []);
 
-				this.$.liveSearchRequest.generateRequest();
+				return this.fetchSirenEntity(this._liveSearchUrl)
+					.then(this._onLiveSearchResponse.bind(this));
 			},
-			_onLiveSearchResponse: function(response) {
-				if (response.detail.status === 200 && this._searchInput) {
-					var searchResponse = this.parseEntity(response.detail.xhr.response);
-					var enrollmentEntities = searchResponse.entities;
-					this.$$('iron-pages').select(enrollmentEntities.length > 0 ? 'search-results-page' : 'no-results-page');
-
-					this._liveSearchResults = [];
-					for (var i = 0; i < enrollmentEntities.length; i++) {
-						// Fetch each search result's organization's information
-						(function(enrollment, index, numEntities, self) {
-							var ajax = document.createElement('d2l-ajax');
-							ajax.url = enrollment.getLinkByRel(self.HypermediaRels.organization).href;
-							ajax.method = 'GET';
-							ajax.onResponse = function(response) {
-								if (response.detail.status === 200 || response.detail.status === 304) {
-									var organization = self.parseEntity(response.detail.response);
-									// Polymer's splice method causes empty results to show up for an
-									// unknown reason, so use a normal Array.prototype.splice...
-									self._liveSearchResults.splice(index, 0, {
-										name: organization.properties.name
-									});
-									// ...then, if this is the last result to get spliced in, manually
-									// call notifySplices with the changes.
-									if (self._liveSearchResults.length >= numEntities) {
-										self.notifySplices('_liveSearchResults', [{
-											index: 0,
-											removed: [],
-											addedCount: numEntities,
-											object: self._liveSearchResults,
-											type: 'splice'
-										}]);
-									}
-								}
-							};
-							ajax.generateRequest();
-							self.push('_organizationRequests', ajax);
-						})(enrollmentEntities[i], i, enrollmentEntities.length, this);
-					}
+			_onLiveSearchResponse: function(enrollmentsEntity) {
+				if (!this._searchInput) {
+					return;
 				}
+
+				var enrollmentEntities = enrollmentsEntity.entities;
+				this.$$('iron-pages').select(enrollmentEntities.length > 0 ? 'search-results-page' : 'no-results-page');
+
+				this._liveSearchResults = [];
+				var fetches = [];
+				for (var i = 0; i < enrollmentEntities.length; i++) {
+					var url = enrollmentEntities[i].getLinkByRel(this.HypermediaRels.organization).href;
+					// Fetch each search result's organization's information
+					var result = this.fetchSirenEntity(url)
+						.then(function(organizationEntity) {
+							// Polymer's splice method causes empty results to show up for an
+							// unknown reason, so use a normal Array.prototype.splice
+							this._liveSearchResults.splice(i, 0, {
+								name: organizationEntity.properties.name
+							});
+						}.bind(this));
+					fetches.push(result);
+				}
+
+				return Promise.all(fetches)
+					.then(function() {
+						// Once all fetches have completed, manually call notifySplices with the changes
+						this.notifySplices('_liveSearchResults', [{
+							index: 0,
+							removed: [],
+							addedCount: enrollmentEntities.length,
+							type: 'splice'
+						}]);
+					}.bind(this));
 			},
 
 			/*

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -4,6 +4,8 @@
 <script>
 	'use strict';
 
+	/* global Promise */
+
 	window.D2L = window.D2L || {};
 	window.D2L.MyCourses = window.D2L.MyCourses || {};
 

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -42,6 +42,23 @@
 		},
 		parseEntity: function(entity) {
 			return window.D2L.Hypermedia.Siren.Parse(entity);
+		},
+		fetchSirenEntity: function(url) {
+			return window.d2lfetch
+				.fetch(new Request(url, {
+					headers: { Accept: 'application/vnd.siren+json' }
+				}))
+				.then(this.responseToSirenEntity.bind(this));
+		},
+		responseToSirenEntity: function(response) {
+			if (response.ok) {
+				return response
+					.json()
+					.then(function(json) {
+						return window.D2L.Hypermedia.Siren.Parse(json);
+					});
+			}
+			return Promise.reject(response.status + ' ' + response.statusText);
 		}
 	};
 </script>

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "cross-env": "^5.0.5",
-    "eslint": "^4.3.0",
+    "eslint": "^4.5.0",
     "eslint-config-brightspace": "^0.3.1",
-    "eslint-plugin-html": "^3.1.1",
+    "eslint-plugin-html": "^3.2.0",
     "frau-publisher": "^2.6.2",
-    "polymer-cli": "^1.3.1",
+    "polymer-cli": "^1.5.2",
     "rimraf": "^2.6.1",
-    "web-component-tester": "^6.0.0"
+    "web-component-tester": "^6.1.3"
   }
 }

--- a/polyfill/Array.prototype.includes.js
+++ b/polyfill/Array.prototype.includes.js
@@ -1,0 +1,52 @@
+// Required to use d2l-fetch-simple-cache
+
+if (!Array.prototype.includes) {
+	Object.defineProperty(Array.prototype, 'includes', {
+		value: function(searchElement, fromIndex) {
+
+		// 1. Let O be ? ToObject(this value).
+		if (this == null) {
+			throw new TypeError('"this" is null or not defined');
+		}
+
+		var o = Object(this);
+
+		// 2. Let len be ? ToLength(? Get(O, "length")).
+		var len = o.length >>> 0;
+
+		// 3. If len is 0, return false.
+		if (len === 0) {
+			return false;
+		}
+
+		// 4. Let n be ? ToInteger(fromIndex).
+		//    (If fromIndex is undefined, this step produces the value 0.)
+		var n = fromIndex | 0;
+
+		// 5. If n ≥ 0, then
+		//  a. Let k be n.
+		// 6. Else n < 0,
+		//  a. Let k be len + n.
+		//  b. If k < 0, let k be 0.
+		var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+		function sameValueZero(x, y) {
+			return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+		}
+
+		// 7. Repeat, while k < len
+		while (k < len) {
+			// a. Let elementK be the result of ? Get(O, ! ToString(k)).
+			// b. If SameValueZero(searchElement, elementK) is true, return true.
+			// c. Increase k by 1.
+			if (sameValueZero(o[k], searchElement)) {
+			return true;
+			}
+			k++;
+		}
+
+		// 8. Return false
+		return false;
+		}
+	});
+}

--- a/polyfill/Array.prototype.includes.js
+++ b/polyfill/Array.prototype.includes.js
@@ -1,52 +1,54 @@
 // Required to use d2l-fetch-simple-cache
 
+'use strict';
+
 if (!Array.prototype.includes) {
 	Object.defineProperty(Array.prototype, 'includes', {
 		value: function(searchElement, fromIndex) {
 
-		// 1. Let O be ? ToObject(this value).
-		if (this == null) {
-			throw new TypeError('"this" is null or not defined');
-		}
-
-		var o = Object(this);
-
-		// 2. Let len be ? ToLength(? Get(O, "length")).
-		var len = o.length >>> 0;
-
-		// 3. If len is 0, return false.
-		if (len === 0) {
-			return false;
-		}
-
-		// 4. Let n be ? ToInteger(fromIndex).
-		//    (If fromIndex is undefined, this step produces the value 0.)
-		var n = fromIndex | 0;
-
-		// 5. If n ≥ 0, then
-		//  a. Let k be n.
-		// 6. Else n < 0,
-		//  a. Let k be len + n.
-		//  b. If k < 0, let k be 0.
-		var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
-
-		function sameValueZero(x, y) {
-			return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
-		}
-
-		// 7. Repeat, while k < len
-		while (k < len) {
-			// a. Let elementK be the result of ? Get(O, ! ToString(k)).
-			// b. If SameValueZero(searchElement, elementK) is true, return true.
-			// c. Increase k by 1.
-			if (sameValueZero(o[k], searchElement)) {
-			return true;
+			// 1. Let O be ? ToObject(this value).
+			if (this == null) { // eslint-disable-line eqeqeq
+				throw new TypeError('"this" is null or not defined');
 			}
-			k++;
-		}
 
-		// 8. Return false
-		return false;
+			var o = Object(this);
+
+			// 2. Let len be ? ToLength(? Get(O, "length")).
+			var len = o.length >>> 0;
+
+			// 3. If len is 0, return false.
+			if (len === 0) {
+				return false;
+			}
+
+			// 4. Let n be ? ToInteger(fromIndex).
+			//    (If fromIndex is undefined, this step produces the value 0.)
+			var n = fromIndex | 0;
+
+			// 5. If n ≥ 0, then
+			//  a. Let k be n.
+			// 6. Else n < 0,
+			//  a. Let k be len + n.
+			//  b. If k < 0, let k be 0.
+			var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+
+			function sameValueZero(x, y) {
+				return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+			}
+
+			// 7. Repeat, while k < len
+			while (k < len) {
+				// a. Let elementK be the result of ? Get(O, ! ToString(k)).
+				// b. If SameValueZero(searchElement, elementK) is true, return true.
+				// c. Increase k by 1.
+				if (sameValueZero(o[k], searchElement)) {
+					return true;
+				}
+				k++;
+			}
+
+			// 8. Return false
+			return false;
 		}
 	});
 }

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
+		<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
 
 		<link rel="import" href="../../d2l-all-courses.html">
 	</head>

--- a/test/d2l-course-tile/d2l-course-tile.html
+++ b/test/d2l-course-tile/d2l-course-tile.html
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
+		<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
 
 		<link rel="import" href="../../d2l-course-tile.html">
 	</head>

--- a/test/d2l-filter-menu-content/d2l-list-item-filter.html
+++ b/test/d2l-filter-menu-content/d2l-list-item-filter.html
@@ -5,6 +5,7 @@
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
+		<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
 
 		<link rel="import" href="../../d2l-filter-menu-content/d2l-list-item-filter.html">
 	</head>


### PR DESCRIPTION
This seems to improve our loading time locally by about 1 second. There is about a 1-second gap between the initial loading the page and when we fetch the token using `d2l-ajax`, but with `d2lfetch` this gap is all but gone.

Before - note the gap between the `Framework.UserProfileBadge` and `token` requests, resulting in the enrollments request happening around the 2.2s mark:

![image](https://user-images.githubusercontent.com/6231623/30835210-1c27061a-a225-11e7-9731-75da9bd0a1b7.png)

After - note the lack of gap between the `Framework.UserProfileBadge` and `token` requests, resulting in the enrollments request happening around the 1.2s mark:

![image](https://user-images.githubusercontent.com/6231623/30835145-ae876924-a224-11e7-93a3-2d3aaff1826e.png)

Actual results may vary, but using d2lfetch also improves our code maintainability/cleanliness as it allows for more promisey structures in fetching data.

TODO:

- [x] Merge #387 and rebase this
- [x] Merge and release https://github.com/Brightspace/d2l-search-widget-ui/pull/32
- [x] Remove d2l-ajax from remaining components
- [x] Add/update/remove tests as required