### PR TITLE
Fix some small pinning issues

### DIFF
--- a/src/d2l-course-tile-styles.html
+++ b/src/d2l-course-tile-styles.html
@@ -13,6 +13,8 @@
 				--scale-fade-max-scale: 1.5;
 				--scale-fade-min-scale: 1.05;
 			}
+			:host:not([updated-sort-logic]) #pin-indicator-button,
+			:host:not([pinned]) #pin-indicator-button,
 			.d2l-course-tile-hidden {
 				display: none;
 			}

--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -106,16 +106,14 @@ the user has in that organization - student, teacher, TA, etc.
 						</template>
 					</d2l-dropdown>
 				</div>
-				<template is="dom-if" if$="[[_showPinIndicator]]">
-					<button
-						id="pin-indicator-button"
-						class="menu-item static"
-						on-tap="_pinClickHandler"
-						on-keypress="_pinPressHandler"
-						aria-label$="[[_coursePinButtonLabel]]">
-						<d2l-icon icon="d2l-tier1:pin-filled"></d2l-icon>
-					</button>
-				</template>
+				<button
+					id="pin-indicator-button"
+					class="menu-item static"
+					on-tap="_pinClickHandler"
+					on-keypress="_pinPressHandler"
+					aria-label$="[[_coursePinButtonLabel]]">
+					<d2l-icon icon="d2l-tier1:pin-filled"></d2l-icon>
+				</button>
 			</div>
 
 		</div>
@@ -166,7 +164,11 @@ the user has in that organization - student, teacher, TA, etc.
 					value: false
 				},
 				// Feature flag (switch) for using the updated sort logic and related fetaures
-				updatedSortLogic: Boolean,
+				updatedSortLogic: {
+					type: Boolean,
+					value: false,
+					observer: '_updatedSortLogicChanged'
+				},
 				// Types of notifications to include in update count
 				courseUpdatesConfig: Object,
 				//number of course updates to show
@@ -213,11 +215,6 @@ the user has in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					value: true,
 					computed: '_computeHideSeparator(_semesterName)'
-				},
-				_showPinIndicator: {
-					type: Boolean,
-					value: false,
-					computed: '_computeShowPinIndicator(pinned, updatedSortLogic)'
 				},
 				// Set by the IntersectionObserver when tile is first visible in viewport
 				_load: Boolean
@@ -721,8 +718,12 @@ the user has in that organization - student, teacher, TA, etc.
 			_computeHideSeparator: function(semesterName) {
 				return semesterName.length === 0;
 			},
-			_computeShowPinIndicator: function(pinned, updatedSortLogic) {
-				return pinned && updatedSortLogic;
+			_updatedSortLogicChanged: function(updatedSortLogic) {
+				if (updatedSortLogic) {
+					this.setAttribute('updated-sort-logic', '');
+				} else {
+					this.removeAttribute('updated-sort-logic');
+				}
 			}
 		});
 	</script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -232,22 +232,34 @@
 			if (e.target === this) return;
 
 			var enrollment = this._orgUnitIdMap[e.detail.orgUnitId];
-			if (enrollment) {
-				if (e.detail.isPinned) {
-					this.unshift('_enrollments', enrollment);
-				} else {
-					var unpinnedEnrollmentId = this.getEntityIdentifier(enrollment);
-					for (var i = 0; i < this._enrollments.length; i++) {
-						var enrollmentId = this.getEntityIdentifier(this._enrollments[i]);
-						if (enrollmentId === unpinnedEnrollmentId) {
-							this.splice('_enrollments', i, 1);
-							break;
-						}
-					}
-				}
-			} else {
-				this.fetchSirenEntity(this.enrollmentsUrl)
+			if (!enrollment) {
+				return this.fetchSirenEntity(this.enrollmentsUrl)
 					.then(this._refetchEnrollments.bind(this));
+			}
+
+			var changedEnrollmentId = this.getEntityIdentifier(enrollment);
+			for (var i = 0; i < this._enrollments.length; i++) {
+				var enrollmentId = this.getEntityIdentifier(this._enrollments[i]);
+
+				if (enrollmentId !== changedEnrollmentId) {
+					continue;
+				}
+
+				// We want to remove the enrollment from its current location either way
+				this.splice('_enrollments', i, 1);
+
+				if (!e.detail.isPinned) {
+					// If unpinning, we're done - just need to remove the enrollment (above)
+					break;
+				}
+
+				// If we're pinning an enrollment, re-fetch said enrollment by self link,
+				// so we get the updated enrollment entity
+				return this.fetchSirenEntity(enrollment.getLinkByRel('self').href)
+					.then(function(updatedEnrollment) {
+						this._orgUnitIdMap[e.detail.orgUnitId] = updatedEnrollment;
+						this.unshift('_enrollments', updatedEnrollment);
+					}.bind(this));
 			}
 		},
 		_onStartedInactiveAlert: function(e) {

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -601,7 +601,7 @@ describe('<d2l-course-tile>', function() {
 
 			expect(widget.pinned).to.be.false;
 			var pinIndicatorButton = widget.$$('#pin-indicator-button');
-			expect(pinIndicatorButton).to.not.exist;
+			expect(window.getComputedStyle(pinIndicatorButton).display).to.equal('none');
 		});
 
 		it('should not show the pin indicator button when a course is pinned but the feature flag is off', function() {
@@ -611,7 +611,7 @@ describe('<d2l-course-tile>', function() {
 
 			expect(widget.pinned).to.be.true;
 			var pinIndicatorButton = widget.$$('#pin-indicator-button');
-			expect(pinIndicatorButton).to.not.exist;
+			expect(window.getComputedStyle(pinIndicatorButton).display).to.equal('none');
 		});
 
 		it('should unpin the course when pressed', function() {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -607,16 +607,14 @@ describe('d2l-my-courses-content', () => {
 
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', () => {
 			component._hasMoreEnrollments = false;
-			component._enrollments = new Array(4);
-			component._allEnrollments = new Array(6);
+			component._enrollments = new Array(6);
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6)');
 		});
 
-		it('should show 50+ with the View All Courses link when there are more than 50 courses', () => {
+		it('should show include "+" in the View All Courses link when there are more courses', () => {
 			component._hasMoreEnrollments = true;
-			component._enrollments = new Array (4);
-			component._allEnrollments = new Array(50);
-			expect(component._viewAllCoursesText).to.equal('View All Courses (50+)');
+			component._enrollments = new Array (6);
+			expect(component._viewAllCoursesText).to.equal('View All Courses (6+)');
 		});
 	});
 });


### PR DESCRIPTION
First issue: pinning an unpinned filled-to-12 enrollment would cause the enrollment to show up twice. This was because we would add the enrollment to the beginning of the list of enrollments, but not remove the old copy of it below the pins. Simple enough to fix, we just need to always remove the enrollment on a `d2l-course-pinned-change` event, then in the case that it's being pinned, we need to re-add it.

Second issue: related to the first, when an enrollment was pinned and added to the beginning of the list, it wouldn't show up as pinned. However, we do have the self link of the enrollment, so we can use that to re-fetch the enrollment (which will have the correct pinned status on the response). Bonus to this is that it animates quite nicely!