### PR TITLE
Use d2l-fetch from bower, to take advantage of version resolution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,7 @@
     "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.4.1",
     "d2l-icons": "^3.2.0",
-    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^1.1.0",
+    "d2l-image-selector": "git://github.com/Brightspace/image-selector#^2.0.1",
     "d2l-link": "^3.5.0",
     "d2l-loading-spinner": "^5.0.4",
     "d2l-menu": "^0.3.5",

--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "d2l-menu": "^0.3.5",
     "d2l-offscreen": "^2.2.4",
     "d2l-polymer-behaviors": "<1.0.0",
-    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.0.0",
+    "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.0.1",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.1",
     "d2l-typography": "^5.4.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.0.1",

--- a/bower.json
+++ b/bower.json
@@ -32,6 +32,7 @@
     "d2l-colors": "^2.3.0",
     "d2l-course-image": "git://github.com/Brightspace/course-image.git#^1.0.3",
     "d2l-dropdown": "^5.0.6",
+    "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.4.1",
     "d2l-icons": "^3.2.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^1.1.0",

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
 <link rel="import" href="../d2l-alert/d2l-alert.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-link/d2l-link.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
@@ -115,10 +116,6 @@
 
 	</template>
 
-	<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
-	<script src="https://s.brightspace.com/lib/d2lfetch-auth/0.6.0/d2lfetch-auth.js"></script>
-	<script src="https://s.brightspace.com/lib/d2lfetch-dedupe/0.10.0/d2lfetch-dedupe.js"></script>
-	<script src="https://s.brightspace.com/lib/d2lfetch-simple-cache/0.3.0/d2lfetch-simple-cache.js"></script>
 	<script>
 		'use strict';
 
@@ -214,10 +211,6 @@
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
-				window.d2lfetch.use({name: 'auth', fn: window.d2lfetch.auth});
-				window.d2lfetch.use({name: 'dedupe', fn: window.d2lfetch.dedupe});
-				window.d2lfetch.use({name: 'simpleCache', fn: window.d2lfetch.simpleCache});
-
 				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
 				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseTiles);
 				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseList);

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
 
 <script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 <script>


### PR DESCRIPTION
Under this new method, `.use`ing the various middlewares is done by the consumer of the element, in this case BSI. This means we can get the same versions for everything, and the same middlewares. In addition, My Courses shouldn't really _care_ how the d2l-fetch sausage is made, only that it gets made somehow.

Unclear whether I really need to have the HTML import at all in My Courses, but hopefully if nothing else it makes it more obvious that it's not just an unused bower reference.

TODO

- [x] Merge and release https://github.com/Brightspace/d2l-fetch/pull/10
- [x] Update this to point at actual versions, not a branch