### PR TITLE
switching to use imported d2lIntl library instead of relying on BSI

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,6 +36,7 @@
     "d2l-icons": "^3.7.0",
     "d2l-image-selector": "git://github.com/Brightspace/image-selector#^2.2.0",
     "d2l-intersection-observer-polyfill-import": "Brightspace/intersection-observer-polyfill-import#^1.0.0",
+    "d2l-intl-import": "^1.0.0",
     "d2l-link": "^3.5.1",
     "d2l-loading-spinner": "^5.0.5",
     "d2l-localize-behavior": "^1.0.1",

--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -5,6 +5,7 @@
 <link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../d2l-icons/d2l-icons.html">
+<link rel="import" href="../../d2l-intl-import/d2l-intl.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item-link.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
@@ -605,9 +606,9 @@ the user has in that organization - student, teacher, TA, etc.
 			},
 			_setOverlayContent: function(type, date, inactive) {
 				this._clearOverlayContent();
-				if (!this._dateFormatter && window.BSI && window.BSI.Intl) {
-					this._dateFormatter = new window.BSI.Intl.DateTimeFormat(this.locale, { format: 'MMM d, yyyy' });
-					this._fullDateFormatter = new window.BSI.Intl.DateTimeFormat(this.locale, { format: 'MMMM d, yyyy' });
+				if (!this._dateFormatter && window.d2lIntl) {
+					this._dateFormatter = new window.d2lIntl.DateTimeFormat(this.locale, { format: 'MMM d, yyyy' });
+					this._fullDateFormatter = new window.d2lIntl.DateTimeFormat(this.locale, { format: 'MMMM d, yyyy' });
 				}
 
 				if (this._dateFormatter) {

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -675,8 +675,7 @@ describe('<d2l-course-tile>', function() {
 					isActive: true
 				}
 			};
-			window.BSI = window.BSI || {};
-			window.BSI.Intl = window.BSI.Intl || {
+			window.d2lIntl = {
 				DateTimeFormat: function() {
 					this.format = sinon.stub().returns(formattedDate);
 				}


### PR DESCRIPTION
This is an interim step that I'd like to get in now, before making improvements to `d2l-localize-behavior` and switching to use those.

I've makde `d2lIntl` importable, so I'm updating everything that referenced `BSI.Intl` (my-courses and BSI) to instead import it and then reference it that way.

So this change will need to go in at the same time as a corresponding change to BSI and the monolith.