### PR TITLE
DE28618 Hide past courses

### DIFF
--- a/src/d2l-course-tile-grid-styles.html
+++ b/src/d2l-course-tile-grid-styles.html
@@ -29,6 +29,11 @@
 			--four-column-width: 24.25%;
 		}
 
+		:host[hide-past-courses] d2l-course-tile[past-course]:not([pinned]),
+		:host[limit-to-12] d2l-course-tile:not([past-course]):nth-child(n+13) {
+			display: none;
+		}
+
 		.grid-container {
 			position: relative;
 			width: calc(100% + 20px);

--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -592,7 +592,10 @@ the user has in that organization - student, teacher, TA, etc.
 				var startDate = Date.parse(organization.properties.startDate);
 				var inactive = !organization.properties.isActive;
 
+				this.removeAttribute('past-course');
+
 				if (endDate < nowDate) {
+					this.setAttribute('past-course', '');
 					this._setOverlayContent('courseEnded', endDate);
 				} else if (startDate > nowDate) {
 					this._setOverlayContent('courseStarting', startDate, inactive);
@@ -666,6 +669,7 @@ the user has in that organization - student, teacher, TA, etc.
 			},
 			_pinnedChanged: function(pinned) {
 				this._pinned = pinned === undefined ? this._pinned : pinned;
+				this._pinned ? this.setAttribute('pinned', '') : this.removeAttribute('pinned');
 				this._pinLabel = this.localize(this._pinned ? 'unpin' : 'pin');
 
 				if (pinned === false && this.isStartedInactive) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -197,11 +197,18 @@
 						'd2l.my-courses.attached',
 						'd2l.my-courses.visible-images-complete'
 					);
+
+					setTimeout(function() {
+						// At worst, we show content 1s after the first organization has loaded
+						this._showContent = true;
+					}.bind(this), 1000);
 				}
 
 				this._courseTileOrganizationEventCount++;
 
 				if (this._courseTileOrganizationEventCount === this._initiallyVisibleCourseTileCount) {
+					// Only show content once the last visible organization has loaded, to reduce jank
+					this._showContent = true;
 					this.performanceMark('d2l.my-courses.visible-organizations-complete');
 					this.performanceMeasure(
 						'd2l.my-courses.meaningful.visible',

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -24,11 +24,6 @@
 				type: Array,
 				value: function() { return []; }
 			},
-			// Array of all enrollments fetched from the API (including those not displayed)
-			_allEnrollments: {
-				type: Array,
-				value: function() { return []; }
-			},
 			// Whether course tiles should animate during pin/unpin
 			_animateCourseTileGrid: {
 				type: Boolean,
@@ -77,7 +72,7 @@
 			// Text to render for "View All Courses" link (includes enrollment count approximation)
 			_viewAllCoursesText: {
 				type: String,
-				computed: '_getViewAllCoursesText(_hasMoreEnrollments, _allEnrollments)'
+				computed: '_getViewAllCoursesText(_hasMoreEnrollments, _enrollments.length)'
 			}
 		},
 		listeners: {
@@ -188,11 +183,18 @@
 					'd2l.my-courses.attached',
 					'd2l.my-courses.visible-images-complete'
 				);
+
+				setTimeout(function() {
+					// At worst, we show content 1s after the first organization has loaded
+					this._showContent = true;
+				}.bind(this), 1000);
 			}
 
 			this._courseTileOrganizationEventCount++;
 
 			if (this._courseTileOrganizationEventCount === this._initiallyVisibleCourseTileCount) {
+				// Only show content once the last visible organization has loaded, to reduce jank
+				this._showContent = true;
 				this.performanceMark('d2l.my-courses.visible-organizations-complete');
 				this.performanceMeasure(
 					'd2l.my-courses.meaningful.visible',
@@ -320,14 +322,11 @@
 		_fetchRoot: function() {
 			this.performanceMark('d2l.my-courses.root-enrollments.request');
 
-			var showContent = function() {
-				this._showContent = true;
-			}.bind(this);
-
 			return this.fetchSirenEntity(this.enrollmentsUrl)
 				.then(this._fetchEnrollments.bind(this))
-				.then(showContent)
-				.catch(showContent);
+				.catch(function() {
+					this._showContent = true;
+				}.bind(this));
 		},
 		_fetchEnrollments: function(enrollmentsRootEntity) {
 			this.performanceMark('d2l.my-courses.root-enrollments.response');
@@ -366,10 +365,10 @@
 			}
 			return match[0];
 		},
-		_getViewAllCoursesText: function(hasMoreEnrollments, allEnrollments) {
+		_getViewAllCoursesText: function(hasMoreEnrollments, enrollmentsLength) {
 			var viewAllCourses = this.localize('viewAllCourses');
 
-			var count = String(allEnrollments.length) + (hasMoreEnrollments ? '+' : '');
+			var count = String(enrollmentsLength) + (hasMoreEnrollments ? '+' : '');
 
 			return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 		},
@@ -397,28 +396,32 @@
 			var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 			this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
 			var newEnrollments = [];
-			var allNewEnrollments = [];
+
+			var searchAction = enrollmentsEntity.getActionByName('search-my-enrollments');
+			if (
+				searchAction
+				&& searchAction.hasFieldByName('sort')
+				&& searchAction.getFieldByName('sort').value.toLowerCase() === 'current'
+			) {
+				// When using Current sort, hide past courses in the widget view
+				this.$$('d2l-course-tile-grid').setAttribute('hide-past-courses', '');
+			}
 
 			enrollmentEntities.forEach(function(enrollment) {
-				var displayedEnrollmentCount = this._enrollments.length + newEnrollments.length;
-				if (enrollment.hasClass('pinned') || displayedEnrollmentCount < 12) {
-					var enrollmentId = this.getEntityIdentifier(enrollment);
-					if (!this._existingEnrollmentsMap.hasOwnProperty(enrollmentId)) {
-						newEnrollments.push(enrollment);
-						this._existingEnrollmentsMap[enrollmentId] = true;
-					}
+				var enrollmentId = this.getEntityIdentifier(enrollment);
+				if (!this._existingEnrollmentsMap.hasOwnProperty(enrollmentId)) {
+					newEnrollments.push(enrollment);
+					this._existingEnrollmentsMap[enrollmentId] = true;
 				}
 
 				var orgHref = (enrollment.getLinkByRel(this.HypermediaRels.organization) || {}).href;
 				var orgUnitId = this._getOrgUnitIdFromHref(orgHref);
 				if (!this._orgUnitIdMap.hasOwnProperty(orgUnitId)) {
 					this._orgUnitIdMap[orgUnitId] = enrollment;
-					allNewEnrollments.push(enrollment);
 				}
 			}, this);
 
 			this._enrollments = this._enrollments.concat(newEnrollments);
-			this._allEnrollments = this._allEnrollments.concat(allNewEnrollments);
 
 			var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._enrollments.length);
 			this._tileSizes = (colNum === 2) ?

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -58,6 +58,7 @@
 				</d2l-alert>
 			</template>
 			<d2l-course-tile-grid
+				limit-to-12
 				enrollments="[[_enrollments]]"
 				tile-sizes="[[_tileSizes]]"
 				locale="[[locale]]"


### PR DESCRIPTION
To prevent a user from just seeing a wall of ended courses (as they will show up after future courses in Current sort), hide them from the main widget view. In doing so with CSS, I realized that we can take a similar CSS-based approach to limiting the widget to 12 items - which removes the need to keep two arrays up to date, so _allEnrollments was removed. Now, the `limit-to-12` attribute on the `d2l-course-tile-grid` does the work for us.

Note that this only applies for users using Current sorting (users with large numbers of enrollments will be using LastAccessed, and will see past courses in the widget), and the "hide if ended" rule is always overridden by the enrollment being pinned.

Also slightly reworked when we show the widget - we set _showContent = true now either after the last visible organization has loaded, or at worst one second after the first visible organization has loaded. This is to prevent some jank as things are loading, and generally makes the experience a bit more polished.