### PR TITLE
Move d2l-my-courses.html back

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,7 @@
     "widget"
   ],
   "homepage": "https://github.com/Brightspace/d2l-my-courses-ui",
-  "main": "src/d2l-my-courses.html",
+  "main": "d2l-my-courses.html",
   "private": true,
   "ignore": [
     "**/.*",

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,19 +1,19 @@
-<link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../../d2l-alert/d2l-alert.html">
-<link rel="import" href="../../d2l-fetch/d2l-fetch.html">
-<link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
-<link rel="import" href="../../d2l-link/d2l-link.html">
-<link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
-<link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
-<link rel="import" href="../../d2l-image-selector/d2l-basic-image-selector.html">
-<link rel="import" href="../../d2l-typography/d2l-typography-shared-styles.html">
-<link rel="import" href="d2l-alert-behavior.html">
-<link rel="import" href="d2l-all-courses.html">
-<link rel="import" href="d2l-course-management-behavior.html">
-<link rel="import" href="d2l-course-tile-grid.html">
-<link rel="import" href="d2l-utility-behavior.html">
-<link rel="import" href="localize-behavior.html">
+<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../d2l-alert/d2l-alert.html">
+<link rel="import" href="../d2l-fetch/d2l-fetch.html">
+<link rel="import" href="../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../d2l-link/d2l-link.html">
+<link rel="import" href="../d2l-loading-spinner/d2l-loading-spinner.html">
+<link rel="import" href="../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="../d2l-image-selector/d2l-basic-image-selector.html">
+<link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
+<link rel="import" href="src/d2l-alert-behavior.html">
+<link rel="import" href="src/d2l-all-courses.html">
+<link rel="import" href="src/d2l-course-management-behavior.html">
+<link rel="import" href="src/d2l-course-tile-grid.html">
+<link rel="import" href="src/d2l-utility-behavior.html">
+<link rel="import" href="src/localize-behavior.html">
 <dom-module id="d2l-my-courses">
 	<template>
 		<style>

--- a/test/d2l-my-courses/d2l-my-courses.html
+++ b/test/d2l-my-courses/d2l-my-courses.html
@@ -6,7 +6,7 @@
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
 
-		<link rel="import" href="../../src/d2l-my-courses.html">
+		<link rel="import" href="../../d2l-my-courses.html">
 	</head>
 	<body>
 		<test-fixture id="d2l-my-courses-fixture">


### PR DESCRIPTION
This makes this a non-breaking change, and also makes it abundantly clear which components are intended to be used publicly (i.e. just d2l-my-courses) and which ones are internal/"private" (i.e. everything else).