### PR TITLE
Pick correct filtering action more robustly

### DIFF
--- a/d2l-filter-menu/d2l-filter-menu-tab-roles.html
+++ b/d2l-filter-menu/d2l-filter-menu-tab-roles.html
@@ -104,11 +104,8 @@
 			},
 			_onMenuItemChange: function(e) {
 				var changeFilterAction;
-				if (e.detail.selected) {
-					changeFilterAction = e.detail.value.getActionByName('add-filter');
-				} else {
-					changeFilterAction = e.detail.value.getActionByName('remove-filter');
-				}
+				changeFilterAction = e.detail.value.getActionByName('add-filter')
+					|| e.detail.value.getActionByName('remove-filter');
 				// Create the URL to add/remove the filter to overall filter
 				var addRemoveUrl = this.createActionUrl(changeFilterAction);
 


### PR DESCRIPTION
On occasion, if you select/deselect filters fast enough (before the new response comes back), you can get into an error state here. Rather than explicitly selecting the action, we can just select whichever one is there.