### PR TITLE
De27941: Unpinning course in My Courses doesn't update course list dropdown

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -281,7 +281,7 @@
 				if (!this._setImageOrg) {
 					return;
 				}
-				return this._getOrgUnitIdFromLink(this.getEntityIdentifier(this._setImageOrg));
+				return this._getOrgUnitIdFromHref(this.getEntityIdentifier(this._setImageOrg));
 			},
 
 			/*
@@ -302,7 +302,7 @@
 			},
 			_onEnrollmentPinAction: function(e) {
 				var isPinned = e.type === 'enrollment-pinned';
-				var orgUnitId = this._getOrgUnitIdFromLink(this.getEntityIdentifier(e.detail.organization));
+				var orgUnitId = this._getOrgUnitIdFromHref(this.getEntityIdentifier(e.detail.organization));
 
 				if (!orgUnitId) {
 					return;
@@ -528,8 +528,8 @@
 						}
 					}
 
-					var orgLink = enrollment.getLinkByRel(this.HypermediaRels.organization);
-					var orgUnitId = this._getOrgUnitIdFromLink(orgLink);
+					var orgHref = (enrollment.getLinkByRel(this.HypermediaRels.organization) || {}).href;
+					var orgUnitId = this._getOrgUnitIdFromHref(orgHref);
 					if (!this.orgUnitIdMap.hasOwnProperty(orgUnitId)) {
 						this.orgUnitIdMap[orgUnitId] = enrollment;
 					}
@@ -625,8 +625,8 @@
 			_refreshPage: function() {
 				document.location.reload(true);
 			},
-			_getOrgUnitIdFromLink: function(organizationHref) {
-				var match = /[0-9]+$/.exec((organizationHref || {}).href);
+			_getOrgUnitIdFromHref: function(organizationHref) {
+				var match = /[0-9]+$/.exec(organizationHref);
 
 				if (!match) {
 					return;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -239,13 +239,14 @@
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
+				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
 				this._onEnrollmentPinnedMessage = this._onEnrollmentPinnedMessage.bind(this);
 			},
 			attached: function() {
 				this.performanceMark('d2l.my-courses.attached');
 				this._fetchRoot();
 
-				document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage.bind(this), true);
+				document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 			},

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -316,20 +316,19 @@
 				);
 			},
 			_onEnrollmentPinnedMessage: function(e) {
-				if (e.target !== this) {
-					var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
+				if (e.target === this) return;
 
-					if (enrollment) {
-						if (e.detail.isPinned) {
-							this._moveEnrollmentToPinnedList(enrollment);
-						} else {
-							this._moveEnrollmentToUnpinnedList(enrollment);
-						}
-						setTimeout(this._onStartedInactiveAlert.bind(this), 50);
+				var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
+				if (enrollment) {
+					if (e.detail.isPinned) {
+						this._moveEnrollmentToPinnedList(enrollment);
 					} else {
-						this.fetchSirenEntity(this.enrollmentsUrl)
-							.then(this._refetchEnrollments.bind(this));
+						this._moveEnrollmentToUnpinnedList(enrollment);
 					}
+					setTimeout(this._onStartedInactiveAlert.bind(this), 50);
+				} else {
+					this.fetchSirenEntity(this.enrollmentsUrl)
+						.then(this._refetchEnrollments.bind(this));
 				}
 			},
 			_onStartedInactiveAlert: function(e) {
@@ -469,7 +468,18 @@
 
 				this.performanceMark('d2l.my-courses.search-enrollments.request');
 				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
+					.then(this._enrollmentsResponsePerfMeasures.bind(this))
 					.then(this._populateEnrollments.bind(this));
+			},
+			_enrollmentsResponsePerfMeasures: function(enrollmentsEntity) {
+				this.performanceMark('d2l.my-courses.search-enrollments.response');
+				this.performanceMeasure(
+					'd2l.my-courses.search-enrollments',
+					'd2l.my-courses.search-enrollments.request',
+					'd2l.my-courses.search-enrollments.response'
+				);
+
+				return Promise.resolve(enrollmentsEntity);
 			},
 			_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
 				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
@@ -487,30 +497,16 @@
 			},
 			_refetchEnrollments: function(enrollmentsRootEntity) {
 
-				this.performanceMark('d2l.my-courses.root-enrollments.response');
-				this.performanceMeasure(
-					'd2l.my-courses.root-enrollments',
-					'd2l.my-courses.root-enrollments.request',
-					'd2l.my-courses.root-enrollments.response'
-				);
-
 				if (!enrollmentsRootEntity.hasAction('search-my-enrollments')) {
 					return Promise.resolve();
 				}
 
 				var enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity, true);
 
-				this.performanceMark('d2l.my-courses..search-enrollments.request');
 				return this.fetchSirenEntity(enrollmentsSearchUrl)
 					.then(this._populateEnrollments.bind(this));
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
-				this.performanceMark('d2l.my-courses..search-enrollments.response');
-				this.performanceMeasure(
-					'd2l.my-courses.search-enrollments',
-					'd2l.my-courses.search-enrollments.request',
-					'd2l.my-courses.search-enrollments.response'
-				);
 
 				this._lastEnrollmentsSearchResponse = enrollmentsEntity;
 				var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -239,14 +239,13 @@
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
-				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
 				this._onEnrollmentPinnedMessage = this._onEnrollmentPinnedMessage.bind(this);
 			},
 			attached: function() {
 				this.performanceMark('d2l.my-courses.attached');
 				this._fetchRoot();
 
-				document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
+				document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage.bind(this), true);
 				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 			},

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -281,7 +281,7 @@
 				if (!this._setImageOrg) {
 					return;
 				}
-				return this._getOrgUnitId(this._setImageOrg);
+				return this._getOrgUnitIdFromLink(this.getEntityIdentifier(this._setImageOrg));
 			},
 
 			/*
@@ -302,7 +302,7 @@
 			},
 			_onEnrollmentPinAction: function(e) {
 				var isPinned = e.type === 'enrollment-pinned';
-				var orgUnitId = this._getOrgUnitId(e.detail.organization);
+				var orgUnitId = this._getOrgUnitIdFromLink(this.getEntityIdentifier(e.detail.organization));
 
 				if (!orgUnitId) {
 					return;
@@ -624,14 +624,6 @@
 			},
 			_refreshPage: function() {
 				document.location.reload(true);
-			},
-			_getOrgUnitId: function(organization) {
-				var match = /[0-9]+$/.exec(this.getEntityIdentifier(organization));
-
-				if (!match) {
-					return;
-				}
-				return match[0];
 			},
 			_getOrgUnitIdFromLink: function(organizationHref) {
 				var match = /[0-9]+$/.exec((organizationHref || {}).href);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -207,6 +207,10 @@
 							startMark: 'd2l.my-courses.tiles.first-organization'
 						}
 					}
+				},
+				orgUnitIdMap: {
+					type: Object,
+					value: function() { return {}; }
 				}
 			},
 			behaviors: [
@@ -236,13 +240,18 @@
 			],
 			ready: function() {
 				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
+				this._onEnrollmentPinnedMessage = this._onEnrollmentPinnedMessage.bind(this);
 			},
 			attached: function() {
 				this.performanceMark('d2l.my-courses.attached');
 				this._fetchRoot();
 
+				document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
+			},
+			detached: function() {
+ 				document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			},
 
 			/*
@@ -306,6 +315,25 @@
 					}
 				);
 			},
+			_onEnrollmentPinnedMessage: function(e) {
+ 				if (e.target !== this) {
+					// TODO: Not necessary once parsed down to orgUnitId
+					var orgUnitIdLink = 'http://KLX1-TJONES:44453/d2l/api/hm/organizations/' + e.detail.orgUnitId;
+ 					var enrollment = this.orgUnitIdMap[orgUnitIdLink];
+
+ 					if (enrollment) {
+ 						if (e.detail.isPinned) {
+ 							this._moveEnrollmentToPinnedList(enrollment);
+ 						} else {
+ 							this._moveEnrollmentToUnpinnedList(enrollment);
+ 						}
+ 						setTimeout(this._onStartedInactiveAlert.bind(this), 50);
+ 					} else {
+						this.fetchSirenEntity(this.enrollmentsUrl)
+							.then(this._refetchEnrollments.bind(this))
+ 					}
+ 				}
+ 			},
 			_onStartedInactiveAlert: function(e) {
 				var type = e && e.detail && e.detail.type;
 
@@ -439,6 +467,13 @@
 					return Promise.resolve();
 				}
 
+				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity)
+
+				this.performanceMark('d2l.my-courses.search-enrollments.request');
+				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
+					.then(this._populateEnrollments.bind(this));
+			},
+			_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
 				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
 
 				var query = {
@@ -447,15 +482,32 @@
 					sort: '-PinDate,OrgUnitName,OrgUnitId',
 					autoPinCourses: true
 				};
-				this._enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
+				var enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
+				if (bustCache) enrollmentsSearchUrl += '&bustCache=' + Math.random();
 
-				this.performanceMark('d2l.my-courses.search-enrollments.request');
-				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
+				return enrollmentsSearchUrl;
+			},
+			_refetchEnrollments: function(enrollmentsRootEntity) {
+
+				this.performanceMark('my-courses.root-enrollments.response');
+				this.performanceMeasure(
+					'my-courses.root-enrollments',
+					'my-courses.root-enrollments.request',
+					'my-courses.root-enrollments.response'
+				);
+
+				if (!enrollmentsRootEntity.hasAction('search-my-enrollments')) {
+					return Promise.resolve();
+				}
+
+				var enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity, true);
+
+				this.performanceMark('d2l.my-courses..search-enrollments.request');
+				return this.fetchSirenEntity(enrollmentsSearchUrl)
 					.then(this._populateEnrollments.bind(this));
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
-
-				this.performanceMark('d2l.my-courses.search-enrollments.response');
+				this.performanceMark('d2l.my-courses..search-enrollments.response');
 				this.performanceMeasure(
 					'd2l.my-courses.search-enrollments',
 					'd2l.my-courses.search-enrollments.request',
@@ -480,6 +532,13 @@
 							newUnpinnedEnrollments.push(enrollment);
 							this._unpinnedCoursesMap[enrollmentId] = true;
 						}
+					}
+
+					// TODO: This should be parsed down to just orgUnitId
+					var orgLink = enrollment.getLinkByRel(this.HypermediaRels.organization);
+					var orgUnitId = (orgLink || {}).href;
+					if (!this.orgUnitIdMap.hasOwnProperty(orgUnitId)) {
+						this.orgUnitIdMap[orgUnitId] = enrollment;
 					}
 				}, this);
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -487,11 +487,11 @@
 			},
 			_refetchEnrollments: function(enrollmentsRootEntity) {
 
-				this.performanceMark('my-courses.root-enrollments.response');
+				this.performanceMark('d2l.my-courses.root-enrollments.response');
 				this.performanceMeasure(
-					'my-courses.root-enrollments',
-					'my-courses.root-enrollments.request',
-					'my-courses.root-enrollments.response'
+					'd2l.my-courses.root-enrollments',
+					'd2l.my-courses.root-enrollments.request',
+					'd2l.my-courses.root-enrollments.response'
 				);
 
 				if (!enrollmentsRootEntity.hasAction('search-my-enrollments')) {

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -317,9 +317,7 @@
 			},
 			_onEnrollmentPinnedMessage: function(e) {
  				if (e.target !== this) {
-					// TODO: Not necessary once parsed down to orgUnitId
-					var orgUnitIdLink = 'http://KLX1-TJONES:44453/d2l/api/hm/organizations/' + e.detail.orgUnitId;
- 					var enrollment = this.orgUnitIdMap[orgUnitIdLink];
+ 					var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
 
  					if (enrollment) {
  						if (e.detail.isPinned) {
@@ -534,9 +532,8 @@
 						}
 					}
 
-					// TODO: This should be parsed down to just orgUnitId
 					var orgLink = enrollment.getLinkByRel(this.HypermediaRels.organization);
-					var orgUnitId = (orgLink || {}).href;
+					var orgUnitId = this._getOrgUnitIdFromLink(orgLink);
 					if (!this.orgUnitIdMap.hasOwnProperty(orgUnitId)) {
 						this.orgUnitIdMap[orgUnitId] = enrollment;
 					}
@@ -634,6 +631,14 @@
 			},
 			_getOrgUnitId: function(organization) {
 				var match = /[0-9]+$/.exec(this.getEntityIdentifier(organization));
+
+				if (!match) {
+					return;
+				}
+				return match[0];
+			},
+			_getOrgUnitIdFromLink: function(organizationHref) {
+				var match = /[0-9]+$/.exec((organizationHref || {}).href);
 
 				if (!match) {
 					return;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -251,7 +251,7 @@
 				this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 			},
 			detached: function() {
- 				document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
+				document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			},
 
 			/*
@@ -316,22 +316,22 @@
 				);
 			},
 			_onEnrollmentPinnedMessage: function(e) {
- 				if (e.target !== this) {
- 					var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
+				if (e.target !== this) {
+					var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
 
- 					if (enrollment) {
- 						if (e.detail.isPinned) {
- 							this._moveEnrollmentToPinnedList(enrollment);
- 						} else {
- 							this._moveEnrollmentToUnpinnedList(enrollment);
- 						}
- 						setTimeout(this._onStartedInactiveAlert.bind(this), 50);
- 					} else {
+					if (enrollment) {
+						if (e.detail.isPinned) {
+							this._moveEnrollmentToPinnedList(enrollment);
+						} else {
+							this._moveEnrollmentToUnpinnedList(enrollment);
+						}
+						setTimeout(this._onStartedInactiveAlert.bind(this), 50);
+					} else {
 						this.fetchSirenEntity(this.enrollmentsUrl)
-							.then(this._refetchEnrollments.bind(this))
- 					}
- 				}
- 			},
+							.then(this._refetchEnrollments.bind(this));
+					}
+				}
+			},
 			_onStartedInactiveAlert: function(e) {
 				var type = e && e.detail && e.detail.type;
 
@@ -465,7 +465,7 @@
 					return Promise.resolve();
 				}
 
-				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity)
+				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity);
 
 				this.performanceMark('d2l.my-courses.search-enrollments.request');
 				return this.fetchSirenEntity(this._enrollmentsSearchUrl)

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -358,17 +358,8 @@ describe('d2l-my-courses', function() {
 			});
 
 			it('should return correct org unit id from various href', function() {
-				var org = {
-					rel: ['self'],
-					href: '/organizations/671'
-				};
-				expect(widget._getOrgUnitIdFromLink(org)).to.equal('671');
-
-				org = {
-					rel: ['self'],
-					href: '/some/other/route/8798734534'
-				};
-				expect(widget._getOrgUnitIdFromLink(org)).to.equal('8798734534');
+				expect(widget._getOrgUnitIdFromHref('/organizations/671')).to.equal('671');
+				expect(widget._getOrgUnitIdFromHref('/some/other/route/8798734534')).to.equal('8798734534');
 			});
 		});
 


### PR DESCRIPTION
This more or less undoes [this commit](https://github.com/Brightspace/d2l-my-courses-ui/commit/1d331908094119ac69ff175d13eb7fcb24e09634#diff-37608caf11263d278dd1c2fa6da3bc3a) but updated to work with `enrolledUser`s.

This isn't a perfect or long term solution but it addresses the issue of pin state not syncing between the course selector and the my courses widget. The perfect solution would be for the course selector to pass `enrolledUser` links with the `pin-event` but that got into a mess of dependencies which would require some refactoring to the `D2L.LP.Tools` solution to work with the hypermedia/enrolled user stuff in the course selector. Since that will require a bigger refactor and it seems like we're heading into some course selector updates I'm going to create a story to work with `enrolledUser` in the Course Selector.

For now, what this fix does:
- Brings back the events listening for the `'d2l-course-pinned-change'`
- Added a map of the enrollments keyed with the `orgUnitId` so that the enrollments can be referenced to adding the the `_moveEnrollmentToPinnedList` and `_moveEnrollmentToUnpinnedList`.
- Added some code for refetching the enrollments, such that it doesn't get back the cached result. This is for when a course was pinned but not yet fetched, and since we can't call it back directly yet without the `enrolledUser` link we will need to fetch enrollments again.

What kinda stinks:
- No animation when unfetched course is pinned.
- Refetching every time a unfetched course is pinned.
- Still parsing out orgUnitId.

What it should do in the future (after `D2L.LP.Tools` refactor):
- Get enrolledUser link instead of orgUnitId.
- Get rid of orgUnitId map
- Get rid of refetch stuff

I will update the tests to this code as this goes through reviews