### PR TITLE
Invalidate the cache so that pin states will update

### DIFF
--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -391,7 +391,7 @@
 				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
 					sort: sortParameter,
 					promotePins: promotePins
-				});
+				}) + '&bustCache=' + Math.random();
 
 				this.$.sortText.textContent = this.localize(langterm || '');
 				this.$.sortDropdown.toggleOpen();

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -125,7 +125,7 @@ describe('d2l-all-courses', function() {
 				value: 'LastAccessed'
 			});
 
-			expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=&sort=LastAccessed');
+			expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=LastAccessed');
 		});
 	});
 


### PR DESCRIPTION
When pins get updated, but the sort or something changed it just returned the result from the cache, with the old pin state, this should fix that.

I've got another PR in the works to only do this after the pin state changes, but just putting this here for now so things are more right again