### PR TITLE
If user has no enrollments, immediately show content

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -332,6 +332,10 @@
 			}
 		},
 		_fetchRoot: function() {
+			if (!this.enrollmentsUrl) {
+				return;
+			}
+
 			this.performanceMark('d2l.my-courses.root-enrollments.request');
 
 			return this.fetchSirenEntity(this.enrollmentsUrl)
@@ -434,6 +438,12 @@
 			}, this);
 
 			this._enrollments = this._enrollments.concat(newEnrollments);
+
+			if (this._enrollments.length === 0) {
+				// Normally we'd wait until the visible organization requests have finished,
+				// but this user has no enrollments, so we won't hit that case.
+				this._showContent = true;
+			}
 
 			var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._enrollments.length);
 			this._tileSizes = (colNum === 2) ?

--- a/test/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.html
@@ -10,7 +10,7 @@
 	<body>
 		<test-fixture id="d2l-my-courses-content-fixture">
 			<template>
-				<d2l-my-courses-content enrollments-url="/enrollments"></d2l-my-courses-content>
+				<d2l-my-courses-content></d2l-my-courses-content>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -123,6 +123,7 @@ describe('d2l-my-courses-content', () => {
 		SetupFetchStub(/\/enrollments\/users\/169.*bookmark=2/, enrollmentsSearchPageTwoEntity);
 
 		component = fixture('d2l-my-courses-content-fixture');
+		component.enrollmentsUrl = '/enrollments';
 	});
 
 	afterEach(() => {
@@ -290,7 +291,7 @@ describe('d2l-my-courses-content', () => {
 					expect(unshiftSpy).to.have.been.calledWith('_enrollments', enrollmentEntity);
 					// This is the first two that are loaded automatically when the widget loads,
 					// plus the one being added by the event
-					expect(component._enrollments.length).to.equal(3);
+					expect(component._enrollments.length).to.equal(1);
 					done();
 				});
 			});
@@ -524,6 +525,7 @@ describe('d2l-my-courses-content', () => {
 			}));
 
 			return component._fetchRoot().then(() => {
+				expect(component._showContent).to.be.true;
 				expect(component._hasEnrollments).to.be.false;
 				expect(component._alerts).to.include({
 					alertName: 'noCourses',


### PR DESCRIPTION
Missed this case when I moved when/how we _showContent. In the case where a user doesn't have any enrollments, we'll never hit _onCourseTileOrganization (obviously), so we should immediately show content in that case.