### PR TITLE
Decouple d2l-all-courses

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -255,6 +255,7 @@
 			_courseImagesLoadedEventCount: 0,
 			_courseTileOrganizationEventCount: 0,
 			_initiallyVisibleCourseTileCount: 0,
+			_enrollmentsSearchUrl: null,
 
 			/*
 			* Listeners
@@ -457,10 +458,10 @@
 					return Promise.resolve();
 				}
 
-				var searchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity);
+				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity);
 
 				this.performanceMark('d2l.my-courses.search-enrollments.request');
-				return this.fetchSirenEntity(searchUrl)
+				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
 					.then(this._enrollmentsResponsePerfMeasures.bind(this))
 					.then(this._populateEnrollments.bind(this));
 			},
@@ -495,9 +496,9 @@
 					return Promise.resolve();
 				}
 
-				var enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity, true);
+				this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(enrollmentsRootEntity, true);
 
-				return this.fetchSirenEntity(enrollmentsSearchUrl)
+				return this.fetchSirenEntity(this._enrollmentsSearchUrl)
 					.then(this._populateEnrollments.bind(this));
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
@@ -602,7 +603,7 @@
 				e.preventDefault();
 				e.stopPropagation();
 
-				allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
+				allCourses.searchUrl = this._enrollmentsSearchUrl;
 				allCourses.locale = this.locale;
 				allCourses.showCourseCode = this.showCourseCode;
 				allCourses.showSemester = this.showSemester;

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -598,10 +598,6 @@
 				this._createAllCourses();
 
 				var allCourses = this.$$('d2l-all-courses');
-				allCourses.open();
-
-				e.preventDefault();
-				e.stopPropagation();
 
 				allCourses.searchUrl = this._enrollmentsSearchUrl;
 				allCourses.locale = this.locale;
@@ -613,7 +609,10 @@
 				allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
 				allCourses.updatedSortLogic = this.updatedSortLogic;
 
-				this.$$('d2l-all-courses').load();
+				allCourses.open();
+
+				e.preventDefault();
+				e.stopPropagation();
 			},
 			_refreshPage: function() {
 				document.location.reload(true);

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -602,25 +602,17 @@
 				e.preventDefault();
 				e.stopPropagation();
 
-				this.async(function() {
-					// The opening of the overlay lags slightly if we try to do this while it
-					// is opening - do it after the animation is finished. Animation takes
-					// 500ms, but some lag if we wait exactly that long, so +100ms for safety)
-					allCourses.pinnedEnrollments = this.pinnedEnrollments;
-					allCourses.unpinnedEnrollments = this.unpinnedEnrollments;
-					allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
-					allCourses.lastEnrollmentsSearchResponse = this._lastEnrollmentsSearchResponse;
-					allCourses.locale = this.locale;
-					allCourses.showCourseCode = this.showCourseCode;
-					allCourses.showSemester = this.showSemester;
-					allCourses.advancedSearchUrl = this.advancedSearchUrl;
-					allCourses.filterStandardSemesterName = this.standardSemesterName;
-					allCourses.filterStandardDepartmentName = this.standardDepartmentName;
-					allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
-					allCourses.updatedSortLogic = this.updatedSortLogic;
+				allCourses.myEnrollmentsEntity = this._lastEnrollmentsSearchResponse;
+				allCourses.locale = this.locale;
+				allCourses.showCourseCode = this.showCourseCode;
+				allCourses.showSemester = this.showSemester;
+				allCourses.advancedSearchUrl = this.advancedSearchUrl;
+				allCourses.filterStandardSemesterName = this.standardSemesterName;
+				allCourses.filterStandardDepartmentName = this.standardDepartmentName;
+				allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
+				allCourses.updatedSortLogic = this.updatedSortLogic;
 
-					this.$$('d2l-all-courses').load();
-				}.bind(this), 600);
+				this.$$('d2l-all-courses').load();
 			},
 			_refreshPage: function() {
 				document.location.reload(true);

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -462,13 +462,16 @@
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 			},
 			_myEnrollmentsEntityChanged: function(entity) {
-				if (entity) {
-					var myEnrollmentsEntity = this.parseEntity(entity);
-
-					if (myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
-						this._enrollmentsSearchAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
-					}
+				var myEnrollmentsEntity = this.parseEntity(entity);
+				if (!myEnrollmentsEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
+					return;
 				}
+
+				this._enrollmentsSearchAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
+				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
+					embedDepth: 1,
+					autoPinCourses: false
+				});
 			},
 			_pinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -329,7 +329,6 @@
 				return itemCount;
 			},
 			load: function() {
-				// Load course tile and filter contents. Called from d2l-my-courses.
 				this.$['all-courses-scroll-threshold'].scrollTarget = this.$['all-courses'].scrollRegion;
 				this.$['all-courses-scroll-threshold'].clearTriggers();
 				this._filteredPinnedEnrollments.forEach(function(enrollment) {
@@ -339,8 +338,9 @@
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
 
+				var url;
 				// We never want to autopin results in the overlay
-				var url = this.searchUrl.replace('autoPinCourses=true', 'autoPinCourses=false');
+				url = this.searchUrl.replace('autoPinCourses=true', 'autoPinCourses=false');
 				// Busts d2l-fetch cache, since enrollments may have been pinned/unpinned
 				// since last time this URL was fetched
 				url += '&bustCache=' + Math.random();
@@ -348,11 +348,15 @@
 
 				requestAnimationFrame(function() {
 					this.fire('recalculate-columns');
-					this._showContent = true;
 				}.bind(this));
 			},
 			open: function() {
+				// Initially hide the content, until we have some data to show
+				// (set back to true in _onSearchResultsChanged)
+				this._showContent = false;
+
 				this.$$('#all-courses').open();
+				this.load();
 			},
 			setCourseImage: function(details) {
 				this._removeAlert('setCourseImageFailure');
@@ -443,6 +447,7 @@
 				this._unpinnedCoursesMap = {};
 				this._updateFilteredEnrollments(e.detail, false);
 				this.myEnrollmentsEntity = e.detail;
+				this._showContent = true;
 			},
 			_onSimpleOverlayOpening: function() {
 				this._removeAlert('setCourseImageFailure');

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -189,6 +189,7 @@
 					value: function() { return []; },
 					observer: '_pinnedEnrollmentsChanged'
 				},
+				searchUrl: String,
 				showCourseCode: Boolean,
 				showSemester: Boolean,
 				// Feature flag (switch) for using the updated sort logic and related fetaures
@@ -338,11 +339,12 @@
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
 
-				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
-					embedDepth: 1,
-					autoPinCourses: false,
-					pageSize: 25
-				}) + '&bustCache=' + Math.random();
+				// We never want to autopin results in the overlay
+				var url = this.searchUrl.replace('autoPinCourses=true', 'autoPinCourses=false');
+				// Busts d2l-fetch cache, since enrollments may have been pinned/unpinned
+				// since last time this URL was fetched
+				url += '&bustCache=' + Math.random();
+				this._searchUrl = url;
 
 				requestAnimationFrame(function() {
 					this.fire('recalculate-columns');

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -338,6 +338,12 @@
 					this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 				}, this);
 
+				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
+					embedDepth: 1,
+					autoPinCourses: false,
+					pageSize: 25
+				}) + '&bustCache=' + Math.random();
+
 				requestAnimationFrame(function() {
 					this.fire('recalculate-columns');
 					this._showContent = true;
@@ -468,10 +474,6 @@
 				}
 
 				this._enrollmentsSearchAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
-				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
-					embedDepth: 1,
-					autoPinCourses: false
-				});
 			},
 			_pinnedEnrollmentsChanged: function() {
 				this._updateTileSizes();

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -315,6 +315,7 @@ describe('d2l-all-courses', function() {
 				value: 'OrgUnitCode'
 			};
 
+			widget.searchUrl = '';
 			widget.load();
 			widget.$$('d2l-dropdown-menu').fire('d2l-menu-item-change', event);
 			expect(widget._searchUrl).to.contain('-PinDate,OrgUnitCode,OrgUnitId');

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -284,6 +284,47 @@ describe('d2l-all-courses', function() {
 		});
 	});
 
+	describe('opening the overlay', function() {
+		it('should set _searchUrl from the public property', function() {
+			widget.searchUrl = '/foo';
+
+			widget.open();
+
+			expect(widget._searchUrl).to.match(/\/foo/);
+		});
+
+		it('should not request auto-pinned courses', function() {
+			widget.searchUrl = '/foo?autoPinCourses=true';
+
+			widget.open();
+
+			expect(widget._searchUrl).to.match(/\/foo\?autoPinCourses=false/);
+		});
+
+		it('should initially hide content', function() {
+			widget.searchUrl = '';
+			widget.open();
+
+			expect(widget._showContent).to.be.false;
+		});
+
+		it('should show content once search results have loaded', function(done) {
+			window.d2lfetch.fetch = sinon.stub().returns(Promise.resolve({
+				ok: true,
+				json: function() {}
+			}));
+			var spy = sinon.spy(widget, '_onSearchResultsChanged');
+			widget.searchUrl = '/foo';
+			widget.open();
+
+			setTimeout(function() {
+				expect(spy).to.have.been.called;
+				expect(widget._showContent).to.be.true;
+				done();
+			});
+		});
+	});
+
 	describe('closing the overlay', function() {
 		it('should clear search text', function() {
 			var spy = sandbox.spy(widget, '_clearSearchWidget');

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -3,36 +3,38 @@ describe('d2l-my-courses', function() {
 		widget,
 		rootHref = '/enrollments',
 		searchHref = '/enrollments/users/169',
+		searchAction = {
+			name: 'search-my-enrollments',
+			method: 'GET',
+			href: searchHref,
+			fields: [{
+				name: 'search',
+				type: 'search',
+				value: ''
+			}, {
+				name: 'pageSize',
+				type: 'number',
+				value: 20
+			}, {
+				name: 'embedDepth',
+				type: 'number',
+				value: 0
+			}, {
+				name: 'sort',
+				type: 'text',
+				value: ''
+			}]
+		},
 		enrollmentsRootResponse = {
 			class: ['enrollments', 'root'],
-			actions: [{
-				name: 'search-my-enrollments',
-				method: 'GET',
-				href: searchHref,
-				fields: [{
-					name: 'search',
-					type: 'search',
-					value: ''
-				}, {
-					name: 'pageSize',
-					type: 'number',
-					value: 20
-				}, {
-					name: 'embedDepth',
-					type: 'number',
-					value: 0
-				}, {
-					name: 'sort',
-					type: 'text',
-					value: ''
-				}]
-			}],
+			actions: [searchAction],
 			links: [{
 				rel: ['self'],
 				href: rootHref
 			}]
 		},
 		enrollmentsSearchResponse = {
+			actions: [searchAction],
 			entities: [{
 				class: ['pinned', 'enrollment'],
 				rel: ['https://api.brightspace.com/rels/user-enrollment'],
@@ -526,6 +528,8 @@ describe('d2l-my-courses', function() {
 	describe('User interaction', function() {
 		it('should rescale the all courses view when it is opened', function() {
 			clock = sinon.useFakeTimers();
+			widget._lastEnrollmentsSearchResponse = enrollmentsSearchResponse;
+
 			widget.$$('#viewAllCourses').click();
 			var allCoursesRescaleSpy = sinon.spy(widget.$$('d2l-all-courses'), '_rescaleCourseTileRegions');
 
@@ -536,6 +540,8 @@ describe('d2l-my-courses', function() {
 
 		it('should remove a setCourseImageFailure alert when the all-courses overlay is closed', function() {
 			clock = sinon.useFakeTimers();
+			widget._lastEnrollmentsSearchResponse = enrollmentsSearchResponse;
+
 			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
 			widget._openAllCoursesView(new Event('foo'));
 			clock.tick(1001);

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -528,7 +528,7 @@ describe('d2l-my-courses', function() {
 	describe('User interaction', function() {
 		it('should rescale the all courses view when it is opened', function() {
 			clock = sinon.useFakeTimers();
-			widget._lastEnrollmentsSearchResponse = enrollmentsSearchResponse;
+			widget._enrollmentsSearchUrl = '';
 
 			widget.$$('#viewAllCourses').click();
 			var allCoursesRescaleSpy = sinon.spy(widget.$$('d2l-all-courses'), '_rescaleCourseTileRegions');
@@ -540,7 +540,7 @@ describe('d2l-my-courses', function() {
 
 		it('should remove a setCourseImageFailure alert when the all-courses overlay is closed', function() {
 			clock = sinon.useFakeTimers();
-			widget._lastEnrollmentsSearchResponse = enrollmentsSearchResponse;
+			widget._enrollmentsSearchUrl = '';
 
 			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
 			widget._openAllCoursesView(new Event('foo'));


### PR DESCRIPTION
Rather than directly setting the pinned and unpinned courses, we can instead treat the connection between d2l-all-courses and d2l-my-courses like the connection between d2l-all-courses and the filter - just set the myEnrollmentsEntity, and let the child component take it from there. The downside to this is that we do need to re-fetch things, but a) caching, and b) we no longer require the 600ms delay to make the animation not stutter.