### PR TITLE
US90475 PR follow-up feedback

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,3 +7,4 @@ globals:
   Polymer: false
   WCT: false
   D2L: false
+  Promise: false

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -107,8 +107,6 @@ the user has in that organization - student, teacher, TA, etc.
 	<script>
 		'use strict';
 
-		/* global Promise */
-
 		Polymer({
 			is: 'd2l-course-tile',
 
@@ -499,14 +497,14 @@ the user has in that organization - student, teacher, TA, etc.
 				this.$$('#courseUpdates').setAttribute( 'aria-hidden', updates === 0 ? 'true' : 'false' );
 			},
 			_checkDateBounds: function(organization) {
-				var serverDate = Date.now();
+				var nowDate = Date.now();
 				var endDate = Date.parse(organization.properties.endDate);
 				var startDate = Date.parse(organization.properties.startDate);
 				var inactive = !organization.properties.isActive;
 
-				if (endDate < serverDate) {
+				if (endDate < nowDate) {
 					this._setOverlayContent('courseEnded', endDate);
-				} else if (startDate > serverDate) {
+				} else if (startDate > nowDate) {
 					this._setOverlayContent('courseStarting', startDate, inactive);
 				} else if (startDate && inactive) {
 					this._setOverlayStartedInactive();

--- a/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
+++ b/d2l-filter-menu-content/d2l-filter-menu-content-tabbed.html
@@ -170,8 +170,6 @@
 	<script>
 		'use strict';
 
-		/* global Promise */
-
 		Polymer({
 			is: 'd2l-filter-menu-content-tabbed',
 			properties: {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -122,8 +122,6 @@
 	<script>
 		'use strict';
 
-		/* global Promise */
-
 		Polymer({
 			is: 'd2l-my-courses',
 

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -99,8 +99,6 @@
 	<script>
 		'use strict';
 
-		/* global Promise */
-
 		Polymer({
 			is: 'd2l-search-widget-custom',
 

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -4,8 +4,6 @@
 <script>
 	'use strict';
 
-	/* global Promise */
-
 	window.D2L = window.D2L || {};
 	window.D2L.MyCourses = window.D2L.MyCourses || {};
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "npm run test:lint:js && npm run test:lint:wc && wct",
     "test:lint:js": "eslint --ext .js,.html . d2l-filter-menu-content/ demo/ lang/ test/",
     "test:lint:wc": "polymer lint",
-    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=firefox wct -p"
+    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=chrome wct -p"
   },
   "config": {
     "frauPublisher": {


### PR DESCRIPTION
Addresses some additional feedback from https://github.com/Brightspace/d2l-my-courses-ui/pull/382

- Move Promise to eslintrc
- Use UTC date for comparison, since that's what comes back from the server

Doesn't include the `d2l-fetch` -> BSI changes, as I'm still working on those, but figured I should get these in as they're small, and independent of that change.