### PR TITLE
Remove unpinnedEnrollments list

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -10,7 +10,6 @@
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="src/d2l-alert-behavior.html">
 <link rel="import" href="src/d2l-all-courses.html">
-<link rel="import" href="src/d2l-course-management-behavior.html">
 <link rel="import" href="src/d2l-course-tile-grid.html">
 <link rel="import" href="src/d2l-utility-behavior.html">
 <link rel="import" href="src/localize-behavior.html">
@@ -60,7 +59,7 @@
 				</d2l-alert>
 			</template>
 			<d2l-course-tile-grid
-				enrollments="[[pinnedEnrollments]]"
+				enrollments="[[_pinnedEnrollments]]"
 				tile-sizes="[[_tileSizes]]"
 				locale="[[locale]]"
 				show-course-code="[[showCourseCode]]"
@@ -136,11 +135,20 @@
 				* Private Polymer properties
 				*/
 
+				_allEnrollments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				_pinnedEnrollments: {
+					type: Array,
+					value: function() { return []; }
+				},
+				// True when there are enrollments (i.e. `_allEnrollments.length > 0`)
 				_hasEnrollments: {
 					type: Boolean,
 					value: false
 				},
-				// True when there are pinned enrollments (i.e. `pinnedEnrollments.length > 0`)
+				// True when there are pinned enrollments (i.e. `_pinnedEnrollments.length > 0`)
 				_hasPinnedEnrollments: {
 					type: Boolean,
 					value: false
@@ -166,10 +174,6 @@
 				_viewAllCoursesText: {
 					type: Number,
 					computed: '_getViewAllCoursesCount(_hasMoreEnrollments, _allEnrollments)'
-				},
-				_allEnrollments: {
-					type: Array,
-					value: function() { return []; }
 				}
 			},
 			behaviors: [
@@ -177,7 +181,6 @@
 				window.D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
 				window.D2L.MyCourses.InteractionDetectionBehavior,
-				window.D2L.MyCourses.CourseManagementBehavior,
 				window.D2L.MyCourses.AlertBehavior,
 				window.D2L.MyCourses.UtilityBehavior
 			],
@@ -193,7 +196,7 @@
 				'initially-visible-course-tile': '_onInitiallyVisibleCourseTile'
 			},
 			observers: [
-				'_enrollmentsChanged(pinnedEnrollments.length, _allEnrollments.length)',
+				'_enrollmentsChanged(_pinnedEnrollments.length, _allEnrollments.length)',
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
@@ -234,7 +237,7 @@
 			},
 
 			getCourseTileItemCount: function() {
-				return this.pinnedEnrollments.length;
+				return this._pinnedEnrollments.length;
 			},
 
 			getLastOrgUnitId: function() {
@@ -378,7 +381,7 @@
 						'd2l.my-courses.attached',
 						'd2l.my-courses.visible-organizations-complete'
 					);
-				} else if (this._courseTileOrganizationEventCount === this.pinnedEnrollments.length) {
+				} else if (this._courseTileOrganizationEventCount === this._pinnedEnrollments.length) {
 					this.performanceMark('d2l.my-courses.all-organizations-complete');
 					this.performanceMeasure(
 						'd2l.my-courses.meaningful.all',
@@ -393,7 +396,7 @@
 			*/
 
 			_enrollmentsChanged: function() {
-				this.set('_hasPinnedEnrollments', this.pinnedEnrollments.length > 0);
+				this.set('_hasPinnedEnrollments', this._pinnedEnrollments.length > 0);
 				this.set('_hasEnrollments', this._allEnrollments.length > 0);
 			},
 			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
@@ -512,10 +515,10 @@
 					}
 				}, this);
 
-				this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);
+				this._pinnedEnrollments = this._pinnedEnrollments.concat(newPinnedEnrollments);
 				this._allEnrollments = this._allEnrollments.concat(enrollmentEntities);
 
-				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
+				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._pinnedEnrollments.length);
 				this._tileSizes = (colNum === 2) ?
 					{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
 					{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
@@ -531,8 +534,7 @@
 			},
 			_addToPinnedEnrollments: function(enrollment) {
 				if (enrollment) {
-					this._setEnrollmentPinData(enrollment, true);
-					this.unshift('pinnedEnrollments', enrollment);
+					this.unshift('_pinnedEnrollments', enrollment);
 				}
 			},
 			_removeFromPinnedEnrollments: function(enrollment) {
@@ -540,10 +542,10 @@
 					? enrollment
 					: this.getEntityIdentifier(enrollment);
 
-				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
-					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
+				for (var index = 0; index < this._pinnedEnrollments.length; index++) {
+					var unpinnedEnrollmentId = this.getEntityIdentifier(this._pinnedEnrollments[index]);
 					if (unpinnedEnrollmentId === enrollmentId) {
-						this.splice('pinnedEnrollments', index, 1);
+						this.splice('_pinnedEnrollments', index, 1);
 						break;
 					}
 				}

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -145,8 +145,6 @@
 					type: Boolean,
 					value: false
 				},
-				// Object containing the last response from an enrollments search request
-				_lastEnrollmentsSearchResponse: Object,
 				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
 				_pinnedCoursesMap: {
 					type: Object,
@@ -160,11 +158,6 @@
 				},
 				// Size the tile should render with respect to vw
 				_tileSizes: Object,
-				// Object containing the IDs of previously loaded unpinned enrollments, to avoid duplicates
-				_unpinnedCoursesMap: {
-					type: Object,
-					value: function() { return {}; }
-				},
 				orgUnitIdMap: {
 					type: Object,
 					value: function() { return {}; }
@@ -172,7 +165,11 @@
 				_hasMoreEnrollments: Boolean,
 				_viewAllCoursesText: {
 					type: Number,
-					computed: '_getViewAllCoursesCount(_hasMoreEnrollments, pinnedEnrollments, unpinnedEnrollments)'
+					computed: '_getViewAllCoursesCount(_hasMoreEnrollments, _allEnrollments)'
+				},
+				_allEnrollments: {
+					type: Array,
+					value: function() { return []; }
 				}
 			},
 			behaviors: [
@@ -196,7 +193,7 @@
 				'initially-visible-course-tile': '_onInitiallyVisibleCourseTile'
 			},
 			observers: [
-				'_enrollmentsChanged(pinnedEnrollments.length, unpinnedEnrollments.length)',
+				'_enrollmentsChanged(pinnedEnrollments.length, _allEnrollments.length)',
 				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
 			],
 			ready: function() {
@@ -288,9 +285,9 @@
 				var enrollment = this.orgUnitIdMap[e.detail.orgUnitId];
 				if (enrollment) {
 					if (e.detail.isPinned) {
-						this._moveEnrollmentToPinnedList(enrollment);
+						this._addToPinnedEnrollments(enrollment);
 					} else {
-						this._moveEnrollmentToUnpinnedList(enrollment);
+						this._removeFromPinnedEnrollments(enrollment);
 					}
 					setTimeout(this._onStartedInactiveAlert.bind(this), 50);
 				} else {
@@ -334,9 +331,9 @@
 			},
 			_onTileRemoveComplete: function(e) {
 				if (e.detail.pinned) {
-					this._moveEnrollmentToPinnedList(e.detail.enrollment);
+					this._addToPinnedEnrollments(e.detail.enrollment);
 				} else {
-					this._moveEnrollmentToUnpinnedList(e.detail.enrollment);
+					this._removeFromPinnedEnrollments(e.detail.enrollment);
 				}
 			},
 			_onInitiallyVisibleCourseTile: function() {
@@ -397,7 +394,7 @@
 
 			_enrollmentsChanged: function() {
 				this.set('_hasPinnedEnrollments', this.pinnedEnrollments.length > 0);
-				this.set('_hasEnrollments', this._hasPinnedEnrollments || this.unpinnedEnrollments.length > 0);
+				this.set('_hasEnrollments', this._allEnrollments.length > 0);
 			},
 			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
 				this._clearAlerts();
@@ -415,12 +412,6 @@
 			* Utility/helper functions
 			*/
 
-			_addEnrollmentToList: function(pinned, enrollmentEntity) {
-				var listName = (pinned ? 'pinned' : 'unpinned') + 'Enrollments';
-
-				this._setEnrollmentPinData(enrollmentEntity, pinned);
-				this.unshift(listName, enrollmentEntity);
-			},
 			_createAllCourses: function() {
 				if (!this._allCoursesCreated) {
 					var allCourses = document.createElement('d2l-all-courses');
@@ -446,7 +437,6 @@
 					.catch(showContent);
 			},
 			_fetchEnrollments: function(enrollmentsRootEntity) {
-
 				this.performanceMark('d2l.my-courses.root-enrollments.response');
 				this.performanceMeasure(
 					'd2l.my-courses.root-enrollments',
@@ -491,7 +481,6 @@
 				return enrollmentsSearchUrl;
 			},
 			_refetchEnrollments: function(enrollmentsRootEntity) {
-
 				if (!enrollmentsRootEntity.hasAction('search-my-enrollments')) {
 					return Promise.resolve();
 				}
@@ -502,12 +491,9 @@
 					.then(this._populateEnrollments.bind(this));
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
-
-				this._lastEnrollmentsSearchResponse = enrollmentsEntity;
 				var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 				this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
 				var newPinnedEnrollments = [];
-				var newUnpinnedEnrollments = [];
 
 				enrollmentEntities.forEach(function(enrollment) {
 					var enrollmentId = this.getEntityIdentifier(enrollment);
@@ -516,11 +502,6 @@
 						if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
 							newPinnedEnrollments.push(enrollment);
 							this._pinnedCoursesMap[enrollmentId] = true;
-						}
-					} else {
-						if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-							newUnpinnedEnrollments.push(enrollment);
-							this._unpinnedCoursesMap[enrollmentId] = true;
 						}
 					}
 
@@ -532,7 +513,7 @@
 				}, this);
 
 				this.pinnedEnrollments = this.pinnedEnrollments.concat(newPinnedEnrollments);
-				this.unpinnedEnrollments = this.unpinnedEnrollments.concat(newUnpinnedEnrollments);
+				this._allEnrollments = this._allEnrollments.concat(enrollmentEntities);
 
 				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this.pinnedEnrollments.length);
 				this._tileSizes = (colNum === 2) ?
@@ -548,50 +529,23 @@
 						.then(this._populateEnrollments.bind(this));
 				}
 			},
-			_moveEnrollmentToPinnedList: function(enrollment) {
-				var enrollmentId, enrollmentEntity;
-
-				if (typeof enrollment === 'string') {
-					enrollmentId = enrollment;
-				} else {
-					enrollmentEntity = enrollment;
-					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
-				}
-
-				for (var index = 0; index < this.unpinnedEnrollments.length; index++) {
-					var pinnedEnrollmentId = this.getEntityIdentifier(this.unpinnedEnrollments[index]);
-					if (pinnedEnrollmentId === enrollmentId) {
-						enrollmentEntity = enrollmentEntity || this.unpinnedEnrollments[index];
-						this.splice('unpinnedEnrollments', index, 1);
-						break;
-					}
-				}
-
-				if (enrollmentEntity) {
-					this._addEnrollmentToList(true, enrollmentEntity);
+			_addToPinnedEnrollments: function(enrollment) {
+				if (enrollment) {
+					this._setEnrollmentPinData(enrollment, true);
+					this.unshift('pinnedEnrollments', enrollment);
 				}
 			},
-			_moveEnrollmentToUnpinnedList: function(enrollment) {
-				var enrollmentId, enrollmentEntity;
-
-				if (typeof enrollment === 'string') {
-					enrollmentId = enrollment;
-				} else {
-					enrollmentEntity = enrollment;
-					enrollmentId = this.getEntityIdentifier(enrollmentEntity);
-				}
+			_removeFromPinnedEnrollments: function(enrollment) {
+				var enrollmentId = typeof enrollment === 'string'
+					? enrollment
+					: this.getEntityIdentifier(enrollment);
 
 				for (var index = 0; index < this.pinnedEnrollments.length; index++) {
 					var unpinnedEnrollmentId = this.getEntityIdentifier(this.pinnedEnrollments[index]);
 					if (unpinnedEnrollmentId === enrollmentId) {
-						enrollmentEntity = enrollmentEntity || this.pinnedEnrollments[index];
 						this.splice('pinnedEnrollments', index, 1);
 						break;
 					}
-				}
-
-				if (enrollmentEntity) {
-					this._addEnrollmentToList(false, enrollmentEntity);
 				}
 			},
 			_openAllCoursesView: function(e) {
@@ -625,11 +579,11 @@
 				}
 				return match[0];
 			},
-			_getViewAllCoursesCount: function(_hasMoreEnrollments, pinnedEnrollments, unpinnedEnrollments) {
+			_getViewAllCoursesCount: function(_hasMoreEnrollments, allEnrollments) {
 				var viewAllCourses = this.localize('viewAllCourses');
 				if (!this.updatedSortLogic) return viewAllCourses;
 
-				var count = String(pinnedEnrollments.length + unpinnedEnrollments.length);
+				var count = String(allEnrollments.length);
 				if (_hasMoreEnrollments) count += '+';
 
 				return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -197,7 +197,7 @@ describe('d2l-my-courses', function() {
 			return widget._fetchRoot()
 				.then(widget._fetchRoot.bind(widget))
 				.then(function() {
-					expect(widget.pinnedEnrollments.length).to.equal(2);
+					expect(widget._pinnedEnrollments.length).to.equal(2);
 				});
 		});
 
@@ -331,7 +331,7 @@ describe('d2l-my-courses', function() {
 
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', function() {
 			widget.updatedSortLogic = true;
-			widget.pinnedEnrollments = new Array(6);
+			widget._pinnedEnrollments = new Array(6);
 			widget._allEnrollments = new Array(9);
 			widget._hasMoreEnrollments = false;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses (9)');
@@ -339,7 +339,7 @@ describe('d2l-my-courses', function() {
 
 		it('should show 50+ with the View All Courses link when there are more than 50 courses', function() {
 			widget.updatedSortLogic = true;
-			widget.pinnedEnrollments = new Array(4);
+			widget._pinnedEnrollments = new Array(4);
 			widget._allEnrollments = new Array(50);
 			widget._hasMoreEnrollments = true;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses (50+)');
@@ -347,7 +347,7 @@ describe('d2l-my-courses', function() {
 
 		it('should not show the count in the View All Courses link when the updated sortfeature flag is off', function() {
 			widget.updatedSortLogic = false;
-			widget.pinnedEnrollments = new Array(4);
+			widget._pinnedEnrollments = new Array(4);
 			widget._allEnrollments = new Array(50);
 			widget._hasMoreEnrollments = true;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses');

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -332,15 +332,15 @@ describe('d2l-my-courses', function() {
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', function() {
 			widget.updatedSortLogic = true;
 			widget.pinnedEnrollments = new Array(6);
-			widget.unpinnedEnrollments = new Array(9);
+			widget._allEnrollments = new Array(9);
 			widget._hasMoreEnrollments = false;
-			expect(widget._viewAllCoursesText).to.equal('View All Courses (15)');
+			expect(widget._viewAllCoursesText).to.equal('View All Courses (9)');
 		});
 
 		it('should show 50+ with the View All Courses link when there are more than 50 courses', function() {
 			widget.updatedSortLogic = true;
 			widget.pinnedEnrollments = new Array(4);
-			widget.unpinnedEnrollments = new Array(46);
+			widget._allEnrollments = new Array(50);
 			widget._hasMoreEnrollments = true;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses (50+)');
 		});
@@ -348,7 +348,7 @@ describe('d2l-my-courses', function() {
 		it('should not show the count in the View All Courses link when the updated sortfeature flag is off', function() {
 			widget.updatedSortLogic = false;
 			widget.pinnedEnrollments = new Array(4);
-			widget.unpinnedEnrollments = new Array(46);
+			widget._allEnrollments = new Array(50);
 			widget._hasMoreEnrollments = true;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses');
 		});
@@ -454,8 +454,8 @@ describe('d2l-my-courses', function() {
 			});
 
 			it('should move the correct pinned enrollment to the unpinned list when receiving an external unpin event', function(done) {
-				widget._moveEnrollmentToPinnedList = sinon.stub();
-				widget._moveEnrollmentToUnpinnedList = sinon.stub();
+				widget._addToPinnedEnrollments = sinon.stub();
+				widget._removeFromPinnedEnrollments = sinon.stub();
 				var coursePinnedChangeEvent = new CustomEvent(
 					'd2l-course-pinned-change', {
 						detail: {
@@ -469,15 +469,15 @@ describe('d2l-my-courses', function() {
 				document.body.dispatchEvent(coursePinnedChangeEvent);
 
 				setTimeout(function() {
-					expect(widget._moveEnrollmentToUnpinnedList).to.have.been.calledWith('enrollment1');
-					expect(widget._moveEnrollmentToPinnedList).to.not.have.been.called;
+					expect(widget._removeFromPinnedEnrollments).to.have.been.calledWith('enrollment1');
+					expect(widget._addToPinnedEnrollments).to.not.have.been.called;
 					done();
 				});
 			});
 
 			it('should move the correct unpinned enrollment to the pinned list when receiving an external unpin event', function(done) {
-				widget._moveEnrollmentToPinnedList = sinon.stub();
-				widget._moveEnrollmentToUnpinnedList = sinon.stub();
+				widget._addToPinnedEnrollments = sinon.stub();
+				widget._removeFromPinnedEnrollments = sinon.stub();
 				var coursePinnedChangeEvent = new CustomEvent(
 					'd2l-course-pinned-change', {
 						detail: {
@@ -491,15 +491,15 @@ describe('d2l-my-courses', function() {
 				document.body.dispatchEvent(coursePinnedChangeEvent);
 
 				setTimeout(function() {
-					expect(widget._moveEnrollmentToUnpinnedList).to.not.have.been.called;
-					expect(widget._moveEnrollmentToPinnedList).to.have.been.calledWith('enrollment2');
+					expect(widget._removeFromPinnedEnrollments).to.not.have.been.called;
+					expect(widget._addToPinnedEnrollments).to.have.been.calledWith('enrollment2');
 					done();
 				});
 			});
 
 			it('should refetch enrollments if the pinned enrollment has no previously been fetched', function(done) {
-				widget._moveEnrollmentToPinnedList = sinon.stub();
-				widget._moveEnrollmentToUnpinnedList = sinon.stub();
+				widget._addToPinnedEnrollments = sinon.stub();
+				widget._removeFromPinnedEnrollments = sinon.stub();
 				widget.fetchSirenEntity = sandbox.stub();
 				widget.fetchSirenEntity.withArgs(rootHref).returns(Promise.resolve());
 				widget._refetchEnrollments = sandbox.stub();
@@ -516,8 +516,8 @@ describe('d2l-my-courses', function() {
 				document.body.dispatchEvent(coursePinnedChangeEvent);
 
 				setTimeout(function() {
-					expect(widget._moveEnrollmentToUnpinnedList).to.not.have.been.called;
-					expect(widget._moveEnrollmentToPinnedList).to.not.have.been.called;
+					expect(widget._removeFromPinnedEnrollments).to.not.have.been.called;
+					expect(widget._addToPinnedEnrollments).to.not.have.been.called;
 					expect(widget._refetchEnrollments).to.have.been.called;
 					done();
 				});


### PR DESCRIPTION
With the decoupling of d2l-all-courses and d2l-my-courses, the latter no longer needs to keep track of unpinned enrollments. It still needs to _remove_ enrollments when they get unpinned (either from d2l-all-courses or the course selector), but doesn't need to hang on to them.

Also removed _lastEnrollmentsSearchResponse, as it was unused.

Also also removed the dependency on d2l-course-management-behavior - this added the pinnedEnrollments and unpinnedEnrollments properties, as well as the _setEnrollmentPinData function. The function was being used once, but has no real effect, since we're no longer moving items from one array to another, but rather adding or removing them from a single array. With unpinnedEnrollments now being removed as well, we can just use a local/private _pinnedEnrollments array in place of the behavior-defined public pinnedEnrollments one now.