### PR TITLE
US91774 Use IntersectionObserver to lazy-load course tiles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,6 +35,7 @@
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^3.0.0",
     "d2l-icons": "^3.7.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^2.2.0",
+    "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import",
     "d2l-link": "^3.5.1",
     "d2l-loading-spinner": "^5.0.5",
     "d2l-localize-behavior": "^1.0.1",

--- a/d2l-all-courses.html
+++ b/d2l-all-courses.html
@@ -110,7 +110,6 @@
 					id="all-courses-pinned"
 					enrollments="[[_filteredPinnedEnrollments]]"
 					enrollments-to-animate="[[_pinnedEnrollmentsToAnimate]]"
-					delay-load="[[delayLoad]]"
 					tile-sizes="[[_tileSizes]]"
 					locale="[[locale]]"
 					show-course-code="[[showCourseCode]]"
@@ -135,7 +134,6 @@
 					id="all-courses-unpinned"
 					enrollments="[[_filteredUnpinnedEnrollments]]"
 					enrollments-to-animate="[[_unpinnedEnrollmentsToAnimate]]"
-					delay-load="[[delayLoad]]"
 					tile-sizes="[[_tileSizes]]"
 					locale="[[locale]]"
 					show-course-code="[[showCourseCode]]"
@@ -172,11 +170,6 @@
 				defaultSortValue: {
 					type: String,
 					value: 'OrgUnitName'
-				},
-				// Sets the delay-load property on the course tile grid
-				delayLoad: {
-					type: Boolean,
-					value: true
 				},
 				// Standard Department OU Type name to be displayed in the filter dropdown
 				filterStandardDepartmentName: String,
@@ -344,7 +337,6 @@
 				this._filteredPinnedEnrollments.forEach(function(enrollment) {
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
-				this.set('delayLoad', false);
 
 				requestAnimationFrame(function() {
 					this.fire('recalculate-columns');

--- a/d2l-course-tile-grid.html
+++ b/d2l-course-tile-grid.html
@@ -21,7 +21,6 @@
 					animate-insertion="[[_grid_shouldAnimateEnrollmentInsertion(item)]]"
 					class="grid-child"
 					enrollment-id="[[getEntityIdentifier(item)]]"
-					delay-load="[[delayLoad]]"
 					tile-sizes="[[tileSizes]]"
 					locale="[[locale]]"
 					show-course-code="[[showCourseCode]]"
@@ -46,8 +45,6 @@
 			is: 'd2l-course-tile-grid',
 
 			properties: {
-				// Sets the delay-load property on the course tiles
-				delayLoad: Boolean,
 				// Set of enrollment Entities for which to display course tiles
 				enrollments: {
 					type: Array,

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -218,7 +218,7 @@ the user has in that organization - student, teacher, TA, etc.
 					computed: '_computeShowPinIndicator(pinned, updatedSortLogic)'
 				},
 				// Set by the IntersectionObserver when tile is first visible in viewport
-				_isVisible: Boolean
+				_load: Boolean
 			},
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
@@ -230,7 +230,7 @@ the user has in that organization - student, teacher, TA, etc.
 				'animationend': '_onAnimationComplete'
 			},
 			observers: [
-				'_fetchEnrollmentData(_isVisible, enrollment)'
+				'_fetchEnrollmentData(_load, enrollment)'
 			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
@@ -245,14 +245,27 @@ the user has in that organization - student, teacher, TA, etc.
 							// so we need to also make sure the tile is visible for that first run
 							// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
 							if (entries[i].intersectionRatio > 0) {
-								this._isVisible = true;
-								observer.unobserve(this.$$('.tile-container'));
+								observer.unobserve(tileContainerEl);
+								this._load = true;
+								break;
 							}
+						}
+
+						if (!this._load) {
+							// Tile isn't visible - schedule it to load via requestIdleCallback
+
+							// Small shim for Edge/IE/Safari
+							var delayFunction = window.requestIdleCallback || setTimeout;
+
+							delayFunction(function() {
+								observer.unobserve(tileContainerEl);
+								this._load = true;
+							}.bind(this));
 						}
 					};
 
 					var observer = new IntersectionObserver(observerCallback.bind(this));
-					observer.observe(this.$$('.tile-container'));
+					observer.observe(tileContainerEl);
 				});
 			},
 			ready: function() {
@@ -405,7 +418,7 @@ the user has in that organization - student, teacher, TA, etc.
 				return Promise.resolve();
 			},
 			_fetchEnrollmentData: function() {
-				if (!this.enrollment || !this._isVisible) {
+				if (!this.enrollment || !this._load) {
 					return;
 				}
 

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -127,20 +127,8 @@ the user has in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					reflectToAttribute: true
 				},
-				// Delays initial loading of the organization until explicitly triggered by `loadOrganization`
-				delayLoad: {
-					type: Boolean,
-					observer: '_delayLoadChanged'
-				},
-				/*
-				* Course tile enrollment Entity. When the enrollment is set, the course
-				* tile will automatically fetch information about the organization the
-				* enrollment is in.
-				*/
-				enrollment: {
-					type: Object,
-					observer: '_enrollmentChanged'
-				},
+				// Course tile enrollment entity
+				enrollment: Object,
 				enrollmentId: String,
 				// Specifies whether the (desktop) hover menu is enabled on the course tile
 				hoverEnabled: {
@@ -227,7 +215,9 @@ the user has in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					value: false,
 					computed: '_computeShowPinIndicator(pinned, updatedSortLogic)'
-				}
+				},
+				// Set by the IntersectionObserver when tile is first visible in viewport
+				_isVisible: Boolean
 			},
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
@@ -238,13 +228,22 @@ the user has in that organization - student, teacher, TA, etc.
 			listeners: {
 				'animationend': '_onAnimationComplete'
 			},
+			observers: [
+				'_fetchEnrollmentData(_isVisible, enrollment)'
+			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this.fire('course-tile-first-render');
 					var tileContainerEl = this.$$('.tile-container');
 					document.body.addEventListener('focus', this._onFocus, true);
 					tileContainerEl.addEventListener('focus', this._hoverCourseTile, true);
-				}.bind(this));
+
+					var observer = new IntersectionObserver(function() {
+						this._isVisible = true;
+						observer.unobserve(this.$$('.tile-container'));
+					}.bind(this));
+					observer.observe(this.$$('.tile-container'));
+				});
 			},
 			ready: function() {
 				this._onFocus = this._onFocus.bind(this);
@@ -396,6 +395,17 @@ the user has in that organization - student, teacher, TA, etc.
 				return Promise.resolve();
 			},
 			_fetchEnrollmentData: function() {
+				if (!this.enrollment || !this._isVisible) {
+					return;
+				}
+
+				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
+
+				var organizationLink = this.enrollment.getLinkByRel(this.HypermediaRels.organization);
+				if (!this._organizationUrl || this._organizationUrl.indexOf(organizationLink.href) !== 0) {
+					this._organizationUrl = organizationLink.href + '?embedDepth=1';
+				}
+
 				return this._fetchOrganization()
 					.then(this._onOrganizationResponse.bind(this))
 					.then(function() {
@@ -405,24 +415,6 @@ the user has in that organization - student, teacher, TA, etc.
 								.then(this._onNotificationsResponse.bind(this))
 						]);
 					}.bind(this));
-			},
-			_enrollmentChanged: function() {
-				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
-
-				var organizationLink = this.enrollment.getLinkByRel(this.HypermediaRels.organization);
-
-				if (!this._organizationUrl || this._organizationUrl.indexOf(organizationLink.href) !== 0) {
-					this._organizationUrl = organizationLink.href + '?embedDepth=1';
-
-					if (!this.delayLoad) {
-						this._fetchEnrollmentData();
-					}
-				}
-			},
-			_delayLoadChanged: function(delayLoad) {
-				if (this.isAttached && !delayLoad && !this._organization) {
-					this._fetchEnrollmentData();
-				}
 			},
 			_displaySetImageResult: function(success, skipSetImage) {
 				var tileContainer = this.$$('.tile-container');

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -240,6 +240,11 @@ the user has in that organization - student, teacher, TA, etc.
 					tileContainerEl.addEventListener('focus', this._hoverCourseTile, true);
 
 					var observerCallback = function(entries, observer) {
+						if (this._load) {
+							// The tile already loaded via requestIdleCallback/setTimeout
+							return;
+						}
+
 						for (var i = 0; i < entries.length; i++) {
 							// Chrome/FF immediately call the callback when we observer.observe()
 							// so we need to also make sure the tile is visible for that first run
@@ -250,19 +255,20 @@ the user has in that organization - student, teacher, TA, etc.
 								break;
 							}
 						}
-
-						if (!this._load) {
-							// Tile isn't visible - schedule it to load via requestIdleCallback
-
-							// Small shim for Edge/IE/Safari
-							var delayFunction = window.requestIdleCallback || setTimeout;
-
-							delayFunction(function() {
-								observer.unobserve(tileContainerEl);
-								this._load = true;
-							}.bind(this));
-						}
 					};
+
+					// Small shim for Edge/IE/Safari
+					var delayFunction = window.requestIdleCallback || setTimeout;
+					delayFunction(function() {
+						if (this._load) {
+							// The tile already loaded via the IntersectionObserver
+							return;
+						}
+						// Whether we load because the tile became visible, or because we got some
+						// idle time, we want to disconnect the observer either way
+						observer.unobserve(tileContainerEl);
+						this._load = true;
+					}.bind(this));
 
 					var observer = new IntersectionObserver(observerCallback.bind(this));
 					observer.observe(tileContainerEl);

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -239,10 +239,19 @@ the user has in that organization - student, teacher, TA, etc.
 					document.body.addEventListener('focus', this._onFocus, true);
 					tileContainerEl.addEventListener('focus', this._hoverCourseTile, true);
 
-					var observer = new IntersectionObserver(function() {
-						this._isVisible = true;
-						observer.unobserve(this.$$('.tile-container'));
-					}.bind(this));
+					var observerCallback = function(entries, observer) {
+						for (var i = 0; i < entries.length; i++) {
+							// Chrome/FF immediately call the callback when we observer.observe()
+							// so we need to also make sure the tile is visible for that first run
+							// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
+							if (entries[i].intersectionRatio > 0) {
+								this._isVisible = true;
+								observer.unobserve(this.$$('.tile-container'));
+							}
+						}
+					};
+
+					var observer = new IntersectionObserver(observerCallback.bind(this));
 					observer.observe(this.$$('.tile-container'));
 				});
 			},

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -10,6 +10,7 @@
 <link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../d2l-polymer-behaviors/d2l-dom.html">
 <link rel="import" href="../iron-a11y-announcer/iron-a11y-announcer.html">
+<link rel="import" href="../d2l-intersection-observer-polyfill-import/intersection-observer.html">
 <link rel="import" href="d2l-course-tile-styles.html">
 <link rel="import" href="localize-behavior.html">
 <link rel="import" href="d2l-utility-behavior.html">

--- a/test/d2l-course-tile/d2l-course-tile.html
+++ b/test/d2l-course-tile/d2l-course-tile.html
@@ -16,12 +16,6 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="d2l-course-tile-fixture-delayed">
-			<template>
-				<d2l-course-tile delay-load></d2l-course-tile>
-			</template>
-		</test-fixture>
-
 		<script src="d2l-course-tile.js"></script>
 	</body>
 </html>

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -141,7 +141,7 @@ describe('<d2l-course-tile>', function() {
 		beforeEach(function(done) {
 			var spy = sandbox.spy(widget, '_onOrganizationResponse');
 
-			widget._isVisible = true;
+			widget._load = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {
@@ -283,7 +283,7 @@ describe('<d2l-course-tile>', function() {
 		beforeEach(function(done) {
 			var spy = sandbox.spy(widget, '_onOrganizationResponse');
 
-			widget._isVisible = true;
+			widget._load = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {
@@ -534,7 +534,7 @@ describe('<d2l-course-tile>', function() {
 				'/organizations/1?embedDepth=1',
 				[200, {}, JSON.stringify(organization)]);
 
-			widget._isVisible = true;
+			widget._load = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -137,21 +137,11 @@ describe('<d2l-course-tile>', function() {
 		expect(widget).to.exist;
 	});
 
-	it('should fetch the organization when the enrollment changes', function(done) {
-		var spy = sandbox.spy(widget, '_onOrganizationResponse');
-
-		widget.enrollment = enrollmentEntity;
-
-		setTimeout(function() {
-			expect(spy).to.have.been.calledOnce;
-			done();
-		});
-	});
-
 	describe('setting the enrollment attribute', function() {
 		beforeEach(function(done) {
 			var spy = sandbox.spy(widget, '_onOrganizationResponse');
 
+			widget._isVisible = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {
@@ -287,39 +277,13 @@ describe('<d2l-course-tile>', function() {
 		});
 	});
 
-	describe('delay-load attribute', function() {
-		it('should not fetch the organization if delay-load=true', function(done) {
-			var delayedWidget = fixture('d2l-course-tile-fixture-delayed');
-			delayedWidget._fetchOrganization = sandbox.stub().returns(Promise.resolve(organizationEntity));
-
-			delayedWidget.enrollment = enrollmentEntity;
-
-			setTimeout(function() {
-				expect(delayedWidget._fetchOrganization).to.have.not.been.called;
-				done();
-			});
-		});
-
-		it('should fetch the organization when delay-load is set to false', function(done) {
-			var delayedWidget = fixture('d2l-course-tile-fixture-delayed');
-			var spy = sandbox.spy(delayedWidget, '_onOrganizationResponse');
-			delayedWidget._fetchOrganization = sandbox.stub().returns(Promise.resolve(organizationEntity));
-
-			delayedWidget.delayLoad = false;
-
-			setTimeout(function() {
-				expect(delayedWidget._fetchOrganization).to.have.been.calledOnce;
-				expect(spy).to.have.been.calledOnce;
-				done();
-			});
-		});
-	});
-
 	describe('changing the pinned state', function() {
 		var event = { preventDefault: function() {} };
 
 		beforeEach(function(done) {
 			var spy = sandbox.spy(widget, '_onOrganizationResponse');
+
+			widget._isVisible = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {
@@ -340,7 +304,9 @@ describe('<d2l-course-tile>', function() {
 			widget._pinClickHandler(event);
 
 			setTimeout(function() {
-				expect(window.d2lfetch.fetch).to.have.been.calledOnce;
+				expect(window.d2lfetch.fetch).to.have.been
+					.calledWith(sinon.match.has('url', sinon.match('/enrollments/users/169/organizations/1'))
+						.and(sinon.match.has('method', 'PUT')));
 				done();
 			});
 		});
@@ -359,7 +325,9 @@ describe('<d2l-course-tile>', function() {
 			expect(widget.pinned).to.be.false;
 
 			setTimeout(function() {
-				expect(window.d2lfetch.fetch).to.have.been.calledOnce;
+				expect(window.d2lfetch.fetch).to.have.been
+					.calledWith(sinon.match.has('url', sinon.match('/enrollments/users/169/organizations/1'))
+						.and(sinon.match.has('method', 'PUT')));
 				// We responded with pinned = true, so it gets set back to true by the response
 				expect(widget.pinned).to.be.true;
 				done();
@@ -566,6 +534,7 @@ describe('<d2l-course-tile>', function() {
 				'/organizations/1?embedDepth=1',
 				[200, {}, JSON.stringify(organization)]);
 
+			widget._isVisible = true;
 			widget.enrollment = enrollmentEntity;
 
 			setTimeout(function() {


### PR DESCRIPTION
A primitive version of this behaviour already existed via the `delay-load` attribute, which was used to defer loading of course information for the tiles in the first fetch that weren't pinned. With `IntersectionObserver`, we are able to instead be more intelligent about this deferral, and simply load the course tile's information whenever it becomes partially visible to the user. It's quite neat and kinda makes me want to redo paging a bit, so that it feels more "infinite scroll"-y.

This includes a polyfill for Edge/IE (Firefox and Chrome support it natively).

TODO:

- [x] Get some performance numbers on this w.r.t. initial load