### PR TITLE
US92691 Add new d2l-my-courses-content

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,21 +1,38 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-content.html">
 <link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-content-animated.html">
 <link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-behavior.html">
 
 <dom-module id="d2l-my-courses">
 	<template>
-		<d2l-my-courses-content-animated
-			advanced-search-url="[[advancedSearchUrl]]"
-			enrollments-url="[[enrollmentsUrl]]"
-			image-catalog-location="[[imageCatalogLocation]]"
-			show-course-code="[[showCourseCode]]"
-			show-semester="[[showSemester]]"
-			standard-department-name="[[standardDepartmentName]]"
-			standard-semester-name="[[standardSemesterName]]"
-			course-updates-config="[[courseUpdatesConfig]]"
-			course-image-upload-cb="[[courseImageUploadCb]]"
-			updated-sort-logic="[[updatedSortLogic]]">
-		</d2l-my-courses-content-animated>
+		<template is="dom-if" if="[[!updatedSortLogic]]">
+			<d2l-my-courses-content-animated
+				advanced-search-url="[[advancedSearchUrl]]"
+				enrollments-url="[[enrollmentsUrl]]"
+				image-catalog-location="[[imageCatalogLocation]]"
+				show-course-code="[[showCourseCode]]"
+				show-semester="[[showSemester]]"
+				standard-department-name="[[standardDepartmentName]]"
+				standard-semester-name="[[standardSemesterName]]"
+				course-updates-config="[[courseUpdatesConfig]]"
+				course-image-upload-cb="[[courseImageUploadCb]]"
+				updated-sort-logic="[[updatedSortLogic]]">
+			</d2l-my-courses-content-animated>
+		</template>
+		<template is="dom-if" if="[[updatedSortLogic]]">
+			<d2l-my-courses-content
+				advanced-search-url="[[advancedSearchUrl]]"
+				enrollments-url="[[enrollmentsUrl]]"
+				image-catalog-location="[[imageCatalogLocation]]"
+				show-course-code="[[showCourseCode]]"
+				show-semester="[[showSemester]]"
+				standard-department-name="[[standardDepartmentName]]"
+				standard-semester-name="[[standardSemesterName]]"
+				course-updates-config="[[courseUpdatesConfig]]"
+				course-image-upload-cb="[[courseImageUploadCb]]"
+				updated-sort-logic="[[updatedSortLogic]]">
+			</d2l-my-courses-content>
+		</template>
 	</template>
 	<script>
 		Polymer({

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -29,7 +29,10 @@
 			// Callback for upload in image-selector
 			courseImageUploadCb: Function,
 			// Feature flag (switch) for using the updated sort logic and related fetaures
-			updatedSortLogic: Boolean
+			updatedSortLogic: {
+				type: Boolean,
+				value: false
+			}
 		}
 	};
 </script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -1,9 +1,8 @@
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-alert-behavior.html">
-<link rel="import" href="../d2l-all-courses.html">
-<link rel="import" href="../d2l-course-tile-grid.html">
 <link rel="import" href="../d2l-course-tile-responsive-grid-behavior.html">
+<link rel="import" href="../d2l-interaction-detection-behavior.html">
 <link rel="import" href="../d2l-utility-behavior.html">
 
 <script>
@@ -180,23 +179,8 @@
 		* Utility/helper functions
 		*/
 
-		_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
-			var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
-			var pageSize = this.updatedSortLogic ? 50 : 25;
-
-			var query = {
-				pageSize: pageSize,
-				embedDepth: 1,
-				sort: '-PinDate,OrgUnitName,OrgUnitId',
-				autoPinCourses: true
-			};
-			var enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
-
-			if (bustCache) {
-				enrollmentsSearchUrl += '&bustCache=' + Math.random();
-			}
-
-			return enrollmentsSearchUrl;
+		_createFetchEnrollmentsUrl: function() {
+			throw new Error('Must implement _createFetchEnrollmentsUrl in consumer');
 		},
 		_createAllCourses: function() {
 			if (!this._allCoursesCreated) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -34,21 +34,30 @@
 				value: false
 			},
 			// True when user has >1 page of enrollments
-			_hasMoreEnrollments: Boolean,
+			_hasMoreEnrollments: {
+				type: Boolean,
+				value: false
+			},
 			// Lookup table of org unit ID -> enrollment, to avoid having to re-fetch enrollments
 			_orgUnitIdMap: {
 				type: Object,
 				value: function() { return {}; }
 			},
 			// The organization which the user is selecting the image of
-			_setImageOrg: Object,
+			_setImageOrg: {
+				type: Object,
+				value: function() { return {}; }
+			},
 			// Hides loading spinner and shows content when true
 			_showContent: {
 				type: Boolean,
 				value: false
 			},
 			// Size the tile should render with respect to vw
-			_tileSizes: Object
+			_tileSizes: {
+				type: Object,
+				value: function() { return {}; }
+			}
 		},
 		listeners: {
 			'open-change-image-view': '_onOpenChangeImageView',
@@ -73,7 +82,7 @@
 			this.focus();
 		},
 		focus: function() {
-			if (this._setImageOrg && this.$$('d2l-course-tile-grid').focus(this._setImageOrg)) {
+			if (this.$$('d2l-course-tile-grid').focus(this._setImageOrg)) {
 				return;
 			}
 			this.$.viewAllCourses.focus();
@@ -82,7 +91,7 @@
 			throw new Error('Must implement getCourseTileItemCount in consumer');
 		},
 		getLastOrgUnitId: function() {
-			if (!this._setImageOrg) {
+			if (!this._setImageOrg.links) {
 				return;
 			}
 			return this._getOrgUnitIdFromHref(this.getEntityIdentifier(this._setImageOrg));

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -133,7 +133,7 @@
 		},
 		_onEnrollmentPinAction: function(e) {
 			var isPinned = e.type === 'enrollment-pinned';
-			var orgUnitId = this._getOrgUnitIdFromHref(this.getEntityIdentifier(e.detail.organization));
+			var orgUnitId = this._getOrgUnitIdFromHref(this.getEntityIdentifier(this.parseEntity(e.detail.organization)));
 
 			if (!orgUnitId) {
 				return;
@@ -164,7 +164,7 @@
 		},
 		_onOpenChangeImageView: function(e) {
 			if (e.detail.organization) {
-				this._setImageOrg = e.detail.organization;
+				this._setImageOrg = this.parseEntity(e.detail.organization);
 			}
 
 			this.$['basic-image-selector-overlay'].open();

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -52,7 +52,7 @@
 					[[item.alertMessage]]
 					<a
 						is="d2l-link"
-						href="Javascript:void(0);"
+						href="javascript:void(0);"
 						hidden$="[[_hasEnrollments]]"
 						on-tap="_refreshPage">[[localize('refresh')]]</a>
 				</d2l-alert>

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -6,14 +6,11 @@
 <link rel="import" href="../../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
-<link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
-<link rel="import" href="../d2l-all-courses.html">
-<link rel="import" href="../d2l-course-tile-grid.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-my-courses-behavior.html">
 <link rel="import" href="d2l-my-courses-content-behavior.html">
 
-<dom-module id="d2l-my-courses-content-animated">
+<dom-module id="d2l-my-courses-content">
 	<template strip-whitespace>
 		<style>
 			:host {
@@ -50,22 +47,23 @@
 		<div hidden$="[[!_showContent]]" class="my-courses-content">
 			<template is="dom-repeat" items="[[_alerts]]">
 				<d2l-alert type="[[item.alertType]]">
-					{{item.alertMessage}}
+					[[item.alertMessage]]
 					<a
 						is="d2l-link"
 						href="Javascript:void(0);"
 						hidden$="[[_hasEnrollments]]"
-						on-tap="_refreshPage">{{localize('refresh')}}</a>
+						on-tap="_refreshPage">[[localize('refresh')]]</a>
 				</d2l-alert>
 			</template>
 			<d2l-course-tile-grid
-				enrollments="[[_pinnedEnrollments]]"
+				enrollments="[[_enrollments]]"
 				tile-sizes="[[_tileSizes]]"
 				locale="[[locale]]"
 				show-course-code="[[showCourseCode]]"
 				show-semester="[[showSemester]]"
 				course-updates-config="[[courseUpdatesConfig]]"
-				updated-sort-logic="[[updatedSortLogic]]">
+				updated-sort-logic="[[updatedSortLogic]]"
+				animate="[[_animateCourseTileGrid]]">
 			</d2l-course-tile-grid>
 			<a
 				is="d2l-link"
@@ -76,7 +74,7 @@
 				on-keypress="_keypressOpenAllCoursesView"
 				on-mouseover="_createAllCourses"
 				on-focus="_createAllCourses"
-				tabindex="0" >
+				tabindex="0">
 				<h3 class="d2l-body-standard">[[_viewAllCoursesText]]</h3>
 			</a>
 		</div>
@@ -86,8 +84,8 @@
 
 		<d2l-simple-overlay
 			id="basic-image-selector-overlay"
-			title-name="{{localize('changeImage')}}"
-			close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}"
+			title-name="[[localize('changeImage')]]"
+			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
 			with-backdrop>
 			<iron-scroll-threshold
 				id="image-selector-threshold"
@@ -99,25 +97,22 @@
 				course-image-upload-cb="[[courseImageUploadCb]]">
 			</d2l-basic-image-selector>
 		</d2l-simple-overlay>
-
 	</template>
 	<script>
 		Polymer({
-			is: 'd2l-my-courses-content-animated',
-
+			is: 'd2l-my-courses-content',
 			properties: {
+				_animateCourseTileGrid: {
+					type: Boolean,
+					value: false
+				},
+				_enrollments: {
+					type: Array,
+					value: function() { return []; }
+				},
 				_allEnrollments: {
 					type: Array,
 					value: function() { return []; }
-				},
-				_pinnedEnrollments: {
-					type: Array,
-					value: function() { return []; }
-				},
-				// True when there are pinned enrollments (i.e. `_pinnedEnrollments.length > 0`)
-				_hasPinnedEnrollments: {
-					type: Boolean,
-					value: false
 				},
 				_viewAllCoursesText: {
 					type: Number,
@@ -129,57 +124,52 @@
 				window.D2L.MyCourses.MyCoursesBehavior,
 				window.D2L.MyCourses.MyCoursesContentBehavior
 			],
-			listeners: {
-				'tile-remove-complete': '_onTileRemoveComplete'
-			},
-			observers: [
-				'_enrollmentsChanged(_pinnedEnrollments.length, _allEnrollments.length)',
-				'_updateEnrollmentAlerts(_hasEnrollments, _hasPinnedEnrollments)'
-			],
-			ready: function() {
-				this._updateEnrollmentAlerts(this._hasEnrollments, this._hasPinnedEnrollments);
-			},
 			attached: function() {
 				this.__myCoursesContentBehavior_attached();
 			},
 			detached: function() {
 				this.__myCoursesContentBehavior_detached();
 			},
-
-			/*
-			* Public API functions
-			*/
+			observers: [
+				'_enrollmentsChanged(_enrollments)'
+			],
 
 			getCourseTileItemCount: function() {
-				return this._pinnedEnrollments.length;
+				return this._enrollments.length;
 			},
 
-			/*
-			* Listeners
-			*/
+			_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
+				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
 
-			_onEnrollmentPinnedMessage: function(e) {
-				if (e.target === this) return;
+				var query = {
+					pageSize: 50,
+					embedDepth: 1,
+					sort: 'current',
+					autoPinCourses: false,
+					promotePins: true
+				};
+				var enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
 
-				var enrollment = this._orgUnitIdMap[e.detail.orgUnitId];
-				if (enrollment) {
-					if (e.detail.isPinned) {
-						this._addToPinnedEnrollments(enrollment);
-					} else {
-						this._removeFromPinnedEnrollments(enrollment);
-					}
-					setTimeout(this._onStartedInactiveAlert.bind(this), 50);
-				} else {
-					this.fetchSirenEntity(this.enrollmentsUrl)
-						.then(this._refetchEnrollments.bind(this));
+				if (bustCache) {
+					enrollmentsSearchUrl += '&bustCache=' + Math.random();
+				}
+
+				return enrollmentsSearchUrl;
+			},
+			_enrollmentsChanged: function(enrollments) {
+				this._hasEnrollments = enrollments.length > 0;
+
+				this._clearAlerts();
+				if (!this._hasEnrollments) {
+					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
 				}
 			},
-			_onTileRemoveComplete: function(e) {
-				if (e.detail.pinned) {
-					this._addToPinnedEnrollments(e.detail.enrollment);
-				} else {
-					this._removeFromPinnedEnrollments(e.detail.enrollment);
-				}
+			_getViewAllCoursesCount: function(hasMoreEnrollments, allEnrollments) {
+				var viewAllCourses = this.localize('viewAllCourses');
+
+				var count = String(allEnrollments.length) + (hasMoreEnrollments ? '+' : '');
+
+				return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 			},
 			_onCourseTileOrganization: function() {
 				if (this._initiallyVisibleCourseTileCount === 0 && this._courseTileOrganizationEventCount === 0) {
@@ -208,7 +198,7 @@
 						'd2l.my-courses.attached',
 						'd2l.my-courses.visible-organizations-complete'
 					);
-				} else if (this._courseTileOrganizationEventCount === this._pinnedEnrollments.length) {
+				} else if (this._courseTileOrganizationEventCount === this._enrollments.length) {
 					this.performanceMark('d2l.my-courses.all-organizations-complete');
 					this.performanceMeasure(
 						'd2l.my-courses.meaningful.all',
@@ -217,61 +207,36 @@
 					);
 				}
 			},
+			_onEnrollmentPinnedMessage: function(e) {
+				if (e.target === this) return;
 
-			/*
-			* Observers
-			*/
-
-			_enrollmentsChanged: function() {
-				this.set('_hasPinnedEnrollments', this._pinnedEnrollments.length > 0);
-				this.set('_hasEnrollments', this._allEnrollments.length > 0);
-			},
-			_updateEnrollmentAlerts: function(hasEnrollments, hasPinnedEnrollments) {
-				this._clearAlerts();
-
-				if (hasEnrollments) {
-					if (!hasPinnedEnrollments) {
-						this._addAlert('call-to-action', 'noPinnedCourses', this.localize('noPinnedCoursesMessage'));
+				var enrollment = this._orgUnitIdMap[e.detail.orgUnitId];
+				if (enrollment) {
+					if (e.detail.isPinned) {
+						this.unshift('_enrollments', enrollment);
+					} else {
+						var enrollmentId = this.getEntityIdentifier(enrollment);
+						for (var i = 0; i < this._enrollments.length; i++) {
+							var unpinnedEnrollmentId = this.getEntityIdentifier(enrollment);
+							if (unpinnedEnrollmentId === enrollmentId) {
+								this.splice('_enrollments', i, 1);
+							}
+						}
 					}
-				} else {
-					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
 				}
-			},
-
-			/*
-			* Utility/helper functions
-			*/
-
-			_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
-				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
-				var pageSize = this.updatedSortLogic ? 50 : 25;
-
-				var query = {
-					pageSize: pageSize,
-					embedDepth: 1,
-					sort: '-PinDate,OrgUnitName,OrgUnitId',
-					autoPinCourses: true
-				};
-				var enrollmentsSearchUrl = this.createActionUrl(searchAction, query);
-
-				if (bustCache) {
-					enrollmentsSearchUrl += '&bustCache=' + Math.random();
-				}
-
-				return enrollmentsSearchUrl;
 			},
 			_populateEnrollments: function(enrollmentsEntity) {
 				var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 				this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
 				var newEnrollments = [];
-				var newPinnedEnrollments = [];
+				var allNewEnrollments = [];
 
 				enrollmentEntities.forEach(function(enrollment) {
-					var enrollmentId = this.getEntityIdentifier(enrollment);
-
-					if (enrollment.hasClass('pinned')) {
+					var displayedEnrollmentCount = this._enrollments.length + newEnrollments.length;
+					if (enrollment.hasClass('pinned') || displayedEnrollmentCount < 12) {
+						var enrollmentId = this.getEntityIdentifier(enrollment);
 						if (!this._existingEnrollmentsMap.hasOwnProperty(enrollmentId)) {
-							newPinnedEnrollments.push(enrollment);
+							newEnrollments.push(enrollment);
 							this._existingEnrollmentsMap[enrollmentId] = true;
 						}
 					}
@@ -280,14 +245,14 @@
 					var orgUnitId = this._getOrgUnitIdFromHref(orgHref);
 					if (!this._orgUnitIdMap.hasOwnProperty(orgUnitId)) {
 						this._orgUnitIdMap[orgUnitId] = enrollment;
-						newEnrollments.push(enrollment);
+						allNewEnrollments.push(enrollment);
 					}
 				}, this);
 
-				this._pinnedEnrollments = this._pinnedEnrollments.concat(newPinnedEnrollments);
-				this._allEnrollments = this._allEnrollments.concat(newEnrollments);
+				this._enrollments = this._enrollments.concat(newEnrollments);
+				this._allEnrollments = this._allEnrollments.concat(allNewEnrollments);
 
-				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._pinnedEnrollments.length);
+				var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._enrollments.length);
 				this._tileSizes = (colNum === 2) ?
 					{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
 					{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
@@ -300,33 +265,6 @@
 					return this.fetchSirenEntity(url)
 						.then(this._populateEnrollments.bind(this));
 				}
-			},
-			_addToPinnedEnrollments: function(enrollment) {
-				if (enrollment) {
-					this.unshift('_pinnedEnrollments', enrollment);
-				}
-			},
-			_removeFromPinnedEnrollments: function(enrollment) {
-				var enrollmentId = typeof enrollment === 'string'
-					? enrollment
-					: this.getEntityIdentifier(enrollment);
-
-				for (var index = 0; index < this._pinnedEnrollments.length; index++) {
-					var unpinnedEnrollmentId = this.getEntityIdentifier(this._pinnedEnrollments[index]);
-					if (unpinnedEnrollmentId === enrollmentId) {
-						this.splice('_pinnedEnrollments', index, 1);
-						break;
-					}
-				}
-			},
-			_getViewAllCoursesCount: function(hasMoreEnrollments, allEnrollments) {
-				var viewAllCourses = this.localize('viewAllCourses');
-				if (!this.updatedSortLogic) return viewAllCourses;
-
-				var count = String(allEnrollments.length);
-				if (hasMoreEnrollments) count += '+';
-
-				return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 			}
 		});
 	</script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -6,6 +6,8 @@
 <link rel="import" href="../../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
+<link rel="import" href="../d2l-all-courses.html">
+<link rel="import" href="../d2l-course-tile-grid.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-my-courses-behavior.html">
 <link rel="import" href="d2l-my-courses-content-behavior.html">

--- a/test/d2l-my-courses-content/consumer-element.html
+++ b/test/d2l-my-courses-content/consumer-element.html
@@ -1,0 +1,23 @@
+<link rel="import" href="../../../polymer/polymer.html">
+<link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="../../../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../src/d2l-my-courses-content/d2l-my-courses-content-behavior.html">
+<link rel="import" href="../../src/d2l-course-tile-grid.html">
+
+<dom-module id="consumer-element">
+	<template>
+		<d2l-simple-overlay id="basic-image-selector-overlay"></d2l-simple-overlay>
+		<d2l-course-tile-grid></d2l-course-tile-grid>
+		<iron-scroll-threshold
+			id="image-selector-threshold">
+		</iron-scroll-threshold>
+	</template>
+	<script>
+		Polymer({
+			is: 'consumer-element',
+			behaviors: [
+				window.D2L.MyCourses.MyCoursesContentBehavior
+			]
+		});
+	</script>
+</dom-module>

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -1,4 +1,3 @@
-<!doctype html>
 <html>
 	<head>
 		<meta charset="utf-8">

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
@@ -1,12 +1,12 @@
 describe('d2l-my-courses-content-animated', function() {
 	var sandbox,
 		widget,
-		organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+		organization = {
 			links: [{
 				rel: ['self'],
 				href: '/organizations/1'
 			}]
-		}),
+		},
 		rootHref = '/enrollments',
 		searchHref = '/enrollments/users/169',
 		searchAction = {
@@ -353,7 +353,7 @@ describe('d2l-my-courses-content-animated', function() {
 			var openChangeImageViewEvent = new CustomEvent(
 				'open-change-image-view', {
 					detail: {
-						organization: organizationEntity
+						organization: organization
 					}
 				}
 			);
@@ -401,7 +401,7 @@ describe('d2l-my-courses-content-animated', function() {
 				var enrollmentPinEvent = new CustomEvent(
 					'enrollment-pinned', {
 						detail: {
-							organization: organizationEntity,
+							organization: organization,
 							isPinned: true
 						}
 					}
@@ -428,7 +428,7 @@ describe('d2l-my-courses-content-animated', function() {
 				var enrollmentUnpinEvent = new CustomEvent(
 					'enrollment-unpinned', {
 						detail: {
-							organization: organizationEntity,
+							organization: organization,
 							isPinned: true
 						}
 					}

--- a/test/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -1,32 +1,11 @@
-<link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
-<link rel="import" href="../../../iron-scroll-threshold/iron-scroll-threshold.html">
-<link rel="import" href="../../src/d2l-my-courses-content/d2l-my-courses-content-behavior.html">
-<link rel="import" href="../../src/d2l-course-tile-grid.html">
-
-<dom-module id="consumer-element">
-	<template>
-		<d2l-simple-overlay id="basic-image-selector-overlay"></d2l-simple-overlay>
-		<d2l-course-tile-grid></d2l-course-tile-grid>
-		<iron-scroll-threshold
-			id="image-selector-threshold">
-		</iron-scroll-threshold>
-	</template>
-	<script>
-		Polymer({
-			is: 'consumer-element',
-			behaviors: [
-				window.D2L.MyCourses.MyCoursesContentBehavior
-			]
-		});
-	</script>
-</dom-module>
-
 <html>
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
 		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
 		<script src="../../../web-component-tester/browser.js"></script>
+
+		<link rel="import" href="consumer-element.html">
 	</head>
 	<body>
 		<test-fixture id="d2l-my-courses-content-behavior-fixture">

--- a/test/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -1,0 +1,40 @@
+<link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="../../../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../src/d2l-my-courses-content/d2l-my-courses-content-behavior.html">
+<link rel="import" href="../../src/d2l-course-tile-grid.html">
+
+<dom-module id="consumer-element">
+	<template>
+		<d2l-simple-overlay id="basic-image-selector-overlay"></d2l-simple-overlay>
+		<d2l-course-tile-grid></d2l-course-tile-grid>
+		<iron-scroll-threshold
+			id="image-selector-threshold">
+		</iron-scroll-threshold>
+	</template>
+	<script>
+		Polymer({
+			is: 'consumer-element',
+			behaviors: [
+				window.D2L.MyCourses.MyCoursesContentBehavior
+			]
+		});
+	</script>
+</dom-module>
+
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+	</head>
+	<body>
+		<test-fixture id="d2l-my-courses-content-behavior-fixture">
+			<template>
+				<consumer-element></consumer-element>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-my-courses-content-behavior.js"></script>
+	</body>
+</html>

--- a/test/d2l-my-courses-content/d2l-my-courses-content-behavior.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-behavior.js
@@ -1,0 +1,320 @@
+describe('d2l-my-courses-content-behavior', () => {
+	var sandbox,
+		component,
+		searchAction,
+		enrollmentsRootEntity,
+		organizationEntity;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		searchAction = {
+			name: 'search-my-enrollments',
+			method: 'GET',
+			href: '/enrollments/users/169',
+			fields: [
+				{ name: 'search', type: 'search', value: '' },
+				{ name: 'pageSize', type: 'number', value: 20 },
+				{ name: 'embedDepth', type: 'number', value: 0 },
+				{ name: 'sort', type: 'text', value: '' },
+				{ name: 'autoPinCourses', type: 'checkbox', value: false }
+			]
+		},
+		organizationEntity = window.D2L.Hypermedia.Siren.Parse({
+			properties: {
+				name: 'Course One'
+			},
+			links: [{
+				rel: ['self'],
+				href: '/organizations/1'
+			}]
+		});
+		enrollmentsRootEntity = window.D2L.Hypermedia.Siren.Parse({
+			actions: [searchAction]
+		});
+		component = fixture('d2l-my-courses-content-behavior-fixture');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should be properly inherited by the consumer element', () => {
+		expect(component).to.exist;
+		expect(component._alerts).to.be.an.instanceof(Array);
+		expect(component._existingEnrollmentsMap).to.be.an('object');
+		expect(component._hasEnrollments).to.be.false;
+		expect(component._hasMoreEnrollments).to.be.false;
+		expect(component._orgUnitIdMap).to.be.an('object');
+		expect(component._setImageOrg).to.be.an('object');
+		expect(component._showContent).to.be.false;
+		expect(component._tileSizes).to.be.an('object');
+	});
+
+	describe('Listener setup', () => {
+		[
+			{ eventName: 'open-change-image-view', handler: '_onOpenChangeImageView' },
+			{ eventName: 'clear-image-scroll-threshold', handler: '_onClearImageScrollThreshold' },
+			{ eventName: 'd2l-simple-overlay-closed', handler: '_onSimpleOverlayClosed' },
+			{ eventName: 'enrollment-pinned', handler: '_onEnrollmentPinAction' },
+			{ eventName: 'enrollment-unpinned', handler: '_onEnrollmentPinAction' },
+			{ eventName: 'course-tile-organization', handler: '_onCourseTileOrganization' },
+			{ eventName: 'course-image-loaded', handler: '_onCourseImageLoaded' },
+			{ eventName: 'initially-visible-course-tile', handler: '_onInitiallyVisibleCourseTile' },
+		].forEach(testCase => {
+			it('should listen for ' + testCase.eventName + ' events', done => {
+				var stub = sandbox.stub(component, testCase.handler);
+
+				var event = new CustomEvent(testCase.eventName);
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(stub).to.have.been.called;
+					done();
+				});
+			});
+		});
+	});
+
+	describe('Public API', () => {
+		it('should implement courseImageUploadCompleted', () => {
+			expect(component.courseImageUploadCompleted).to.be.a('function');
+		});
+
+		it('should implement focus', () => {
+			expect(component.focus).to.be.a('function');
+		});
+
+		it('should implement getCourseTileItemCount', () => {
+			expect(component.getCourseTileItemCount).to.be.a('function');
+		});
+
+		it('should implement getLastOrgUnitId', () => {
+			expect(component.getLastOrgUnitId).to.be.a('function');
+		});
+	});
+
+	describe('Consumer-implemented functionality', () => {
+		[
+			'getCourseTileItemCount',
+			'_onCourseTileOrganization',
+			'_onEnrollmentPinnedMessage',
+			'_createFetchEnrollmentsUrl',
+			'_populateEnrollments'
+		].forEach(method => {
+			it('should require ' + method + ' be implemented in the consumer', () => {
+				expect(component[method]).to.throw;
+			});
+		});
+	});
+
+	describe('Events', () => {
+		describe('open-change-image-view', () => {
+			it('should update _setImageOrg', done => {
+				var event = new CustomEvent('open-change-image-view', {
+					detail: {
+						organization: organizationEntity
+					}
+				});
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(component._setImageOrg.properties.name).to.equal('Course One');
+					done();
+				});
+			});
+
+			it('should open the course image overlay', done => {
+				var spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'open');
+				var event = new CustomEvent('open-change-image-view', { detail: {} });
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(spy).to.have.been.called;
+					done();
+				});
+			});
+		});
+
+		describe('d2l-simple-overlay-closed', () => {
+			it('should remove any existing set-course-image-failure alerts', done => {
+				var spy = sandbox.spy(component, '_removeAlert');
+
+				var event = new CustomEvent('d2l-simple-overlay-closed');
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(spy).to.have.been.calledWith('setCourseImageFailure');
+					done();
+				});
+			});
+		});
+
+		['enrollment-pinned', 'enrollment-unpinned'].forEach(eventName => {
+			describe(eventName, () => {
+				it('should not fire a d2l-course-pinned-change event', done => {
+					var spy = sandbox.spy(component, 'fire');
+
+					organizationEntity.links[0].href = 'not-a-parseable-organization-link';
+					var event = new CustomEvent(eventName, {
+						detail: {
+							organization: organizationEntity
+						}
+					});
+					component.dispatchEvent(event);
+
+					setTimeout(() => {
+						expect(spy).to.have.not.been.called;
+						done();
+					});
+				});
+
+				it('should fire a d2l-course-pinned-change event', done => {
+					var spy = sandbox.spy(component, 'fire');
+
+					var event = new CustomEvent(eventName, {
+						detail: {
+							organization: organizationEntity
+						}
+					});
+					component.dispatchEvent(event);
+
+					setTimeout(() => {
+						expect(spy).to.have.been.called;
+						done();
+					});
+
+				});
+			});
+		});
+
+		describe('course-image-loaded', () => {
+			it('should increment the count of course images loaded', done => {
+				expect(component._courseImagesLoadedEventCount).to.equal(0);
+
+				var event = new CustomEvent('course-image-loaded');
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(component._courseImagesLoadedEventCount).to.equal(1);
+					done();
+				});
+			});
+		});
+
+		describe('initially-visible-course-tile', () => {
+			it('should increment the count of initially visible course tiles', done => {
+				expect(component._initiallyVisibleCourseTileCount).to.equal(0);
+
+				var event = new CustomEvent('initially-visible-course-tile');
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(component._initiallyVisibleCourseTileCount).to.equal(1);
+					done();
+				});
+			});
+		});
+	});
+
+	describe('Performance measures', () => {
+		var stub;
+
+		beforeEach(() => {
+			stub = sandbox.stub(component, 'performanceMeasure');
+		});
+
+		it('should measure d2l.my-courses when all visible course tile images have loaded', done => {
+			var listener = () => {
+				component.removeEventListener('initially-visible-course-tile', listener);
+				component.dispatchEvent(new CustomEvent('course-image-loaded'));
+			};
+			component.addEventListener('initially-visible-course-tile', listener);
+
+			component.dispatchEvent(new CustomEvent('initially-visible-course-tile'));
+
+			setTimeout(() => {
+				expect(stub).to.have.been.calledWith(
+					'd2l.my-courses',
+					'd2l.my-courses.attached',
+					'd2l.my-courses.visible-images-complete'
+				);
+				done();
+			});
+		});
+
+		it('should measure d2l.my-courses.root-enrollments when the root enrollments call has finished', () => {
+			component.fetchSirenEntity = sandbox.stub().returns(
+				Promise.resolve(window.D2L.Hypermedia.Siren.Parse({}))
+			);
+			return component._fetchRoot().then(() => {
+				expect(stub).to.have.been.calledWith(
+					'd2l.my-courses.root-enrollments',
+					'd2l.my-courses.root-enrollments.request',
+					'd2l.my-courses.root-enrollments.response'
+				);
+			});
+		});
+
+		it('should measure d2l.my-courses.search-enrollments when the enrollment search call has finished', () => {
+			sandbox.stub(component, 'fetchSirenEntity')
+				.onFirstCall().returns(Promise.resolve(enrollmentsRootEntity))
+				.onSecondCall().returns(Promise.resolve({}));
+			component._createFetchEnrollmentsUrl = () => {};
+
+			return component._fetchRoot().then(() => {
+				expect(stub).to.have.been.calledWith(
+					'd2l.my-courses.search-enrollments',
+					'd2l.my-courses.search-enrollments.request',
+					'd2l.my-courses.search-enrollments.response'
+				);
+			});
+		});
+	});
+
+	describe('Fetching enrollments', () => {
+		it('should not fetch enrollments if the root request fails', () => {
+			var spy = sandbox.spy(component, '_fetchEnrollments');
+			sandbox.stub(component, 'fetchSirenEntity').returns(Promise.reject());
+
+			return component._fetchRoot().catch(() => {
+				expect(spy).to.have.not.been.called;
+			});
+		});
+
+		it('should hide the loading spinner if loading fails', () => {
+			sandbox.stub(component, 'fetchSirenEntity').returns(
+				Promise.resolve(window.D2L.Hypermedia.Siren.Parse({}))
+			);
+			component._fetchEnrollments = sandbox.stub().returns(Promise.reject());
+
+			return component._fetchRoot().catch(() => {
+				expect(component._showContent).to.be.true;
+			});
+		});
+
+		it('should hide the loading spinner if loading succeeds', () => {
+			sandbox.stub(component, 'fetchSirenEntity').returns(
+				Promise.resolve(window.D2L.Hypermedia.Siren.Parse({}))
+			);
+			component._fetchEnrollments = sandbox.stub().returns(Promise.resolve());
+
+			return component._fetchRoot().then(() => {
+				expect(component._showContent).to.be.true;
+			});
+		});
+
+		it('should fetch enrollments using the constructed enrollmentsSearchUrl', () => {
+			component._populateEnrollments = () => {};
+			var fetchStub = sandbox.stub(component, 'fetchSirenEntity');
+			fetchStub.onFirstCall().returns(Promise.resolve(enrollmentsRootEntity));
+			fetchStub.onSecondCall().returns(Promise.resolve(window.D2L.Hypermedia.Siren.Parse({})));
+			fetchStub.returns(Promise.resolve({}));
+			var createUrlStub = sandbox.stub(component, '_createFetchEnrollmentsUrl').returns('bar');
+
+			return component._fetchRoot().then(() => {
+				expect(createUrlStub).to.have.been.called;
+				expect(fetchStub).to.have.been.calledWith('bar');
+			});
+		});
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -19,6 +19,7 @@
 				'./d2l-filter-menu/d2l-filter-list-item.html',
 				'./d2l-filter-menu/d2l-filter-list-item-role.html',
 				'./d2l-my-courses-content/d2l-my-courses-content-animated.html',
+				'./d2l-my-courses-content/d2l-my-courses-content-behavior.html',
 				'./d2l-touch-menu-item/d2l-touch-menu-item.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',
 				'./d2l-utility-behavior/d2l-utility-behavior.html',


### PR DESCRIPTION
This new content component accomplishes the goal of the US, which was to fill up to 12 enrollments for a user. In particular, we will now fetch all of a user's pinned enrollments, then continue to add enrollments until we hit 12, or they no longer have any enrollments. There are other "new" things in here as well, for example using the new query parameters `?sort=current&promotePins=true`. We also no longer auto-pin in the new logic, so we explicitly set it to false to be safe for the initial request.

Aside from those changes, the component itself is largely the same as the older one, hence breaking out the behaviour in a previous PR.

The idea behind the structure here is that when the `updatedSortLogic` variable is removed, we can just remove `d2l-my-courses-content-animated`, and optionally re-integrate the functionality in `d2l-my-courses-content-behavior` right back into `d2l-my-courses-content` itself.

TODO:

- [x] Add tests
- [x] Wait for `promotePins` bookmarking fix to be merged in the LMS