### PR TITLE
DE28649 Add newly-pinned enrollments to end of pinned enrollments

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -238,27 +238,46 @@
 			}
 
 			var changedEnrollmentId = this.getEntityIdentifier(enrollment);
-			for (var i = 0; i < this._enrollments.length; i++) {
+			var i = 0;
+			var lastPinnedIndex = 0;
+			for (i; i < this._enrollments.length; i++) {
 				var enrollmentId = this.getEntityIdentifier(this._enrollments[i]);
+
+				if (this._enrollments[lastPinnedIndex].hasClass('pinned')) {
+					lastPinnedIndex++;
+				}
 
 				if (enrollmentId !== changedEnrollmentId) {
 					continue;
 				}
 
-				// We want to remove the enrollment from its current location either way
-				this.splice('_enrollments', i, 1);
-
-				if (!e.detail.isPinned) {
-					// If unpinning, we're done - just need to remove the enrollment (above)
-					break;
+				// Find the last pinned enrollment
+				while (
+					lastPinnedIndex < this._enrollments.length
+					&& this._enrollments[lastPinnedIndex].hasClass('pinned')
+				) {
+					lastPinnedIndex++;
 				}
 
-				// If we're pinning an enrollment, re-fetch said enrollment by self link,
-				// so we get the updated enrollment entity
 				return this.fetchSirenEntity(enrollment.getLinkByRel('self').href)
 					.then(function(updatedEnrollment) {
 						this._orgUnitIdMap[e.detail.orgUnitId] = updatedEnrollment;
-						this.unshift('_enrollments', updatedEnrollment);
+
+						if (i === lastPinnedIndex) {
+							// Course is already in the correct position, just update it
+							// (avoids removal animation + insertion animation in exact same position)
+							this.splice('_enrollments', i, 1, updatedEnrollment);
+						} else {
+							// Remove the enrollment from its current location
+							this.splice('_enrollments', i, 1);
+
+							if (i < lastPinnedIndex) {
+								// Need to account for us removing the enrollment
+								lastPinnedIndex--;
+							}
+							// Re-add the (updated) enrollment at the end of the pinned list
+							this.splice('_enrollments', lastPinnedIndex, 0, updatedEnrollment);
+						}
 					}.bind(this));
 			}
 		},


### PR DESCRIPTION
Previously in My Courses, we wanted the most-recently-pinned course first, but with the updated sort order changes, we want it to be the opposite. This is going back to how it was before, which is also consistent with the course selector. This change fixes My Courses so that when a course is pinned in the course selector, it moves to the end of the already-pinned items in My Courses. When the same is done to unpin something, it moves to just-below the pinned items.

Note that this doesn't change the behavior for pinning/unpinning a course tile - in that case, the tile does not move, regardless of its current position. Refreshing the page will result in things being in order in this case, as moving them around when somebody is interacting with the widget directly is pretty janky and weird.

TODO:

- [x] Add some test cases for this, since it's got a fair number of edge cases