### PR TITLE
switching to use imported d2lIntl library instead of relying on BSI

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -53,7 +53,8 @@
     "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.3",
     "iron-pages": "^1.0.9",
     "polymer": "^1.11.0",
-    "siren-parser-import": "Brightspace/siren-parser-import#^6.3.1"
+    "siren-parser-import": "Brightspace/siren-parser-import#^6.3.1",
+    "d2l-intl-import": "^1.0.0"
   },
   "devDependencies": {
     "web-component-tester": "^6.4.0"

--- a/d2l-course-tile.html
+++ b/d2l-course-tile.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../d2l-icons/d2l-icons.html">
+<link rel="import" href="../d2l-intl-import/d2l-intl.html">
 <link rel="import" href="../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../d2l-menu/d2l-menu-item-link.html">
 <link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
@@ -603,9 +604,9 @@ the user has in that organization - student, teacher, TA, etc.
 			},
 			_setOverlayContent: function(type, date, inactive) {
 				this._clearOverlayContent();
-				if (!this._dateFormatter && window.BSI && window.BSI.Intl) {
-					this._dateFormatter = new window.BSI.Intl.DateTimeFormat(this.locale, { format: 'MMM d, yyyy' });
-					this._fullDateFormatter = new window.BSI.Intl.DateTimeFormat(this.locale, { format: 'MMMM d, yyyy' });
+				if (!this._dateFormatter && window.d2lIntl) {
+					this._dateFormatter = new window.d2lIntl.DateTimeFormat(this.locale, { format: 'MMM d, yyyy' });
+					this._fullDateFormatter = new window.d2lIntl.DateTimeFormat(this.locale, { format: 'MMMM d, yyyy' });
 				}
 
 				if (this._dateFormatter) {

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -675,8 +675,7 @@ describe('<d2l-course-tile>', function() {
 					isActive: true
 				}
 			};
-			window.BSI = window.BSI || {};
-			window.BSI.Intl = window.BSI.Intl || {
+			window.d2lIntl = {
 				DateTimeFormat: function() {
 					this.format = sinon.stub().returns(formattedDate);
 				}


### PR DESCRIPTION
This is a temporary first step towards a fix. Eventually, I want this to call into `d2l-localize-behavior` which will contain `d2lIntl`, but in the meantime I need to get it to stop referencing `BSI.Intl` because that's going away.