### PR TITLE
US93378 Change pageSize to 20

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -247,10 +247,9 @@
 			// Override for MyCoursesContentBehavior._createFetchEnrollmentsUrl
 			_createFetchEnrollmentsUrl: function(enrollmentsRootEntity, bustCache) {
 				var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
-				var pageSize = this.updatedSortLogic ? 50 : 25;
 
 				var query = {
-					pageSize: pageSize,
+					pageSize: 20,
 					embedDepth: 1,
 					sort: '-PinDate,OrgUnitName,OrgUnitId',
 					autoPinCourses: true
@@ -328,10 +327,14 @@
 				var viewAllCourses = this.localize('viewAllCourses');
 				if (!this.updatedSortLogic) return viewAllCourses;
 
-				var count = String(allEnrollments.length);
+				// With individual fetching of courses as they get pinned, we can end
+				// up with "21+", "22+", etc., so round down to nearest 5 for >20 courses
+				var count = allEnrollments.length < 20
+					? allEnrollments.length
+					: String(allEnrollments.length - (allEnrollments.length % 5));
 				if (hasMoreEnrollments) count += '+';
 
-				return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
+				return allEnrollments.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 			}
 		});
 	</script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -325,7 +325,7 @@
 			var searchAction = enrollmentsRootEntity.getActionByName('search-my-enrollments');
 
 			var query = {
-				pageSize: 50,
+				pageSize: 20,
 				embedDepth: 1,
 				sort: 'current',
 				autoPinCourses: false,
@@ -411,9 +411,14 @@
 		_getViewAllCoursesText: function(hasMoreEnrollments, enrollmentsLength) {
 			var viewAllCourses = this.localize('viewAllCourses');
 
-			var count = String(enrollmentsLength) + (hasMoreEnrollments ? '+' : '');
+			// With individual fetching of courses as they get pinned, we can end
+			// up with "21+", "22+", etc., so round down to nearest 5 for >20 courses
+			var count = enrollmentsLength < 20
+				? enrollmentsLength
+				: String(enrollmentsLength - (enrollmentsLength % 5));
+			if (hasMoreEnrollments) count += '+';
 
-			return count.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
+			return enrollmentsLength > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 		},
 		_openAllCoursesView: function(e) {
 			this._createAllCourses();

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
@@ -184,7 +184,7 @@ describe('d2l-my-courses-content-animated', function() {
 			return widget._fetchRoot().then(function() {
 				expect(spy).to.have.been.called;
 				expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('autoPinCourses=true'));
-				expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('pageSize=25'));
+				expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('pageSize=20'));
 				expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('embedDepth=1'));
 				expect(widget.fetchSirenEntity).to.have.been.calledWith(sinon.match('sort=-PinDate,OrgUnitName,OrgUnitId'));
 			});
@@ -347,6 +347,14 @@ describe('d2l-my-courses-content-animated', function() {
 			widget._allEnrollments = new Array(50);
 			widget._hasMoreEnrollments = true;
 			expect(widget._viewAllCoursesText).to.equal('View All Courses');
+		});
+
+		it('should round the number of courses in the View All Courses link when there are many courses', () => {
+			widget.updatedSortLogic = true;
+			widget._pinnedEnrollments = new Array(4);
+			widget._allEnrollments = new Array(23);
+			widget._hasMoreEnrollments = true;
+			expect(widget._viewAllCoursesText).to.equal('View All Courses (20+)');
 		});
 
 		describe('course image upload', function() {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -577,7 +577,7 @@ describe('d2l-my-courses-content', () => {
 		it('should fetch enrollments using the constructed enrollmentsSearchUrl', () => {
 			return component._fetchRoot().then(() => {
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('autoPinCourses=false')));
-				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('pageSize=50')));
+				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('pageSize=20')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('embedDepth=1')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('sort=current')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('promotePins=true')));
@@ -705,8 +705,14 @@ describe('d2l-my-courses-content', () => {
 
 		it('should show include "+" in the View All Courses link when there are more courses', () => {
 			component._hasMoreEnrollments = true;
-			component._enrollments = new Array (6);
+			component._enrollments = new Array(6);
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6+)');
+		});
+
+		it('should round the number of courses in the View All Courses link when there are many courses', () => {
+			component._hasMoreEnrollments = true;
+			component._enrollments = new Array(23);
+			expect(component._viewAllCoursesText).to.equal('View All Courses (20+)');
 		});
 	});
 });


### PR DESCRIPTION
Ultimately we were only fetching the larger page size so that we could render a "View All Courses (50+)" link - unfortunately, the response time of this request is pretty much linearly related to page size. This means a page size of 50 takes about twice as long as a page size of 20. On fast connections, not a particularly noticeable difference, but on crappy 3G in a tunnel through a mountain, this can mean loading in 10 seconds rather than 5 (not great either way, but y'know). The only downside of this change is that the View All Courses link now reads "(20+)", but ultimately we're not using the "99+" convention either way, so the actual number doesn't really mean all that much.

Also added round-down-to-10 logic, otherwise it's possible to end up with things like "View All Courses (23+)" if you pin/unpin a few things.

In napkin-math-level testing, this reduced the enrollments request for the widget from about 450ms locally to ~230ms, as expected.