### PR TITLE
Only add new enrollments to _allEnrollments

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -496,6 +496,7 @@
 			_populateEnrollments: function(enrollmentsEntity) {
 				var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 				this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
+				var newEnrollments = [];
 				var newPinnedEnrollments = [];
 
 				enrollmentEntities.forEach(function(enrollment) {
@@ -512,11 +513,12 @@
 					var orgUnitId = this._getOrgUnitIdFromHref(orgHref);
 					if (!this.orgUnitIdMap.hasOwnProperty(orgUnitId)) {
 						this.orgUnitIdMap[orgUnitId] = enrollment;
+						newEnrollments.push(enrollment);
 					}
 				}, this);
 
 				this._pinnedEnrollments = this._pinnedEnrollments.concat(newPinnedEnrollments);
-				this._allEnrollments = this._allEnrollments.concat(enrollmentEntities);
+				this._allEnrollments = this._allEnrollments.concat(newEnrollments);
 
 				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._pinnedEnrollments.length);
 				this._tileSizes = (colNum === 2) ?


### PR DESCRIPTION
Small bug, when I refactored this I missed this case. If you pin a course in the course selector that hasn't already been fetched by My Courses, we were appending the full page of enrollments (all of which we already have) to _allEnrollments, rather than just new ones. This meant the "View All Courses (50+)" link would change to "View All Courses (100+)" after pinning one course, "(150+)" after two, etc.