### PR TITLE
Update Enrollment Date ordering

### DIFF
--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -374,7 +374,7 @@
 						break;
 					case 'EnrollmentDate':
 						langterm = 'sorting.sortEnrollmentDate';
-						sortParameter = 'LastModifiedDate,OrgUnitId';
+						sortParameter = '-LastModifiedDate,OrgUnitId';
 						break;
 					case 'Default':
 						langterm = 'sorting.sortDefault';


### PR DESCRIPTION
I believe the Enrollment Date needs to be sorted descending. That is, largest (nearest) dates at the top, smallest (farthest) dates at the bottom.