### PR TITLE
Clean up hiding things

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -60,6 +60,7 @@
   },
   "resolutions": {
     "d2l-search-widget": "^2.0.0",
-    "d2l-polymer-behaviors": "^1.0.0"
+    "d2l-polymer-behaviors": "^1.0.0",
+    "webcomponentsjs": "^0.7.24"
   }
 }

--- a/d2l-all-courses-styles.html
+++ b/d2l-all-courses-styles.html
@@ -27,9 +27,6 @@
 			.bottom-pad {
 				padding-bottom: 20px;
 			}
-			.d2l-all-courses-hidden {
-				display: none !important;
-			}
 			#search-and-filter {
 				margin-bottom: 50px;
 			}

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -353,11 +353,10 @@
 				}, this);
 				this.set('delayLoad', false);
 
-				setTimeout(function() {
-					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
+				requestAnimationFrame(function() {
 					this.fire('recalculate-columns');
 					this._showContent = true;
-				}.bind(this), 50);
+				}.bind(this));
 			},
 			open: function() {
 				this.$$('#all-courses').open();

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -32,10 +32,7 @@
 			with-backdrop
 			restore-focus-on-close>
 
-			<div
-				id="overlayContent"
-				class="d2l-all-courses-hidden">
-
+			<div hidden$="[[!_showContent]]">
 				<iron-scroll-threshold
 					id="all-courses-scroll-threshold"
 					on-lower-threshold="_onAllCoursesLowerThreshold">
@@ -90,10 +87,8 @@
 							</d2l-dropdown>
 						</div>
 					</div>
-					<div id="advancedSearchLink" class="search-and-filter-row d2l-all-courses-hidden">
-						<div class="advanced-search-link">
-							<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
-						</div>
+					<div class="search-and-filter-row advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]" >
+						<a is="d2l-link" href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</a>
 					</div>
 				</div>
 
@@ -156,12 +151,12 @@
 
 				<d2l-loading-spinner
 					id="lazyLoadSpinner"
-					class="d2l-all-courses-hidden"
+					hidden$="[[!_hasMoreEnrollments]]"
 					size="100">
 				</d2l-loading-spinner>
 			</div>
 			<d2l-loading-spinner
-				id="overlayLoadingSpinner"
+				hidden$="[[_showContent]]"
 				size="100">
 			</d2l-loading-spinner>
 		</d2l-simple-overlay>
@@ -178,10 +173,7 @@
 				*/
 
 				// URL that directs to the advanced search page
-				advancedSearchUrl: {
-					type: String,
-					observer: '_advancedSearchUrlChanged'
-				},
+				advancedSearchUrl: String,
 				// Types of notifications to include in update count in course tile
 				courseUpdatesConfig: Object,
 				// Default option in Sort menu
@@ -252,6 +244,11 @@
 				_hasFilteredPinnedEnrollments: Boolean,
 				// True when there are filtered unpinned enrollments (i.e. `_filteredUnpinnedEnrollments.length > 0`)
 				_hasFilteredUnpinnedEnrollments: Boolean,
+				// True when there are more enrollments to fetch (i.e. current page of enrollments has a `next` link)
+				_hasMoreEnrollments: {
+					type: Boolean,
+					computed: '_computeHasMoreEnrollments(lastEnrollmentsSearchResponse)'
+				},
 				_noPinnedCoursesInSearch: Boolean,
 				_noPinnedCoursesInSelection: Boolean,
 				_noUnpinnedCoursesInSearch: Boolean,
@@ -268,6 +265,15 @@
 				},
 				// URL passed to search widget, called for searching
 				_searchUrl: String,
+				_showAdvancedSearchLink: {
+					type: Boolean,
+					value: false,
+					computed: '_computeShowAdvancedSearchLink(advancedSearchUrl)'
+				},
+				_showContent: {
+					type: Boolean,
+					value: false
+				},
 				_tileSizes: Object,
 				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates
 				_unpinnedCoursesMap: {
@@ -350,9 +356,7 @@
 				setTimeout(function() {
 					// Slight delay to allow for overlay to get a DOM width before triggering the recalculation
 					this.fire('recalculate-columns');
-
-					this.toggleClass('d2l-all-courses-hidden', false, this.$.overlayContent);
-					this.toggleClass('d2l-all-courses-hidden', true, this.$.overlayLoadingSpinner);
+					this._showContent = true;
 				}.bind(this), 50);
 			},
 			open: function() {
@@ -381,7 +385,6 @@
 
 					if (lastResponseEntity && lastResponseEntity.hasLinkByRel('next')) {
 						this._enrollmentsSearchUrl = lastResponseEntity.getLinkByRel('next').href;
-						this.toggleClass('d2l-all-courses-hidden', false, this.$.lazyLoadSpinner);
 						this.$.lazyLoadSpinner.scrollIntoView();
 
 						return this.fetchSirenEntity(this._enrollmentsSearchUrl)
@@ -474,9 +477,6 @@
 			* Observers
 			*/
 
-			_advancedSearchUrlChanged: function() {
-				this.toggleClass('d2l-all-courses-hidden', !this.advancedSearchUrl, this.$.advancedSearchLink);
-			},
 			_enrollmentsChanged: function() {
 				this._hasFilteredPinnedEnrollments = this._filteredPinnedEnrollments.length > 0;
 				this._hasFilteredUnpinnedEnrollments = this._filteredUnpinnedEnrollments.length > 0;
@@ -546,6 +546,13 @@
 			_clearSearchWidget: function() {
 				this.$['search-widget'].clear();
 				this._clearFilteredCourses();
+			},
+			_computeHasMoreEnrollments: function(lastResponse) {
+				lastResponse = this.parseEntity(lastResponse);
+				return lastResponse.hasLinkByRel('next');
+			},
+			_computeShowAdvancedSearchLink: function(link) {
+				return !!link;
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				// Remove enrollment from unpinned list, add to pinned
@@ -621,7 +628,6 @@
 					this._filteredUnpinnedEnrollments = newUnpinnedEnrollments;
 				}
 
-				this.toggleClass('d2l-all-courses-hidden', true, this.$.lazyLoadSpinner);
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this.lastEnrollmentsSearchResponse = enrollments;
 			},

--- a/d2l-course-tile-styles.html
+++ b/d2l-course-tile-styles.html
@@ -16,9 +16,6 @@
 			.d2l-course-tile-hidden {
 				display: none;
 			}
-			.d2l-updates-hidden {
-				display: none;
-			}
 			.tile-container {
 				position: relative;
 				background-color: transparent;

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -63,7 +63,7 @@ the user has in that organization - student, teacher, TA, etc.
 						</div>
 						<d2l-offscreen id="courseNotificationLabel" aria-hidden="true">[[_courseNotificationLabel]]</d2l-offscreen>
 					</div>
-					<div id="courseUpdates" class="d2l-updates-hidden" aria-hidden="true">
+					<div id="courseUpdates" hidden$="[[!_hasCourseUpdates]]" aria-hidden="true">
 						<d2l-offscreen>{{localize('courseTile.updates')}}</d2l-offscreen>
 						<span class="update-text-box">{{_courseUpdates}}</span>
 					</div>
@@ -183,6 +183,10 @@ the user has in that organization - student, teacher, TA, etc.
 				_courseNotificationLabel: String,
 				_canChangeCourseImage: Boolean,
 				_forceImageRefresh: Boolean,
+				_hasCourseUpdates: {
+					type: Boolean,
+					value: false
+				},
 				_image: Object,
 				_nextImage: Object,
 				// The icon we want to show when you select an image
@@ -547,8 +551,8 @@ the user has in that organization - student, teacher, TA, etc.
 				return Promise.resolve();
 			},
 			_setCourseUpdates: function(updates) {
+				this._hasCourseUpdates = updates > 0;
 				this._courseUpdates = updates > 99 ? '99+' : Math.max(updates, 0);
-				this.toggleClass('d2l-updates-hidden', updates <= 0, this.$.courseUpdates);
 				this.$$('#courseUpdates').setAttribute( 'aria-hidden', updates === 0 ? 'true' : 'false' );
 			},
 			_checkDateBounds: function(organization) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -23,9 +23,6 @@
 			:host {
 				display: block;
 			}
-			:host [hidden] {
-				display: none !important;
-			}
 			@media not all and (hover: hover) {
 				:host {
 					-webkit-user-select: none;
@@ -34,9 +31,6 @@
 			}
 			.my-courses-content {
 				padding-top: 10px;
-			}
-			.d2l-my-courses-hidden {
-				display: none;
 			}
 			.spinner-container {
 				display: flex;
@@ -52,12 +46,12 @@
 
 		<div class="spinner-container">
 			<d2l-loading-spinner
-				id="initialLoadingSpinner"
+				hidden$="[[_showContent]]"
 				size="100">
 			</d2l-loading-spinner>
 		</div>
 
-		<div class="my-courses-content d2l-my-courses-hidden">
+		<div hidden$="[[!_showContent]]" class="my-courses-content">
 			<template is="dom-repeat" items="{{_alerts}}">
 				<d2l-alert type="[[item.alertType]]">
 					{{item.alertMessage}}
@@ -182,6 +176,10 @@
 				_semestersUrl: String,
 				// The organization which the user is selecting the image of
 				_setImageOrg: Object,
+				_showContent: {
+					type: Boolean,
+					value: false
+				},
 				_startedInactive: Boolean,
 				// Size the tile should render with respect to vw
 				_tileSizes: Object,
@@ -238,8 +236,6 @@
 			],
 			ready: function() {
 				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
-				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseTiles);
-				this.toggleClass('d2l-my-courses-hidden', true, this.$.courseList);
 			},
 			attached: function() {
 				this.performanceMark('my-courses.attached');
@@ -420,9 +416,15 @@
 			},
 			_fetchRoot: function() {
 				this.performanceMark('my-courses.root-enrollments.request');
+
+				var showContent = function() {
+					this._showContent = true;
+				}.bind(this);
+
 				return this.fetchSirenEntity(this.enrollmentsUrl)
 					.then(this._fetchEnrollments.bind(this))
-					.catch(this._showContent.bind(this));
+					.then(showContent)
+					.catch(showContent);
 			},
 			_fetchEnrollments: function(enrollmentsRootEntity) {
 
@@ -449,8 +451,7 @@
 
 				this.performanceMark('my-courses.search-enrollments.request');
 				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
-					.then(this._populateEnrollments.bind(this))
-					.catch(this._showContent.bind(this));
+					.then(this._populateEnrollments.bind(this));
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
 
@@ -491,8 +492,6 @@
 					{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
 				this.fire('recalculate-columns');
-
-				this._showContent();
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				var enrollmentId, enrollmentEntity;
@@ -573,10 +572,6 @@
 			},
 			_refreshPage: function() {
 				document.location.reload(true);
-			},
-			_showContent: function() {
-				this.toggleClass('d2l-my-courses-hidden', true, this.$.initialLoadingSpinner);
-				this.toggleClass('d2l-my-courses-hidden', false, this.$$('.my-courses-content'));
 			},
 			_getOrgUnitId: function(organization) {
 				var match = /[0-9]+$/.exec(this.getEntityIdentifier(organization));

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -20,12 +20,6 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="d2l-all-courses-without-advanced-search-fixture">
-			<template>
-				<d2l-all-courses>
-				</d2l-all-courses>
-			</template>
-		</test-fixture>
 		<script src="d2l-all-courses.js"></script>
 	</body>
 </html>

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -4,7 +4,6 @@
 
 describe('d2l-all-courses', function() {
 	var widget,
-		widgetNoAdvancedSearch,
 		pinnedEnrollmentEntity,
 		unpinnedEnrollmentEntity,
 		clock,
@@ -50,8 +49,6 @@ describe('d2l-all-courses', function() {
 				value: ''
 			}]
 		};
-
-		widgetNoAdvancedSearch = fixture('d2l-all-courses-without-advanced-search-fixture');
 	});
 
 	afterEach(function() {
@@ -59,19 +56,25 @@ describe('d2l-all-courses', function() {
 		sandbox.restore();
 	});
 
-	describe('when the advancedSearchUrl property has not been set then', function() {
-		it('should not render the advanced search link', function() {
-			var link = widgetNoAdvancedSearch.querySelector('.advanced-search-link > a');
-			expect(link.getAttribute('href')).to.equal(null);
-			expect(widgetNoAdvancedSearch.$.advancedSearchLink.getAttribute('class')).to.contain('d2l-all-courses-hidden');
+	describe('loading spinner', function() {
+		it('should show before content has loaded', function() {
+			expect(widget.$$('d2l-loading-spinner:not(#lazyLoadSpinner)').hasAttribute('hidden')).to.be.false;
 		});
 	});
 
-	describe('when the advancedSearchUrl property has been set then', function() {
-		it('should render the advanced search link', function() {
-			var link = widget.querySelector('.advanced-search-link > a');
-			expect(link.getAttribute('href')).length.to.be.above(0);
-			expect(widget.$.advancedSearchLink.getAttribute('class')).to.not.contain('d2l-all-courses-hidden');
+	describe('advanced search link', function() {
+		it('should not render when advancedSearchUrl is not set', function() {
+			widget.advancedSearchUrl = null;
+
+			expect(widget._showAdvancedSearchLink).to.be.false;
+			expect(widget.$$('.advanced-search-link').hasAttribute('hidden')).to.be.true;
+		});
+
+		it('should render when advancedSearchUrl is set', function() {
+			widget.advancedSearchUrl = '/test/url';
+
+			expect(widget._showAdvancedSearchLink).to.be.true;
+			expect(widget.$$('.advanced-search-link').hasAttribute('hidden')).to.be.false;
 		});
 	});
 

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -605,7 +605,7 @@ describe('<d2l-course-tile>', function() {
 
 		it('should show update number when less than 99', function() {
 			widget._setCourseUpdates(85);
-			expect(widget.$.courseUpdates.getAttribute('class')).to.not.contain('d2l-updates-hidden');
+			expect(widget.$.courseUpdates.hasAttribute('hidden')).to.be.false;
 			expect(widget._courseUpdates).to.equal(85);
 			expect(widget.$$('.update-text-box').innerText).to.equal('85');
 
@@ -613,14 +613,14 @@ describe('<d2l-course-tile>', function() {
 
 		it('should show 99 when 99 updates', function() {
 			widget._setCourseUpdates(99);
-			expect(widget.$.courseUpdates.getAttribute('class')).to.not.contain('d2l-updates-hidden');
+			expect(widget.$.courseUpdates.hasAttribute('hidden')).to.be.false;
 			expect(widget._courseUpdates).to.equal(99);
 			expect(widget.$$('.update-text-box').innerText).to.equal('99');
 		});
 
 		it('should show 99+ when more than 99 updates', function() {
 			widget._setCourseUpdates(100);
-			expect(widget.$.courseUpdates.getAttribute('class')).to.not.contain('d2l-updates-hidden');
+			expect(widget.$.courseUpdates.hasAttribute('hidden')).to.be.false;
 			expect(widget._courseUpdates).to.equal('99+');
 			expect(widget.$$('.update-text-box').innerText).to.equal('99+');
 
@@ -628,13 +628,13 @@ describe('<d2l-course-tile>', function() {
 
 		it('should not show updates number when 0', function() {
 			widget._setCourseUpdates(0);
-			expect(widget.$.courseUpdates.getAttribute('class')).to.contain('d2l-updates-hidden');
+			expect(widget.$.courseUpdates.hasAttribute('hidden')).to.be.true;
 			expect(widget.$$('.update-text-box').innerText).to.equal('0');
 		});
 
 		it('should not display when given less than 0', function() {
 			widget._setCourseUpdates(-1);
-			expect(widget.$.courseUpdates.getAttribute('class')).to.contain('d2l-updates-hidden');
+			expect(widget.$.courseUpdates.hasAttribute('hidden')).to.be.true;
 			expect(widget.$$('.update-text-box').innerText).to.equal('0');
 		});
 	});


### PR DESCRIPTION
Yeeeaaah, this is kinda out of nowhere, but didn't want to to inflate another PR. This just leverages the `hidden` attribute more (and computed properties, where possible), and explicitly `toggleClass`-ing less. I personally find this method a lot easier to read, as it includes any hide/unhide stuff in the DOM, which is always nice. Thoughts/opinions?

I've confirmed that the things I touched here (main content, overlay content, notifications, advanced search URL, and infinite-scroll-spinner) all continue to work as intended.