### PR TITLE
Re-enable some tests

### DIFF
--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -435,6 +435,10 @@ the user has in that organization - student, teacher, TA, etc.
 
 				this.pinned = this.enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
 
+				if (!this.enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
+					return;
+				}
+
 				var organizationLink = this.enrollment.getLinkByRel(this.HypermediaRels.organization);
 				if (!this._organizationUrl || this._organizationUrl.indexOf(organizationLink.href) !== 0) {
 					this._organizationUrl = organizationLink.href + '?embedDepth=1';
@@ -700,8 +704,11 @@ the user has in that organization - student, teacher, TA, etc.
 				return organization && organization.getActionByName(this.HypermediaActions.organizations.setCatalogImage);
 			},
 			_setCourseImageSrc: function() {
-				var image = this._organization.getSubEntityByClass(this.HypermediaClasses.courseImage.courseImage);
+				if (!this._organization.hasSubEntityByClass(this.HypermediaClasses.courseImage.courseImage)) {
+					return;
+				}
 
+				var image = this._organization.getSubEntityByClass(this.HypermediaClasses.courseImage.courseImage);
 				image.forceImageRefresh = this._forceImageRefresh;
 				this._image = image;
 			},

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -117,8 +117,10 @@ describe('d2l-my-courses-content', () => {
 		SetupFetchStub(/\/enrollments$/, enrollmentsRootEntity);
 		SetupFetchStub(/\/organizations\/1$/, organizationEntity);
 		SetupFetchStub(/\/organizations\/2$/, organizationEntity);
+		SetupFetchStub(/\/organizations\/3$/, organizationEntity);
 		SetupFetchStub(/\/organizations\/1\?embedDepth=1$/, organizationEntityHydrated);
 		SetupFetchStub(/\/organizations\/2\?embedDepth=1$/, organizationEntityHydrated);
+		SetupFetchStub(/\/organizations\/3\?embedDepth=1$/, organizationEntityHydrated);
 		SetupFetchStub(/\/enrollments\/users\/169.*&.*$/, enrollmentsSearchEntity);
 		SetupFetchStub(/\/enrollments\/users\/169.*bookmark=2/, enrollmentsSearchPageTwoEntity);
 
@@ -286,10 +288,13 @@ describe('d2l-my-courses-content', () => {
 				{ enrollmentPinStates: [true, false], pin: true, name: 'one pins, pin non-displayed course' },
 				{ enrollmentPinStates: [true, true], pin: true, name: 'two pins, pin non-displayed course' },
 			].forEach(testCase => {
-				it(testCase.name, () => {
+				it.skip(testCase.name, () => {
 					for (var i = 0; i < testCase.enrollmentPinStates.length; i++) {
 						var enrollment = window.D2L.Hypermedia.Siren.Parse({
-							links: [{ rel: ['self'], href: '/enrollments/' + (i + 1) }],
+							links: [
+								{ rel: ['self'], href: '/enrollments/' + (i + 1) },
+								{ rel: ['https://api.brightspace.com/rels/organization'], href: '/organizations/' + (i + 1) }
+							],
 							class: [testCase.enrollmentPinStates[i] ? 'pinned' : 'unpinned']
 						});
 						SetupFetchStub('/enrollments/' + (i + 1), enrollment);
@@ -297,7 +302,10 @@ describe('d2l-my-courses-content', () => {
 						component._orgUnitIdMap[(i + 1)] = enrollment;
 					}
 					var eventEnrollment = window.D2L.Hypermedia.Siren.Parse({
-						links: [{ rel: ['self'], href: '/enrollments/101010' }],
+						links: [
+							{ rel: ['self'], href: '/enrollments/101010' },
+							{ rel: ['https://api.brightspace.com/rels/organization'], href: '/organizations/101010' }
+						],
 						class: [testCase.pin ? 'pinned' : 'unpinned']
 					});
 					SetupFetchStub('/enrollments/101010', eventEnrollment);
@@ -342,10 +350,13 @@ describe('d2l-my-courses-content', () => {
 				{ enrollmentPinStates: [true, true, true], switchStateIndex: 1, name: 'three pins, unpin second course goes to index 2' },
 				{ enrollmentPinStates: [true, true, true], switchStateIndex: 2, name: 'three pins, unpin third course goes to index 2' },
 			].forEach(testCase => {
-				it(testCase.name, () => {
+				it.skip(testCase.name, () => {
 					for (var i = 0; i < testCase.enrollmentPinStates.length; i++) {
 						var enrollment = window.D2L.Hypermedia.Siren.Parse({
-							links: [{ rel: ['self'], href: '/enrollments/' + (i + 1) }],
+							links: [
+								{ rel: ['self'], href: '/enrollments/' + (i + 1) },
+								{ rel: ['https://api.brightspace.com/rels/organization'], href: '/organizations/' + (i + 1) }
+							],
 							class: [testCase.enrollmentPinStates[i] ? 'pinned' : 'unpinned']
 						});
 						SetupFetchStub('/enrollments/' + (i + 1), enrollment);

--- a/test/index.html
+++ b/test/index.html
@@ -19,8 +19,7 @@
 				'./d2l-filter-menu/d2l-filter-menu.html',
 				'./d2l-filter-menu/d2l-filter-list-item.html',
 				'./d2l-filter-menu/d2l-filter-list-item-role.html',
-				// TODO: Causing problems on OSX on Sauce - re-enable once they can be debugged locally
-				// './d2l-my-courses-content/d2l-my-courses-content.html',
+				'./d2l-my-courses-content/d2l-my-courses-content.html',
 				'./d2l-my-courses-content/d2l-my-courses-content-animated.html',
 				'./d2l-touch-menu-item/d2l-touch-menu-item.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',


### PR DESCRIPTION
These tests were added in #455, but intentionally skipped as they were failing in Safari on Sauce. The root cause here appeared to be missing organizations links, which goes unnoticed on other browsers... weird. Fixed the tests, and added a couple safety checks in `d2l-course-tile` to prevent these sorts of (unlikely) errors from happening in the wild. This fixes the tests on a local Safari instance, but unfortunately _some_ of the tests are still problematic on Sauce. Going to skip them for now, so that at least we can get the majority of these tests running.