### PR TITLE
DE28675 Fix "no unpinned" message when config is off

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -197,11 +197,6 @@
 						'd2l.my-courses.attached',
 						'd2l.my-courses.visible-images-complete'
 					);
-
-					setTimeout(function() {
-						// At worst, we show content 1s after the first organization has loaded
-						this._showContent = true;
-					}.bind(this), 1000);
 				}
 
 				this._courseTileOrganizationEventCount++;

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -183,11 +183,6 @@
 					'd2l.my-courses.attached',
 					'd2l.my-courses.visible-images-complete'
 				);
-
-				setTimeout(function() {
-					// At worst, we show content 1s after the first organization has loaded
-					this._showContent = true;
-				}.bind(this), 1000);
 			}
 
 			this._courseTileOrganizationEventCount++;
@@ -357,11 +352,18 @@
 
 			this.performanceMark('d2l.my-courses.root-enrollments.request');
 
+			var showContent = function() {
+				this._showContent = true;
+			}.bind(this);
+
 			return this.fetchSirenEntity(this.enrollmentsUrl)
 				.then(this._fetchEnrollments.bind(this))
-				.catch(function() {
-					this._showContent = true;
-				}.bind(this));
+				.then(function() {
+					// At worst, display content 1s after we fetch enrollments
+					// (Usually set to true before that, in _onCourseTileOrganization)
+					setTimeout(showContent, 1000);
+				})
+				.catch(showContent);
 		},
 		_fetchEnrollments: function(enrollmentsRootEntity) {
 			this.performanceMark('d2l.my-courses.root-enrollments.response');


### PR DESCRIPTION
Accidentally broke this when the config is off and the user has only unpinned courses. Previously _showContent = true was only happening in the handler when organization requests had finished, but this wasn't working when the config was off (since none of said organizations would be visible, as they're unpinned). Moved the handler to be a bit more like it was before, but still with the worst-case-one-second setTimeout. In other words, the content should become visible either after the last visible organization has loaded, or one second after the enrollments request has finished.