### PR TITLE
Fix broken promises

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -321,7 +321,7 @@ the user has in that organization - student, teacher, TA, etc.
 			_telemetryRequest: null,
 			_fetchOrganization: function() {
 				if (!this._organizationUrl) {
-					return;
+					return Promise.reject('Organization URL is not set');
 				}
 
 				return window.d2lfetch
@@ -337,7 +337,7 @@ the user has in that organization - student, teacher, TA, etc.
 			},
 			_fetchNotifications: function() {
 				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
-					return;
+					return Promise.reject('Notifications URL or config is not set');
 				}
 
 				return this.fetchSirenEntity(this._notificationsUrl);

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -484,6 +484,22 @@ describe('<d2l-course-tile>', function() {
 			});
 		});
 
+		it('should reject and not call the response handler when notification URL is not set', function() {
+			widget._onNotificationsResponse = sandbox.stub();
+			widget.courseUpdatesConfig = undefined;
+			return widget._fetchNotifications().catch(function() {
+				expect(widget._onNotificationsResponse).to.have.not.been.called;
+			});
+		});
+
+		it('should reject and not call the response handler when notification URL is not set', function() {
+			widget._onNotificationsResponse = sandbox.stub();
+			widget._notificationsUrl = undefined;
+			return widget._fetchNotifications().catch(function() {
+				expect(widget._onNotificationsResponse).to.have.not.been.called;
+			});
+		});
+
 		it('should show update number when less than 99', function() {
 			widget._setCourseUpdates(85);
 			expect(widget.$.courseUpdates.getAttribute('class')).to.not.contain('d2l-updates-hidden');


### PR DESCRIPTION
Previously, fetching the notifications would exit early if `courseUpdatesConfig` wasn't set. This approach doesn't work with promises, however, as it means the _onNotificationsResponse handler will still get called, and will have a conniption if `courseUpdatesConfig` isn't set. So, reject from _fetchNotifications instead.

Similar approach for _fetchOrganization, which would still run the handler after the `if (!_organizationUrl) { return }`.