### PR TITLE
DE28618 Minor fixup of DE fix

### DIFF
--- a/src/d2l-course-tile-grid-styles.html
+++ b/src/d2l-course-tile-grid-styles.html
@@ -30,7 +30,7 @@
 		}
 
 		:host[hide-past-courses] d2l-course-tile[past-course]:not([pinned]),
-		:host[limit-to-12] d2l-course-tile:not([past-course]):nth-child(n+13) {
+		:host[limit-to-12] d2l-course-tile:not([pinned]):not([past-course]):nth-child(n+13) {
 			display: none;
 		}
 


### PR DESCRIPTION
Missed the case where a user has >12 pinned courses - in that case, we want to show all pinned courses, so this requires an extra `:not([pinned])`.