### PR TITLE
Switch to directly setting searchUrl

### DIFF
--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -48,10 +48,7 @@
 							search-button-label="{{localize('search')}}"
 							clear-button-label="{{localize('search.clearSearch')}}"
 							search-action="[[_enrollmentsSearchAction]]"
-							search-field-name="search"
-							cache-responses
-							parent-organizations="[[_parentOrganizations]]"
-							sort="[[_sortParameter]]">
+							search-url="[[_searchUrl]]">
 						</d2l-search-widget-custom>
 
 						<div id="filterAndSort">
@@ -257,10 +254,6 @@
 				_noUnpinnedCoursesInSearch: Boolean,
 				_noUnpinnedCoursesInSelection: Boolean,
 				_noUnpinnedCourses: Boolean,
-				_parentOrganizations: {
-					type: Array,
-					value: function() { return []; }
-				},
 				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
 				_pinnedCoursesMap: {
 					type: Object,
@@ -270,10 +263,8 @@
 					type: Array,
 					value: function() { return []; }
 				},
-				_sortParameter: {
-					type: String,
-					value: '-PinDate,OrgUnitName,OrgUnitId'
-				},
+				// URL passed to search widget, called for searching
+				_searchUrl: String,
 				_tileSizes: Object,
 				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates
 				_unpinnedCoursesMap: {
@@ -314,10 +305,9 @@
 
 				this._filterText = this.localize('filtering.filter');
 				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').selected = true;
-				this._sortParameter = this._sortOptions[this.defaultSortValue].queryParameter;
 			},
 			attached: function() {
-				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_onMenuItemChange');
+				this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_onSortOrderChanged');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.listen(this.$.filterMenu, 'd2l-filter-menu-change', '_onFilterChanged');
@@ -326,7 +316,7 @@
 				window.addEventListener('resize', this._onResize.bind(this));
 			},
 			detached: function() {
-				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_onMenuItemChange');
+				this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_onSortOrderChanged');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
 				this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
 				this.unlisten(this.$.filterMenu, 'd2l-filter-menu-change', '_onFilterChanged');
@@ -379,30 +369,6 @@
 			},
 
 			/*
-			* Non-Polymer properties
-			*/
-
-			_sortOptions: {
-				OrgUnitCode: {
-					text: 'sorting.sortCourseCode',
-					queryParameter: '-PinDate,OrgUnitCode,OrgUnitId'
-				},
-				OrgUnitName: {
-					text: 'sorting.sortCourseName',
-					queryParameter: '-PinDate,OrgUnitName,OrgUnitId'
-				},
-				PinDate: {
-					text: 'sorting.sortDatePinned',
-					queryParameter: '-PinDate,OrgUnitId'
-				},
-				LastAccessed: {
-					text: 'sorting.sortLastAccessed',
-					// Note: Sorting by LastAccessed is done differently LMS-side, hence this being different
-					queryParameter: 'LastAccessed'
-				}
-			},
-
-			/*
 			* Listeners
 			*/
 
@@ -423,8 +389,13 @@
 				}
 			},
 			_onFilterChanged: function(e) {
-				this._parentOrganizations = [];
-				this.set('_parentOrganizations', e.detail.filters);
+				if (!this._enrollmentsSearchAction) {
+					return;
+				}
+
+				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
+					parentOrganizations: e.detail.filters.join(',')
+				});
 			},
 			_onFilterDropdownClose: function() {
 				var length = this.$.filterMenu.currentFilters.length;
@@ -442,17 +413,43 @@
 				this.set('_filterText', this.localize('filtering.filter'));
 				return this.$.filterMenu.open();
 			},
-			_onMenuItemChange: function(e) {
-				this.set('_sortParameter', this._sortOptions[e.detail.value].queryParameter);
-				this.$.sortText.textContent = this.localize(this._sortOptions[e.detail.value].text || '');
-				this.$.sortDropdown.toggleOpen();
-			},
 			_onResize: function() {
 				this._updateTileSizes();
+			},
+			_onSortOrderChanged: function(e) {
+				var queryParameter, langterm;
+
+				switch (e.detail.value) {
+					case 'OrgUnitCode':
+						langterm = 'sorting.sortCourseCode';
+						queryParameter = '-PinDate,OrgUnitCode,OrgUnitId';
+						break;
+					case 'PinDate':
+						langterm = 'sorting.sortDatePinned';
+						queryParameter = '-PinDate,OrgUnitId';
+						break;
+					case 'LastAccessed':
+						langterm = 'sorting.sortLastAccessed';
+						// Note: Sorting by LastAccessed is done differently LMS-side, hence this being different
+						queryParameter = 'LastAccessed';
+						break;
+					default: // Includes 'OrgUnitName', which is the default sort order
+						langterm = 'sorting.sortCourseName';
+						queryParameter = '-PinDate,OrgUnitName,OrgUnitId';
+						break;
+				}
+
+				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
+					sort: queryParameter
+				});
+
+				this.$.sortText.textContent = this.localize(langterm || '');
+				this.$.sortDropdown.toggleOpen();
 			},
 			_onSearchResultsChanged: function(e) {
 				this._pinnedCoursesMap = {};
 				this._unpinnedCoursesMap = {};
+				this._enrollmentsSearchAction = e.detail.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
 				this._updateFilteredEnrollments(e.detail, false);
 			},
 			_onSimpleOverlayOpening: function() {
@@ -512,7 +509,7 @@
 				this._noUnpinnedCourses = false;
 				var isSearched = this.$['search-widget']._showClearIcon,
 					hasAlert = this._hasAlert('noPinnedCourses'),
-					isFiltered = this._parentOrganizations ? this._parentOrganizations.length > 0 : false;
+					isFiltered = this.$.filterMenu.currentFilters.length > 0;
 				this._clearAlerts();
 				if (!hasPinnedEnrollments) {
 					if (!hasAlert && isSearched) {
@@ -587,11 +584,6 @@
 			},
 			_resetSortDropdown: function() {
 				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').click();
-
-				// The click will not fire an event if the value is already selected, so need to update the sort manually
-				if (this._sortParameter !== this._sortOptions[this.defaultSortValue].queryParameter) {
-					this._sortParameter = this._sortOptions[this.defaultSortValue].queryParameter;
-				}
 
 				var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');
 				if (content) {

--- a/d2l-search-widget-custom.html
+++ b/d2l-search-widget-custom.html
@@ -103,15 +103,10 @@
 			is: 'd2l-search-widget-custom',
 
 			properties: {
-				// Value to send for the `sort` parameter in the search query
-				sort: String,
-
-				// Value to send for the `parentOrganizations` parameter in the search query
-				parentOrganizations: {
-					type: Array,
-					value: function() {
-						return [];
-					}
+				// URL to use to search. Updated by the search field, as well as external sources like sort/filter menus
+				searchUrl: {
+					type: String,
+					observer: '_onSearchUrlChanged'
 				},
 
 				// Outstanding /organizations XHRs, which are cancelled when a new search starts
@@ -159,10 +154,6 @@
 				window.D2L.PolymerBehaviors.SearchWidgetBehavior
 			],
 
-			observers: [
-				'_onSearchDependencyChanged(sort, parentOrganizations)'
-			],
-
 			ready: function() {
 				this._handleFocusBound = this._handleFocus.bind(this);
 				this._handleClickBound = this._handleClick.bind(this);
@@ -193,19 +184,13 @@
 				ENTER: 13
 			},
 
-			_onSearchDependencyChanged: function() {
-				if (this.isAttached) {
-					this.debounce('_onSearchDependencyChanged', this.search, 500);
-				}
-			},
-
 			/*
 			* SearchWidgetBehavior overrides
 			*/
 
 			search: function() {
 				this._addSearchToHistory(this._searchInput);
-				this._setSearchUrl(this._searchPageSize, '_searchUrl');
+				this._setSearchUrl(this._searchPageSize, 'searchUrl');
 			},
 			clear: function() {
 				// Triggers _onSearchInputChanged to call _setSearchUrl with empty query
@@ -227,9 +212,7 @@
 
 				var queryParams = {
 					page: 1,
-					pageSize: pageSize,
-					parentOrganizations: this.parentOrganizations.join(','),
-					sort: this.sort
+					pageSize: pageSize
 				};
 				queryParams[this.searchFieldName] = encodeURIComponent(this._searchInput.trim());
 
@@ -237,7 +220,7 @@
 			},
 			_onSearchInputChanged: function(newSearchString) {
 				if (newSearchString.trim().length === 0) {
-					this._setSearchUrl(this._searchPageSize, '_searchUrl');
+					this._setSearchUrl(this._searchPageSize, 'searchUrl');
 				} else {
 					this.set('_showClearIcon', false);
 				}
@@ -331,7 +314,7 @@
 			},
 
 			/*
-			* Live search funtionality
+			* Live search functionality
 			*/
 
 			_liveSearch: function() {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "npm run test:lint:js && npm run test:lint:wc && wct",
     "test:lint:js": "eslint --ext .js,.html . d2l-filter-menu-content/ demo/ lang/ test/",
     "test:lint:wc": "polymer lint",
-    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=chrome wct --skip-plugin sauce -p"
+    "test:no-lint": "cross-env LAUNCHPAD_BROWSERS=chrome wct -p"
   },
   "homepage": "https://github.com/Brightspace/d2l-my-courses-ui",
   "repository": {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -39,6 +39,17 @@ describe('d2l-all-courses', function() {
 
 		widget = fixture('d2l-all-courses-fixture');
 		widget.$['search-widget']._setSearchUrl = sandbox.stub();
+		widget._enrollmentsSearchAction = {
+			name: 'search-my-enrollments',
+			href: '/enrollments/users/169',
+			fields: [{
+				name: 'parentOrganizations',
+				value: ''
+			}, {
+				name: 'sort',
+				value: ''
+			}]
+		};
 
 		widgetNoAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});
@@ -98,12 +109,10 @@ describe('d2l-all-courses', function() {
 			filters: [1]
 		};
 
-		it('should update the parent organizations', function() {
-			expect(widget._parentOrganizations.length).to.equal(0);
+		it('should set the search URL with the correct parentOrganizations', function() {
+			widget.$.filterMenu.fire('d2l-filter-menu-change', event);
 
-			widget.$$('d2l-filter-menu').fire('d2l-filter-menu-change', event);
-
-			expect(widget._parentOrganizations.length).to.equal(1);
+			expect(widget._searchUrl).to.match(/parentOrganizations=1/);
 		});
 	});
 
@@ -194,7 +203,7 @@ describe('d2l-all-courses', function() {
 
 		it('should show no pinned courses in search message when no pinned courses in filter', function() {
 			widget._clearAlerts();
-			widget._parentOrganizations = ['boop'];
+			widget.$.filterMenu.currentFilters.length = 1;
 			widget._updateEnrollmentAlerts(false, true);
 			expect(widget._noPinnedCoursesInSelection).to.be.true;
 		});
@@ -208,7 +217,7 @@ describe('d2l-all-courses', function() {
 
 		it('should show no unpinned courses in search message when no unpinned courses in filter', function() {
 			widget._clearAlerts();
-			widget._parentOrganizations = ['boop'];
+			widget.$.filterMenu.currentFilters.length = 1;
 			widget._updateEnrollmentAlerts(true, false);
 			expect(widget._noUnpinnedCoursesInSelection).to.be.true;
 		});
@@ -222,7 +231,7 @@ describe('d2l-all-courses', function() {
 
 		it('should not show message when there are pinned courses in filter', function() {
 			widget._clearAlerts();
-			widget._parentOrganizations = ['boop'];
+			widget.$.filterMenu.currentFilters.length = 1;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noPinnedCoursesInSelection).to.be.false;
 		});
@@ -236,7 +245,7 @@ describe('d2l-all-courses', function() {
 
 		it('should not show message when there are unpinned courses in filter', function() {
 			widget._clearAlerts();
-			widget._parentOrganizations = ['boop'];
+			widget.$.filterMenu.currentFilters.length = 1;
 			widget._updateEnrollmentAlerts(true, true);
 			expect(widget._noUnpinnedCoursesInSelection).to.be.false;
 		});
@@ -289,16 +298,12 @@ describe('d2l-all-courses', function() {
 				value: 'OrgUnitCode'
 			};
 
-			var defaultValue = widget.defaultSortValue;
-
 			widget.load();
-			expect(widget._sortParameter).to.equal(widget._sortOptions[defaultValue].queryParameter);
 			widget.$$('d2l-dropdown-menu').fire('d2l-menu-item-change', event);
-			expect(widget._sortParameter).to.equal(widget._sortOptions[event.value].queryParameter);
+			expect(widget._searchUrl).to.contain('-PinDate,OrgUnitCode,OrgUnitId');
 
 			widget.$$('d2l-simple-overlay')._renderOpened();
 			expect(spy.called).to.be.true;
-			expect(widget._sortParameter).to.equal(widget._sortOptions[defaultValue].queryParameter);
 		});
 	});
 });

--- a/test/d2l-search-widget-custom/d2l-search-widget-custom.js
+++ b/test/d2l-search-widget-custom/d2l-search-widget-custom.js
@@ -58,25 +58,18 @@ describe('<d2l-search-widget-custom>', function() {
 		clock.restore();
 	});
 
-	it('should perform a search when sort changes', function() {
-		var spy = sandbox.spy(widget, 'search');
-		widget.set('sort', '-PinDate,OrgUnitName,OrgUnitId');
-		clock.tick(501);
-		expect(spy.called).to.be.true;
-	});
-
-	it('should perform a search when filter changes', function() {
-		var spy = sandbox.spy(widget, 'search');
-		widget.set('parentOrganizations', [1, 2, 3]);
+	it('should perform a search when the searchUrl changes', function() {
+		var spy = sandbox.spy(widget, '_onSearchUrlChanged');
+		widget.searchUrl = '/organizations/1234';
 		clock.tick(501);
 		expect(spy.called).to.be.true;
 	});
 
 	it('only performs one search per debounce period', function() {
-		var spy = sandbox.spy(widget, 'search');
+		var spy = sandbox.spy(widget, '_onSearchUrlChanged');
 
 		for (var i = 0; i < 20; i++) {
-			widget.set('sort', 'sort' + i);
+			widget.searchUrl = '/organizations/1234';
 			clock.tick(200);
 		}
 

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -6,6 +6,7 @@
       }]
     },
     "sauce": {
+      "disabled": true,
       "browsers": [
         {
           "browserName": "chrome",


### PR DESCRIPTION
The role filter tab works distinctly from the existing department/semester filters, which resulted in me realizing that the search isn't really doing state transfer correctly. A better approach is for the search widget to simply take an arbitrary search URL, query it, and return the results. This URL can be modified by search text, sort order, or filters; when the results come back, we update the search URL to be the self URL of the response, which allows us to again modify the search URL -> get results -> update search URL from response.

This more correctly transfers state between the client and server, and means that at any given moment, the self URL of the enrollments search result is representative of what the user is seeing. This also allows for the role filter tab to work more naturally, as the process for filtering by roles is a bit more complex - but with this new approach, it will work the same way as everything else, i.e. just update the search URL (then the search widget fetches that URL, and returns the results).