### PR TITLE
Update to latest d2l-alert.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "app-localize-behavior": "PolymerElements/app-localize-behavior#^1.0.2",
     "d2l-ajax": "^3.4.1",
-    "d2l-alert": "git://github.com/Brightspace/alert.git#^1.0.2",
+    "d2l-alert": "^2.0.0",
     "d2l-colors": "^2.3.0",
     "d2l-course-image": "git://github.com/Brightspace/course-image.git#^1.0.3",
     "d2l-dropdown": "^5.0.6",


### PR DESCRIPTION
No other changes needed.  It looks like My Courses just uses defaults for `d2l-alert`.  So, this change is mainly needed to resolve bower version conflict in BSI.