### PR TITLE
DE28442 Fetch all pinned courses in widget

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -136,8 +136,6 @@
 				* Private Polymer properties
 				*/
 
-				// URL used by the search widget to fetch department-type organizations
-				_departmentsUrl: String,
 				_hasEnrollments: {
 					type: Boolean,
 					value: false
@@ -154,15 +152,12 @@
 					type: Object,
 					value: function() { return {}; }
 				},
-				// URL used by the search widget to fetch semester-type organizations
-				_semestersUrl: String,
 				// The organization which the user is selecting the image of
 				_setImageOrg: Object,
 				_showContent: {
 					type: Boolean,
 					value: false
 				},
-				_startedInactive: Boolean,
 				// Size the tile should render with respect to vw
 				_tileSizes: Object,
 				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -138,9 +138,6 @@
 
 				// URL used by the search widget to fetch department-type organizations
 				_departmentsUrl: String,
-				// URL constructed to fetch a user's enrollments with the enrollments search Action
-				_enrollmentsSearchUrl: String,
-				// True when there are any enrollments (pinned or unpinned)
 				_hasEnrollments: {
 					type: Boolean,
 					value: false
@@ -465,10 +462,10 @@
 					return Promise.resolve();
 				}
 
-				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity);
+				var searchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity);
 
 				this.performanceMark('d2l.my-courses.search-enrollments.request');
-				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
+				return this.fetchSirenEntity(searchUrl)
 					.then(this._enrollmentsResponsePerfMeasures.bind(this))
 					.then(this._populateEnrollments.bind(this));
 			},
@@ -547,6 +544,13 @@
 					{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
 				this.fire('recalculate-columns');
+
+				var lastEnrollment = enrollmentEntities[enrollmentEntities.length - 1];
+				if (lastEnrollment.hasClass('pinned') && this._hasMoreEnrollments) {
+					var url = enrollmentsEntity.getLinkByRel('next').href;
+					return this.fetchSirenEntity(url)
+						.then(this._populateEnrollments.bind(this));
+				}
 			},
 			_moveEnrollmentToPinnedList: function(enrollment) {
 				var enrollmentId, enrollmentEntity;

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -54,16 +54,16 @@ describe('d2l-my-courses', function() {
 					href: '/enrollments/users/169/organizations/1'
 				}]
 			}, {
-				class: ['unpinned', 'enrollment'],
+				class: ['pinned', 'enrollment'],
 				rel: ['https://api.brightspace.com/rels/user-enrollment'],
 				actions: [{
-					name: 'pin-course',
+					name: 'unpin-course',
 					method: 'PUT',
 					href: '/enrollments/users/169/organizations/2',
 					fields: [{
 						name: 'pinned',
 						type: 'hidden',
-						value: true
+						value: false
 					}]
 				}],
 				links: [{
@@ -81,7 +81,7 @@ describe('d2l-my-courses', function() {
 		},
 		enrollmentsNextPageSearchResponse = {
 			entities: [{
-				class: ['pinned', 'enrollment'],
+				class: ['unpinned', 'enrollment'],
 				rel: ['https://api.brightspace.com/rels/user-enrollment'],
 				actions: [{
 					name: 'unpin-course',
@@ -199,10 +199,24 @@ describe('d2l-my-courses', function() {
 				});
 		});
 
-		it('should set the request URL for pinned courses', function() {
-			return widget._fetchRoot().then(function() {
-				expect(widget._enrollmentsSearchUrl).to.match(/sort=-PinDate/);
+		it.only('should fetch all pinned enrollments', function() {
+			enrollmentsSearchResponse.links.push({
+				rel: ['next'],
+				href: '/more-pinned-enrollments'
 			});
+			widget.fetchSirenEntity.withArgs(sinon.match('/enrollments/users/169?search='))
+				.returns(Promise.resolve(
+					window.D2L.Hypermedia.Siren.Parse(enrollmentsSearchResponse)
+				))
+				.withArgs(sinon.match('/more-pinned-enrollments'))
+				.returns(Promise.resolve(
+					window.D2L.Hypermedia.Siren.Parse(enrollmentsNextPageSearchResponse)
+				));
+
+			return widget._fetchRoot()
+				.then(function() {
+					expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('/more-pinned-enrollments'));
+				});
 		});
 
 		it('should rescale the course tile grid on search response', function() {
@@ -280,7 +294,7 @@ describe('d2l-my-courses', function() {
 		});
 
 		it('should return the correct value from getCourseTileItemCount', function() {
-			expect(widget.getCourseTileItemCount()).to.equal(1);
+			expect(widget.getCourseTileItemCount()).to.equal(2);
 		});
 
 		it('should correctly evaluate whether it has pinned/unpinned enrollments', function() {

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -199,7 +199,7 @@ describe('d2l-my-courses', function() {
 				});
 		});
 
-		it.only('should fetch all pinned enrollments', function() {
+		it('should fetch all pinned enrollments', function() {
 			enrollmentsSearchResponse.links.push({
 				rel: ['next'],
 				href: '/more-pinned-enrollments'


### PR DESCRIPTION
This was... probably supposed to always be here? Either way, this is needed functionality for US92691, so two birds one stone - continue to fetch subsequent pages of enrollments until we hit a course that is unpinned, so that a user with >25 pinned courses will still see all of their pinned courses in the widget.

Also removed the _enrollmentsSearchUrl property, as it can just be a local variable to the _fetchEnrollments function.