### PR TITLE
DE27982 Combine role filters with the same name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "d2l-course-image": "Brightspace/course-image#^1.2.0",
     "d2l-dropdown": "^5.0.6",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.5.1",
-    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.8.1",
+    "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^2.10.0",
     "d2l-icons": "^3.2.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^2.0.1",
     "d2l-link": "^3.5.0",

--- a/d2l-filter-menu/d2l-filter-menu-tab-roles.html
+++ b/d2l-filter-menu/d2l-filter-menu-tab-roles.html
@@ -1,4 +1,5 @@
 <link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-menu/d2l-menu.html">
 <link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../d2l-utility-behavior.html">
@@ -58,6 +59,7 @@
 				}
 			},
 			behaviors: [
+				window.D2L.Hypermedia.HMConstantsBehavior,
 				window.D2L.MyCourses.UtilityBehavior
 			],
 			listeners: {
@@ -73,10 +75,11 @@
 				// This should instead use a `clear-role-filters` action from the API
 				// (which would do effectively the same thing), but it doesn't exist yet
 				var myEnrollmentsEntity = this.parseEntity(this.myEnrollmentsEntity);
-				if (!myEnrollmentsEntity.hasActionByName('set-role-filters')) {
+				var actionName = this.HypermediaActions.enrollments.setRoleFilters;
+				if (!myEnrollmentsEntity.hasActionByName(actionName)) {
 					return;
 				}
-				var setRoleFiltersAction = myEnrollmentsEntity.getActionByName('set-role-filters');
+				var setRoleFiltersAction = myEnrollmentsEntity.getActionByName(actionName);
 				var clearRoleFiltersUrl = this.createActionUrl(setRoleFiltersAction, {
 					include: ''
 				});
@@ -97,11 +100,12 @@
 			},
 			_myEnrollmentsEntityChanged: function(myEnrollmentsEntity) {
 				myEnrollmentsEntity = this.parseEntity(myEnrollmentsEntity);
-				if (!myEnrollmentsEntity.hasActionByName('set-role-filters')) {
+				var actionName = this.HypermediaActions.enrollments.setRoleFilters;
+				if (!myEnrollmentsEntity.hasActionByName(actionName)) {
 					return;
 				}
 
-				var setRoleFiltersAction = myEnrollmentsEntity.getActionByName('set-role-filters');
+				var setRoleFiltersAction = myEnrollmentsEntity.getActionByName(actionName);
 				var setRoleFiltersUrl = this.createActionUrl(setRoleFiltersAction);
 
 				this._fetchFilterItems(setRoleFiltersUrl);
@@ -109,9 +113,9 @@
 			_onMenuItemChange: function(e) {
 				var actionName;
 				if (e.detail.selected) {
-					actionName = 'add-filter';
+					actionName = this.HypermediaActions.enrollments.roleFilters.addFilter;
 				} else {
-					actionName = 'remove-filter';
+					actionName = this.HypermediaActions.enrollments.roleFilters.removeFilter;
 				}
 
 				var filters = e.detail.value;
@@ -126,11 +130,16 @@
 					request = request.then(function(newFiltersEntity) {
 						// The first fetchSirenEntity will change the entities, so grab the updated
 						// filter from the newly-updated role filters (based on role href)
-						var selfHref = filter.getLinkByRel('related').href;
+						if (!filter.hasLinkByRel('related')) {
+							return Promise.resolve();
+						}
+						var relatedHref = filter.getLinkByRel('related').href;
+
 						var newFilter = newFiltersEntity.entities.find(function(entity) {
-							return entity.getLinkByRel('related').href === selfHref;
+							var link = entity.getLinkByRel('related');
+							return link ? link.href === relatedHref : false;
 						});
-						if (!newFilter) {
+						if (!newFilter || !newFilter.hasActionByName(actionName)) {
 							// In the event the next filter from the event no longer appears, skip it
 							return Promise.resolve();
 						}
@@ -147,7 +156,9 @@
 			},
 			_applyRoleFilters: function() {
 				// Use the apply-role-filters action to create the new searchUrl
-				var applyAction = this._roleFiltersEntity.getActionByName('apply-role-filters');
+				var applyAction = this._roleFiltersEntity.getActionByName(
+					this.HypermediaActions.enrollments.roleFilters.applyRoleFilters
+				);
 				var searchUrl = this.createActionUrl(applyAction);
 				var roles = applyAction.getFieldByName('roles').value;
 				this.fire('role-filters-changed', {

--- a/d2l-filter-menu/d2l-filter-menu-tab-roles.html
+++ b/d2l-filter-menu/d2l-filter-menu-tab-roles.html
@@ -19,10 +19,10 @@
 
 		<div hidden$="[[!_showContent]]">
 			<d2l-menu label="[[menuLabelText]]">
-				<template is="dom-repeat" items="[[_filterItems]]">
+				<template is="dom-repeat" items="[[_filters]]">
 					<d2l-filter-list-item-role
 						text="[[item.title]]"
-						value="[[item]]">
+						value="[[item.filters]]">
 					</d2l-filter-list-item-role>
 				</template>
 			</d2l-menu>
@@ -44,7 +44,11 @@
 				menuLabelText: String,
 				noFiltersText: String,
 				_roleFiltersEntity: Object,
-				_filterItems: {
+				_filters: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_filterEntities: {
 					type: Array,
 					value: function() { return []; }
 				},
@@ -103,34 +107,81 @@
 				this._fetchFilterItems(setRoleFiltersUrl);
 			},
 			_onMenuItemChange: function(e) {
-				var changeFilterAction;
+				var actionName;
 				if (e.detail.selected) {
-					changeFilterAction = e.detail.value.getActionByName('add-filter');
+					actionName = 'add-filter';
 				} else {
-					changeFilterAction = e.detail.value.getActionByName('remove-filter');
+					actionName = 'remove-filter';
 				}
-				// Create the URL to add/remove the filter to overall filter
-				var addRemoveUrl = this.createActionUrl(changeFilterAction);
 
-				this._fetchFilterItems(addRemoveUrl)
-					.then(function() {
-						// Use the apply-role-filters action to create the new searchUrl
-						var applyAction = this._roleFiltersEntity.getActionByName('apply-role-filters');
-						var searchUrl = this.createActionUrl(applyAction);
-						var roles = applyAction.getFieldByName('roles').value;
-						this.fire('role-filters-changed', {
-							url: searchUrl,
-							filterCount: roles.length ? roles.split(',').length : 0
+				var filters = e.detail.value;
+
+				// Create the URL to add/remove the (first) filter
+				var changeFilterAction = filters[0].getActionByName(actionName);
+				var addRemoveUrl = this.createActionUrl(changeFilterAction);
+				var request = this.fetchSirenEntity(addRemoveUrl);
+
+				for (var i = 1; i < filters.length; i++) {
+					var filter = filters[i];
+					request = request.then(function(newFiltersEntity) {
+						// The first fetchSirenEntity will change the entities, so grab the updated
+						// filter from the newly-updated role filters (based on role href)
+						var selfHref = filter.getLinkByRel('related').href;
+						var newFilter = newFiltersEntity.entities.find(function(entity) {
+							return entity.getLinkByRel('related').href === selfHref;
 						});
+						if (!newFilter) {
+							// In the event the next filter from the event no longer appears, skip it
+							return Promise.resolve();
+						}
+
+						var action = newFilter.getActionByName(actionName);
+						var url = this.createActionUrl(action);
+						return this.fetchSirenEntity(url);
 					}.bind(this));
+				}
+
+				request = request.then(this._parseFilterItems.bind(this));
+
+				return request.then(this._applyRoleFilters.bind(this));
+			},
+			_applyRoleFilters: function() {
+				// Use the apply-role-filters action to create the new searchUrl
+				var applyAction = this._roleFiltersEntity.getActionByName('apply-role-filters');
+				var searchUrl = this.createActionUrl(applyAction);
+				var roles = applyAction.getFieldByName('roles').value;
+				this.fire('role-filters-changed', {
+					url: searchUrl,
+					filterCount: roles.length ? roles.split(',').length : 0
+				});
 			},
 			_fetchFilterItems: function(url) {
 				return this.fetchSirenEntity(url)
-					.then(function(roleFiltersEntity) {
-						this._roleFiltersEntity = roleFiltersEntity;
-						this._filterItems = this._roleFiltersEntity.entities || [];
-						this._showContent = this._filterItems.length > 0;
-					}.bind(this));
+					.then(this._parseFilterItems.bind(this));
+			},
+			_parseFilterItems: function(roleFiltersEntity) {
+				this._roleFiltersEntity = roleFiltersEntity;
+				this._filterEntities = this._roleFiltersEntity.entities || [];
+
+				var filters = [];
+				// DE27982 - Filters with the same title should be combined into one item
+				this._filterEntities.forEach(function(filterEntity) {
+					var existingFilter = filters.find(function(filter) {
+						return filter.title === filterEntity.title;
+					});
+
+					if (existingFilter) {
+						existingFilter.filters.push(filterEntity);
+					} else {
+						filters.push({
+							title: filterEntity.title,
+							filters: [filterEntity]
+						});
+					}
+				});
+				this._filters = filters;
+
+				this._showContent = this._filterEntities.length > 0;
 			}
 		});
 	</script>

--- a/d2l-filter-menu/d2l-filter-menu-tab-roles.html
+++ b/d2l-filter-menu/d2l-filter-menu-tab-roles.html
@@ -20,10 +20,10 @@
 
 		<div hidden$="[[!_showContent]]">
 			<d2l-menu label="[[menuLabelText]]">
-				<template is="dom-repeat" items="[[_filters]]">
+				<template is="dom-repeat" items="[[_filterTitles]]">
 					<d2l-filter-list-item-role
-						text="[[item.title]]"
-						value="[[item.filters]]">
+						text="[[item]]"
+						value="[[item]]">
 					</d2l-filter-list-item-role>
 				</template>
 			</d2l-menu>
@@ -45,11 +45,7 @@
 				menuLabelText: String,
 				noFiltersText: String,
 				_roleFiltersEntity: Object,
-				_filters: {
-					type: Array,
-					value: function() { return []; }
-				},
-				_filterEntities: {
+				_filterTitles: {
 					type: Array,
 					value: function() { return []; }
 				},
@@ -118,41 +114,40 @@
 					actionName = this.HypermediaActions.enrollments.roleFilters.removeFilter;
 				}
 
-				var filters = e.detail.value;
+				var filterTitle = e.detail.value;
 
-				// Create the URL to add/remove the (first) filter
-				var changeFilterAction = filters[0].getActionByName(actionName);
-				var addRemoveUrl = this.createActionUrl(changeFilterAction);
-				var request = this.fetchSirenEntity(addRemoveUrl);
+				var filter = this._findNextFilter(this._roleFiltersEntity.entities, filterTitle, actionName);
+				var action = filter.getActionByName(actionName);
+				var url = this.createActionUrl(action);
+				var request = this.fetchSirenEntity(url);
 
-				for (var i = 1; i < filters.length; i++) {
-					var filter = filters[i];
-					request = request.then(function(newFiltersEntity) {
-						// The first fetchSirenEntity will change the entities, so grab the updated
-						// filter from the newly-updated role filters (based on role href)
-						if (!filter.hasLinkByRel('related')) {
-							return Promise.resolve();
-						}
-						var relatedHref = filter.getLinkByRel('related').href;
-
-						var newFilter = newFiltersEntity.entities.find(function(entity) {
-							var link = entity.getLinkByRel('related');
-							return link ? link.href === relatedHref : false;
-						});
-						if (!newFilter || !newFilter.hasActionByName(actionName)) {
-							// In the event the next filter from the event no longer appears, skip it
-							return Promise.resolve();
+				for (var i = 1; i < this._roleFiltersEntity.entities.length; i++) {
+					request = request.then(function(updatedFilters) {
+						var filter = this._findNextFilter(updatedFilters.entities, filterTitle, actionName);
+						// If there aren't any more "off" filters with the desired title, skip through to end
+						if (!filter) {
+							return Promise.resolve(updatedFilters);
 						}
 
-						var action = newFilter.getActionByName(actionName);
+						// Create the URL to enable the next correctly-titled, "off" filter
+						var action = filter.getActionByName(actionName);
 						var url = this.createActionUrl(action);
 						return this.fetchSirenEntity(url);
 					}.bind(this));
 				}
 
-				request = request.then(this._parseFilterItems.bind(this));
-
-				return request.then(this._applyRoleFilters.bind(this));
+				return request
+					.then(this._parseFilterItems.bind(this))
+					.then(this._applyRoleFilters.bind(this));
+			},
+			_findNextFilter: function(array, title, actionName) {
+				// This could easily be replaced with Array.prototype.find, but... IE.
+				for (var i = 0; i < array.length; i++) {
+					var filter = array[i];
+					if (filter.title === title && filter.hasActionByName(actionName)) {
+						return filter;
+					}
+				}
 			},
 			_applyRoleFilters: function() {
 				// Use the apply-role-filters action to create the new searchUrl
@@ -160,10 +155,9 @@
 					this.HypermediaActions.enrollments.roleFilters.applyRoleFilters
 				);
 				var searchUrl = this.createActionUrl(applyAction);
-				var roles = applyAction.getFieldByName('roles').value;
 				this.fire('role-filters-changed', {
 					url: searchUrl,
-					filterCount: roles.length ? roles.split(',').length : 0
+					filterCount: this.querySelectorAll('d2l-filter-list-item-role[selected]').length
 				});
 			},
 			_fetchFilterItems: function(url) {
@@ -172,27 +166,18 @@
 			},
 			_parseFilterItems: function(roleFiltersEntity) {
 				this._roleFiltersEntity = roleFiltersEntity;
-				this._filterEntities = this._roleFiltersEntity.entities || [];
+				this._roleFiltersEntity.entities = this._roleFiltersEntity.entities || [];
 
-				var filters = [];
 				// DE27982 - Filters with the same title should be combined into one item
-				this._filterEntities.forEach(function(filterEntity) {
-					var existingFilter = filters.find(function(filter) {
-						return filter.title === filterEntity.title;
-					});
-
-					if (existingFilter) {
-						existingFilter.filters.push(filterEntity);
-					} else {
-						filters.push({
-							title: filterEntity.title,
-							filters: [filterEntity]
-						});
+				var uniqueTitles = [];
+				this._roleFiltersEntity.entities.forEach(function(filterEntity) {
+					if (uniqueTitles.indexOf(filterEntity.title) === -1) {
+						uniqueTitles.push(filterEntity.title);
 					}
 				});
-				this._filters = filters;
+				this._filterTitles = uniqueTitles;
 
-				this._showContent = this._filterEntities.length > 0;
+				this._showContent = this._roleFiltersEntity.entities.length > 0;
 			}
 		});
 	</script>

--- a/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
+++ b/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
@@ -102,7 +102,7 @@ describe('d2l-filter-menu-tab-roles', function() {
 
 				component.fire('d2l-menu-item-change', {
 					selected: testCase.selected,
-					value: roleFilterEntity
+					value: [roleFilterEntity]
 				});
 			});
 		});
@@ -119,7 +119,44 @@ describe('d2l-filter-menu-tab-roles', function() {
 
 			component.fire('d2l-menu-item-change', {
 				selected: true,
-				value: roleFilterEntity
+				value: [roleFilterEntity]
+			});
+		});
+
+		it('should work with multiple filters in the event', function(done) {
+			var filter = {
+				actions: [{
+					name: 'add-filter',
+					href: 'http://example.com/add'
+				}],
+				rel: ['foo'],
+				links: [{
+					rel: ['related'],
+					href: 'http://example.com/roles/1'
+				}]
+			};
+			component.fetchSirenEntity = sandbox.stub().returns(Promise.resolve(parse({
+				entities: [filter, filter],
+				actions: [{
+					name: 'apply-role-filters',
+					href: 'http://example.com',
+					fields: [{
+						name: 'roles',
+						value: ''
+					}]
+				}]
+			})));
+			var listener = function() {
+				component.removeEventListener('role-filters-changed', listener);
+				// Once per filter in event.detail.value
+				expect(component.fetchSirenEntity.callCount).to.equal(2);
+				done();
+			};
+			component.addEventListener('role-filters-changed', listener);
+
+			component.fire('d2l-menu-item-change', {
+				selected: true,
+				value: [parse(filter), parse(filter)]
 			});
 		});
 	});

--- a/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
+++ b/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
@@ -182,4 +182,34 @@ describe('d2l-filter-menu-tab-roles', function() {
 			});
 		});
 	});
+
+	describe('_parseFilterItems', function() {
+		it('should have separate entries for filters with different title attributes', function() {
+			component._parseFilterItems({
+				entities: [{
+					title: 'foo',
+					rel: ['filter']
+				}, {
+					title: 'bar',
+					rel: ['filter']
+				}]
+			});
+
+			expect(component._filters.length).to.equal(2);
+		});
+
+		it('should combine entries for filters with the same title attribute', function() {
+			component._parseFilterItems({
+				entities: [{
+					title: 'foo',
+					rel: ['filter']
+				}, {
+					title: 'foo',
+					rel: ['filter']
+				}]
+			});
+
+			expect(component._filters.length).to.equal(1);
+		});
+	});
 });

--- a/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
+++ b/test/d2l-filter-menu/d2l-filter-menu-tab-roles.js
@@ -5,11 +5,25 @@
 var sandbox,
 	component,
 	myEnrollmentsEntity,
-	roleFilterEntity,
 	roleFiltersEntity;
 
 function parse(entity) {
 	return window.D2L.Hypermedia.Siren.Parse(entity);
+}
+
+function getFilter(name, onOrOff) {
+	return {
+		rel: ['filter'],
+		class: [onOrOff || 'off'],
+		title: name,
+		actions: [{
+			name: 'add-filter',
+			href: 'http://example.com/add'
+		}, {
+			name: 'remove-filter',
+			href: 'http://example.com/remove'
+		}]
+	};
 }
 
 beforeEach(function() {
@@ -24,16 +38,8 @@ beforeEach(function() {
 			}]
 		}]
 	};
-	roleFilterEntity = parse({
-		actions: [{
-			name: 'add-filter',
-			href: 'http://example.com/add'
-		}, {
-			name: 'remove-filter',
-			href: 'http://example.com/remove'
-		}]
-	});
 	roleFiltersEntity = parse({
+		entities: [getFilter('foo')],
 		actions: [{
 			name: 'apply-role-filters',
 			href: 'http://example.com',
@@ -92,6 +98,7 @@ describe('d2l-filter-menu-tab-roles', function() {
 			{ name: 'should remove the filter when de-selected', url: 'http://example.com/remove', selected: false }
 		].forEach(function(testCase) {
 			it(testCase.name, function(done) {
+				component._roleFiltersEntity = roleFiltersEntity;
 				component.fetchSirenEntity = sandbox.stub().returns(Promise.resolve(roleFiltersEntity));
 				var listener = function() {
 					component.removeEventListener('role-filters-changed', listener);
@@ -102,53 +109,41 @@ describe('d2l-filter-menu-tab-roles', function() {
 
 				component.fire('d2l-menu-item-change', {
 					selected: testCase.selected,
-					value: [roleFilterEntity]
+					value: 'foo'
 				});
 			});
 		});
 
-		it('should fire a role-filters-changed event with the new URL and filterCount', function(done) {
+		it('should fire a role-filters-changed event with the new URL', function(done) {
+			component._roleFiltersEntity = roleFiltersEntity;
 			component.fetchSirenEntity = sandbox.stub().returns(Promise.resolve(roleFiltersEntity));
 			var listener = function(e) {
 				component.removeEventListener('role-filters-changed', listener);
 				expect(e.detail.url).to.equal('http://example.com?roles=1,2,3,4');
-				expect(e.detail.filterCount).to.equal(4);
 				done();
 			};
 			component.addEventListener('role-filters-changed', listener);
 
 			component.fire('d2l-menu-item-change', {
 				selected: true,
-				value: [roleFilterEntity]
+				value: 'foo'
 			});
 		});
 
-		it('should work with multiple filters in the event', function(done) {
-			var filter = {
-				actions: [{
-					name: 'add-filter',
-					href: 'http://example.com/add'
-				}],
-				rel: ['foo'],
-				links: [{
-					rel: ['related'],
-					href: 'http://example.com/roles/1'
-				}]
-			};
-			component.fetchSirenEntity = sandbox.stub().returns(Promise.resolve(parse({
-				entities: [filter, filter],
-				actions: [{
-					name: 'apply-role-filters',
-					href: 'http://example.com',
-					fields: [{
-						name: 'roles',
-						value: ''
-					}]
-				}]
-			})));
+		it('should work with a filter title that corresponds to more than one filter', function(done) {
+			var filterOn = getFilter('foo', 'on');
+			var filterOff = getFilter('foo', 'off');
+			component._roleFiltersEntity = parse({ entities: [filterOff, filterOff] });
+			component.createActionUrl = sinon.stub();
+
+			var stub = sandbox.stub();
+			stub.onFirstCall().returns(Promise.resolve(parse({ entities: [filterOn, filterOff] })));
+			stub.onSecondCall().returns(Promise.resolve(parse({ entities: [filterOn, filterOn] })));
+			component.fetchSirenEntity = stub;
+
 			var listener = function() {
 				component.removeEventListener('role-filters-changed', listener);
-				// Once per filter in event.detail.value
+				// Once per filter with the name 'foo'
 				expect(component.fetchSirenEntity.callCount).to.equal(2);
 				done();
 			};
@@ -156,14 +151,14 @@ describe('d2l-filter-menu-tab-roles', function() {
 
 			component.fire('d2l-menu-item-change', {
 				selected: true,
-				value: [parse(filter), parse(filter)]
+				value: 'foo'
 			});
 		});
 	});
 
 	describe('clear', function() {
 		it('should reset the "selected" state to false on all filter items', function() {
-			component._filterItems = [{ title: 'one' }, { title: 'two' }, { title: 'three' }];
+			component._filterTitles = [ 'one', 'two', 'three' ];
 			var filters = component.$$('d2l-menu').querySelectorAll('d2l-filter-list-item-role');
 			filters.forEach(function(item) {
 				item.selected = true;
@@ -185,31 +180,15 @@ describe('d2l-filter-menu-tab-roles', function() {
 
 	describe('_parseFilterItems', function() {
 		it('should have separate entries for filters with different title attributes', function() {
-			component._parseFilterItems({
-				entities: [{
-					title: 'foo',
-					rel: ['filter']
-				}, {
-					title: 'bar',
-					rel: ['filter']
-				}]
-			});
+			component._parseFilterItems({ entities: [getFilter('foo'), getFilter('bar')] });
 
-			expect(component._filters.length).to.equal(2);
+			expect(component._filterTitles.length).to.equal(2);
 		});
 
 		it('should combine entries for filters with the same title attribute', function() {
-			component._parseFilterItems({
-				entities: [{
-					title: 'foo',
-					rel: ['filter']
-				}, {
-					title: 'foo',
-					rel: ['filter']
-				}]
-			});
+			component._parseFilterItems({ entities: [getFilter('foo'), getFilter('foo') ]});
 
-			expect(component._filters.length).to.equal(1);
+			expect(component._filterTitles.length).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
This isn't a super performant approach, although it is probably the most robust this can be approached (that I can think of). The idea is that we combine role filters with the same name (easy enough), and when a multi-filter item is selected, we make subsequent "add-filter" action calls for each of the individual filters. This needs to be sequentially, unfortunately - doing them in parallel would just end up in a state where only one is enabled - but it's probably "fast enough", especially once things are cached. If we want to hide the loading, it might also be a good idea to disable further input in the filter menu until the result set is actually updated.