### PR TITLE
Use siren-parser-import

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -52,7 +52,8 @@
     "iron-menu-behavior": "^1.3.1",
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.3",
     "iron-pages": "^1.0.9",
-    "polymer": "^1.11.0"
+    "polymer": "^1.11.0",
+    "siren-parser-import": "Brightspace/siren-parser-import#^6.3.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.4.0"

--- a/d2l-utility-behavior.html
+++ b/d2l-utility-behavior.html
@@ -1,7 +1,7 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../siren-parser-import/siren-parser-global.html">
 <link rel="import" href="../d2l-fetch/d2l-fetch.html">
 
-<script src="https://s.brightspace.com/lib/siren-parser/6.1.0/siren-parser-global.js"></script>
 <script>
 	window.D2L = window.D2L || {};
 	window.D2L.MyCourses = window.D2L.MyCourses || {};


### PR DESCRIPTION
This replaces directly referencing the CDN script, which allows us to leverage bower versioning to know which version we're getting.