### PR TITLE
DE28699 Include past courses in limit-to-12 count (sometimes)

### DIFF
--- a/src/d2l-course-tile-grid-styles.html
+++ b/src/d2l-course-tile-grid-styles.html
@@ -30,6 +30,7 @@
 		}
 
 		:host[hide-past-courses] d2l-course-tile[past-course]:not([pinned]),
+		:host[limit-to-12]:not([hide-past-courses]) d2l-course-tile:not([pinned]):nth-child(n+13),
 		:host[limit-to-12] d2l-course-tile:not([pinned]):not([past-course]):nth-child(n+13) {
 			display: none;
 		}

--- a/src/d2l-course-tile-grid.html
+++ b/src/d2l-course-tile-grid.html
@@ -50,9 +50,7 @@
 				enrollments: {
 					type: Array,
 					notify: true,
-					value: function() {
-						return [];
-					}
+					value: function() { return []; }
 				},
 				animate: {
 					type: Boolean,
@@ -60,13 +58,20 @@
 				},
 				// Set of enrollments which should be animated when being inserted
 				enrollmentsToAnimate: {
-					type: Array
+					type: Array,
+					value: function() { return []; }
 				},
 				// Size the tile should render with respect to vw
-				tileSizes: Object,
+				tileSizes: {
+					type: Object,
+					value: function() { return {}; }
+				},
 				locale: String,
 				// Types of notifications to include in update count in course tile
-				courseUpdatesConfig: Object,
+				courseUpdatesConfig: {
+					type: Object,
+					value: function() { return {}; }
+				},
 				// Set to true if course code should be shown in course tiles
 				showCourseCode: Boolean,
 				// Set to true if semester should be shown in course tiles

--- a/test/d2l-course-tile-grid/d2l-course-tile-grid.html
+++ b/test/d2l-course-tile-grid/d2l-course-tile-grid.html
@@ -1,0 +1,20 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../webcomponentsjs/webcomponents-lite.js"></script>
+		<script src="../../../web-component-tester/browser.js"></script>
+		<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
+
+		<link rel="import" href="../../src/d2l-course-tile-grid.html">
+	</head>
+	<body>
+		<test-fixture id="d2l-course-tile-grid-fixture">
+			<template>
+				<d2l-course-tile-grid></d2l-course-tile-grid>
+			</template>
+		</test-fixture>
+
+		<script src="d2l-course-tile-grid.js"></script>
+	</body>
+</html>

--- a/test/d2l-course-tile-grid/d2l-course-tile-grid.js
+++ b/test/d2l-course-tile-grid/d2l-course-tile-grid.js
@@ -1,0 +1,126 @@
+describe('d2l-course-tile-grid', () => {
+	var component,
+		sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.sandbox.create();
+		component = fixture('d2l-course-tile-grid-fixture');
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should properly instantiate', () => {
+		expect(component).to.exist;
+		expect(component.enrollments).to.be.an.instanceof(Array);
+		expect(component.animate).to.equal(true);
+		expect(component.enrollmentsToAnimate).to.be.an.instanceof(Array);
+		expect(component.tileSizes).to.be.an('object');
+		expect(component.courseUpdatesConfig).to.be.an('object');
+	});
+
+	describe('Listener setup', () => {
+		[
+			{ eventName: 'enrollment-pinned', handler: '_onEnrollmentPinAction' },
+			{ eventName: 'enrollment-unpinned', handler: '_onEnrollmentPinAction' },
+			{ eventName: 'touch-pin-hover', handler: '_onUnpinHover' },
+			{ eventName: 'touch-pin-select', handler: '_onTouchPinSelect' },
+			{ eventName: 'touch-menu-open', handler: '_onTouchMenuOpen' },
+			{ eventName: 'touch-menu-close', handler: '_onTouchMenuClose' },
+			{ eventName: 'dom-change', handler: '_onCourseTilesChanged' }
+		].forEach(testCase => {
+			it('should listen for ' + testCase.eventName + ' events', done => {
+				var stub = sandbox.stub(component, testCase.handler);
+
+				var event = new CustomEvent(testCase.eventName);
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(stub).to.have.been.called;
+					done();
+				});
+			});
+		});
+	});
+
+	describe('Public API', () => {
+		[
+			'getCourseTileItemCount',
+			'setCourseImage',
+			'focus',
+			'refreshCourseTileImage'
+		].forEach(methodName => {
+			it('should implement ' + methodName, () => {
+				expect(component[methodName]).to.be.a('function');
+			});
+		});
+	});
+
+	describe('DOM styling', () => {
+		function getEnrollment() {
+			return {
+				links: [{ rel: ['self'], href: 'foo' }],
+				rel: ['enrollment']
+			};
+		}
+
+		beforeEach(done => {
+			var enrollments = window.D2L.Hypermedia.Siren.Parse({
+				entities: Array(20).fill(getEnrollment())
+			});
+
+			component.enrollments = enrollments.entities;
+
+			setTimeout(() => {
+				done();
+			});
+		});
+
+		it('should only show 12 tiles when limit-to-12 attribute is set', () => {
+			component.setAttribute('limit-to-12', true);
+
+			var twelfthTile = component.$$('.course-tile-container d2l-course-tile:nth-of-type(12)');
+			expect(window.getComputedStyle(twelfthTile).getPropertyValue('display')).to.equal('block');
+			var thirteenthTile = component.$$('.course-tile-container d2l-course-tile:nth-of-type(13)');
+			expect(window.getComputedStyle(thirteenthTile).getPropertyValue('display')).to.equal('none');
+		});
+
+		it('should hide past courses when hide-past-courses attribute is set', () => {
+			component.setAttribute('hide-past-courses', true);
+
+			var pastCourseTile = component.$$('.course-tile-container d2l-course-tile');
+			expect(window.getComputedStyle(pastCourseTile).getPropertyValue('display')).to.equal('block');
+
+			pastCourseTile.setAttribute('past-course', true);
+
+			expect(window.getComputedStyle(pastCourseTile).getPropertyValue('display')).to.equal('none');
+		});
+
+		it('should not hide a pinned past course, even if hide-past-courses is set', () => {
+			var courseTile = component.$$('.course-tile-container d2l-course-tile');
+			courseTile.setAttribute('pinned', true);
+			expect(window.getComputedStyle(courseTile).getPropertyValue('display')).to.equal('block');
+
+			component.setAttribute('hide-past-courses', true);
+			courseTile.setAttribute('past-course', true);
+
+			expect(window.getComputedStyle(courseTile).getPropertyValue('display')).to.equal('block');
+		});
+
+		it('should only show 12 current courses when limit-to-12 and hide-past-courses are both set', () => {
+			var courseTile = component.$$('.course-tile-container d2l-course-tile');
+
+			component.setAttribute('limit-to-12', true);
+			component.setAttribute('hide-past-courses', true);
+			courseTile.setAttribute('past-course', true);
+
+			expect(window.getComputedStyle(courseTile).getPropertyValue('display')).to.equal('none');
+
+			var twelfthTile = component.$$('.course-tile-container d2l-course-tile:nth-of-type(12)');
+			expect(window.getComputedStyle(twelfthTile).getPropertyValue('display')).to.equal('block');
+			var thirteenthTile = component.$$('.course-tile-container d2l-course-tile:nth-of-type(13)');
+			expect(window.getComputedStyle(thirteenthTile).getPropertyValue('display')).to.equal('none');
+		});
+	});
+});

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
 				'./d2l-all-courses/d2l-all-courses.html',
 				'./d2l-all-courses-unified-content/d2l-all-courses-unified-content.html',
 				'./d2l-course-tile/d2l-course-tile.html',
+				'./d2l-course-tile-grid/d2l-course-tile-grid.html',
 				'./d2l-course-tile-responsive-grid-behavior/d2l-course-tile-responsive-grid-behavior.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab-roles.html',


### PR DESCRIPTION
Bit of an oversight here - when a user has many enrollments, they are sorted by last accessed date. This means there's no `hide-past-courses` being applied to the course tile grid, which is correct. However, we were missing the CSS rule for including these (visible) past courses in the `limit-to-12` CSS logic. This meant that all recently-accessed ended courses were not contributing to the 12 limit, so the user ended up seeing more than 12.