### PR TITLE
Re-fix promises to not reject

### DIFF
--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -321,7 +321,7 @@ the user has in that organization - student, teacher, TA, etc.
 			_telemetryRequest: null,
 			_fetchOrganization: function() {
 				if (!this._organizationUrl) {
-					return Promise.reject('Organization URL is not set');
+					return;
 				}
 
 				return window.d2lfetch
@@ -336,8 +336,8 @@ the user has in that organization - student, teacher, TA, etc.
 					.then(this.responseToSirenEntity.bind(this));
 			},
 			_fetchNotifications: function() {
-				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
-					return Promise.reject('Notifications URL or config is not set');
+				if (!this._notificationsUrl) {
+					return;
 				}
 
 				return this.fetchSirenEntity(this._notificationsUrl);
@@ -473,6 +473,10 @@ the user has in that organization - student, teacher, TA, etc.
 				return Promise.resolve();
 			},
 			_onNotificationsResponse: function(notifications) {
+				if (!this.courseUpdatesConfig) {
+					return;
+				}
+
 				var total = 0;
 				if (this.courseUpdatesConfig.showUnattemptedQuizzes) {
 					total += notifications.properties.UnattemptedQuizzes;

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -484,22 +484,6 @@ describe('<d2l-course-tile>', function() {
 			});
 		});
 
-		it('should reject and not call the response handler when notification URL is not set', function() {
-			widget._onNotificationsResponse = sandbox.stub();
-			widget.courseUpdatesConfig = undefined;
-			return widget._fetchNotifications().catch(function() {
-				expect(widget._onNotificationsResponse).to.have.not.been.called;
-			});
-		});
-
-		it('should reject and not call the response handler when notification URL is not set', function() {
-			widget._onNotificationsResponse = sandbox.stub();
-			widget._notificationsUrl = undefined;
-			return widget._fetchNotifications().catch(function() {
-				expect(widget._onNotificationsResponse).to.have.not.been.called;
-			});
-		});
-
 		it('should show update number when less than 99', function() {
 			widget._setCourseUpdates(85);
 			expect(widget.$.courseUpdates.getAttribute('class')).to.not.contain('d2l-updates-hidden');


### PR DESCRIPTION
Erm... yeah rejections still cause console errors, so just like... do the check. A better fix (i.e. one that actually works) for what I was trying to do in #393 (also remove the tests added there, as they're no longer useful.