### PR TITLE
First stage of new d2l-course-image-tile (US90524)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "d2l-alert": "^2.0.1",
     "d2l-colors": "^2.4.0",
-    "d2l-course-image": "Brightspace/course-image#^1.3.0",
+    "d2l-course-image": "Brightspace/course-image#^1.3.1",
     "d2l-dropdown": "^5.2.1",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.7.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^3.0.0",
@@ -44,7 +44,7 @@
     "d2l-polymer-behaviors": "^1.1.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.2.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.2",
-    "d2l-tile": "^3.0.0",
+    "d2l-tile": "^3.0.1",
     "d2l-typography": "^5.5.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.1.0",
     "iron-a11y-announcer": "^1.0.6",
@@ -62,6 +62,7 @@
   "resolutions": {
     "d2l-search-widget": "^2.0.1",
     "d2l-polymer-behaviors": "^1.1.0",
-    "webcomponentsjs": "^0.7"
+    "webcomponentsjs": "^0.7",
+    "d2l-colors": "^3.1.2"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -44,6 +44,7 @@
     "d2l-polymer-behaviors": "^1.1.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.2.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.2",
+    "d2l-tile": "^3.0.0",
     "d2l-typography": "^5.5.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^1.1.0",
     "iron-a11y-announcer": "^1.0.6",

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -30,6 +30,7 @@
 				standard-semester-name="[[standardSemesterName]]"
 				course-updates-config="[[courseUpdatesConfig]]"
 				course-image-upload-cb="[[courseImageUploadCb]]"
+				css-grid-view="[[cssGridView]]"
 				updated-sort-logic="[[updatedSortLogic]]">
 			</d2l-my-courses-content>
 		</template>

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -47,12 +47,12 @@
 			:host:focus .course-text {
 				text-decoration: underline;
 			}
-			:host:hover a[disabled],
-			:host:focus a[disabled] {
+			:host:hover a[aria-disabled],
+			:host:focus a[aria-disabled] {
 				cursor: default;
 			}
-			:host:hover a[disabled] .course-text,
-			:host:focus a[disabled] .course-text {
+			:host:hover a[aria-disabled] .course-text,
+			:host:focus a[aria-disabled] .course-text {
 				text-decoration: none;
 			}
 
@@ -104,6 +104,8 @@
 		</style>
 
 		<d2l-image-tile
+			href="[[_organizationHomepageUrl]]"
+			aria-disabled$="[[!_canAccessCourse]]"
 			hover-effect="[[_hoverEffects]]"
 			dropdown-label="[[_courseSettingsLabel]]"
 			no-mobile-more-button>
@@ -149,20 +151,16 @@
 				<d2l-icon hidden$="[[!pinned]]" icon="d2l-tier1:pin-filled"></d2l-icon>
 			</button>
 
-			<a
-				href="[[_organizationHomepageUrl]]"
-				aria-disabled="[[!_canAccessCourse]]">
-				<div class="flex">
-					<div class="course-text">
-						[[_organization.properties.name]]
-						<div>
-							<span class="course-code-text uppercase">[[_organization.properties.code]]</span>
-							<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
-							<span class="semester-text">[[_semesterName]]</span>
-						</div>
+			<div class="flex">
+				<div class="course-text">
+					[[_organization.properties.name]]
+					<div>
+						<span class="course-code-text uppercase">[[_organization.properties.code]]</span>
+						<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
+						<span class="semester-text">[[_semesterName]]</span>
 					</div>
 				</div>
-			</a>
+			</div>
 		</d2l-image-tile>
 	</template>
 	<script>
@@ -240,7 +238,7 @@
 			],
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					var anchorElement = this.$$('d2l-image-tile');
+					var imageTile = this.$$('d2l-image-tile');
 
 					var observerCallback = function(entries, observer) {
 						if (this._load) {
@@ -253,7 +251,7 @@
 							// so we need to also make sure the tile is visible for that first run
 							// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
 							if (entries[i].intersectionRatio > 0) {
-								observer.unobserve(anchorElement);
+								observer.unobserve(imageTile);
 								this.fire('initially-visible-course-tile');
 								this._load = true;
 								break;
@@ -270,12 +268,12 @@
 						}
 						// Whether we load because the tile became visible, or because we got some
 						// idle time, we want to disconnect the observer either way
-						observer.unobserve(anchorElement);
+						observer.unobserve(imageTile);
 						this._load = true;
 					}.bind(this));
 
 					var observer = new IntersectionObserver(observerCallback.bind(this));
-					observer.observe(anchorElement);
+					observer.observe(imageTile);
 				});
 			},
 			ready: function() {

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -1,0 +1,379 @@
+<link rel="import" href="../../polymer/polymer.html">
+<link rel="import" href="../../d2l-course-image/d2l-course-image.html">
+<link rel="import" href="../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
+<link rel="import" href="../../d2l-icons/d2l-icon.html">
+<link rel="import" href="../../d2l-icons/tier1-icons.html">
+<link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item.html">
+<link rel="import" href="../../d2l-menu/d2l-menu-item-link.html">
+<link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
+<link rel="import" href="../../d2l-tile/d2l-image-tile.html">
+<link rel="import" href="localize-behavior.html">
+<link rel="import" href="d2l-utility-behavior.html">
+
+<dom-module id="d2l-course-image-tile">
+	<template strip-whitespace>
+		<style>
+			:host {
+				margin-bottom: 0.75rem;
+				--course-image-height: 5rem;
+			}
+
+			d2l-image-tile {
+				border-color: transparent;
+				text-align: inherit;
+				width: 100%;
+				--d2l-image-tile-image-height: var(--course-image-height);
+			}
+			d2l-icon {
+				color: white;
+				--d2l-icon-width: 18px;
+				--d2l-icon-height: 18px;
+			}
+
+			.flex {
+				display: flex;
+			}
+
+			.course-text {
+				margin-top: 0.6rem;
+				float: left;
+				flex: 1;
+				overflow: hidden;
+				word-wrap: break-word; /* IE/Edge */
+				overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
+			}
+			:host:hover .course-text,
+			:host:focus .course-text {
+				text-decoration: underline;
+			}
+			:host:hover a[disabled],
+			:host:focus a[disabled] {
+				cursor: default;
+			}
+			:host:hover a[disabled] .course-text,
+			:host:focus a[disabled] .course-text {
+				text-decoration: none;
+			}
+
+			.course-code-text,
+			.separator-icon,
+			.semester-text {
+				display: none;
+			}
+			:host([show-course-code]) .course-code-text,
+			:host([show-course-code]) .separator-icon,
+			:host([show-semester]) .semester-text {
+				display: inline-block;
+			}
+			.course-code-text,
+			.semester-text  {
+				-ms-word-break: break-all;
+				word-break: break-all;
+				word-break: break-word; /* Best case, only works in Chrome though */
+				@apply --d2l-body-small-text;
+			}
+			.separator-icon {
+				color: var(--d2l-color-tungsten)
+			}
+			.uppercase {
+				text-transform: uppercase;
+			}
+
+			.pin-indicator {
+				line-height: 20px;
+				opacity: 1;
+				background: rgba(0,0,0,0.5);
+				border: none;
+				border-radius: 5px;
+				transition: color 0.5s, background 0.5s, opacity 0.25s, width 0.15s, margin-right 0.25s, padding-left 0.25s, padding-right 0.25s;
+				cursor: pointer;
+				width: 35px;
+				height: 35px;
+				margin-right: 10px;
+			}
+			.pin-indicator:hover,
+			.pin-indicator:focus {
+				color: rgba(255,255,255,1);
+				background: var(--d2l-color-celestine);
+			}
+			:host-context([dir="rtl"]) .pin-indicator {
+				margin-left: 10px;
+				margin-right: auto;
+			}
+		</style>
+
+		<d2l-image-tile
+			hover-effect="[[_hoverEffects]]"
+			dropdown-label="[[_courseSettingsLabel]]"
+			no-mobile-more-button>
+			<d2l-course-image
+				slot="d2l-image-tile-image"
+				aria-hidden="true"
+				class="image-layer-bottom"
+				image="[[_image]]"
+				sizes="[[tileSizes]]"
+				type="tile">
+			</d2l-course-image>
+			<d2l-dropdown-menu slot="d2l-image-tile-dropdown">
+				<d2l-menu>
+					<d2l-menu-item-link
+						hidden$="[[!_canAccessCourseInfo]]"
+						text="[[localize('courseOfferingInformation')]]"
+						href="[[_courseInfoUrl]]">
+					</d2l-menu-item-link>
+					<d2l-menu-item
+						on-d2l-menu-item-select="_launchCourseImageSelector"
+						hidden$="[[!_canChangeCourseImage]]"
+						text="[[localize('changeImage')]]">
+					</d2l-menu-item>
+					<d2l-menu-item
+						on-d2l-menu-item-select="_pinClickHandler"
+						hidden$="[[pinned]]"
+						text="[[localize('pin')]]">
+					</d2l-menu-item>
+					<d2l-menu-item
+						on-d2l-menu-item-select="_pinClickHandler"
+						hidden$="[[!pinned]]"
+						text="[[localize('unpin')]]">
+					</d2l-menu-item>
+				</d2l-menu>
+			</d2l-dropdown-menu>
+			<button
+				slot="d2l-image-tile-menu-adjacent"
+				hidden$="[[!pinned]]"
+				class="pin-indicator"
+				on-tap="_pinClickHandler"
+				on-keypress="_pinClickHandler"
+				aria-label$="[[_pinButtonLabel]]">
+				<d2l-icon hidden$="[[!pinned]]" icon="d2l-tier1:pin-filled"></d2l-icon>
+			</button>
+
+			<a
+				href="[[_organizationHomepageUrl]]"
+				aria-disabled="[[!_canAccessCourse]]">
+				<div class="flex">
+					<div class="course-text">
+						[[_organization.properties.name]]
+						<div>
+							<span class="course-code-text uppercase">[[_organization.properties.code]]</span>
+							<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
+							<span class="semester-text">[[_semesterName]]</span>
+						</div>
+					</div>
+				</div>
+			</a>
+		</d2l-image-tile>
+	</template>
+	<script>
+		Polymer({
+			is: 'd2l-course-image-tile',
+
+			properties: {
+				courseUpdatesConfig: Object,
+				enrollment: Object,
+				pinned: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				showCourseCode: {
+					type: Boolean,
+					reflectToAttribute: true
+				},
+				showSemester: {
+					type: Boolean,
+					reflectToAttribute: true
+				},
+				startedInactive: {
+					type: Boolean,
+					value: false,
+					reflectToAttribute: true
+				},
+				tileSizes: Object,
+
+				_canAccessCourse: {
+					type: Boolean,
+					value: false
+				},
+				_canAccessCourseInfo: {
+					type: Boolean,
+					computed: '_computeCanAccessCourseInfo(_organization)'
+				},
+				_canChangeCourseImage: {
+					type: Boolean,
+					computed: '_computeCanChangeCourseImage(_organization)'
+				},
+				_courseInfoUrl: String,
+				_courseSettingsLabel: {
+					type: String,
+					computed: '_computeCourseSettingsLabel(_organization)'
+				},
+				_hoverEffects: {
+					type: String,
+					value: 'emphasize-image lower-menu'
+				},
+				_image: Object,
+				_load: Boolean,
+				_organization: Object,
+				_organizationHomepageUrl: String,
+				_pinButtonLabel: {
+					type: String,
+					computed: '_computePinButtonLabel(_organization)'
+				},
+				_semesterName: String,
+				_semesterUrl: String,
+				_showSeparator: {
+					type: Boolean,
+					value: false,
+					computed: '_computeShowSeparator(_semesterName)'
+				}
+			},
+			behaviors: [
+				window.D2L.Hypermedia.HMConstantsBehavior,
+				window.D2L.Hypermedia.OrganizationHMBehavior,
+				window.D2L.MyCourses.UtilityBehavior,
+				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
+			],
+			observers: [
+				'_fetchEnrollmentData(_load, enrollment)'
+			],
+			attached: function() {
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					var anchorElement = this.$$('d2l-image-tile');
+
+					var observerCallback = function(entries, observer) {
+						if (this._load) {
+							// The tile already loaded via requestIdleCallback/setTimeout
+							return;
+						}
+
+						for (var i = 0; i < entries.length; i++) {
+							// Chrome/FF immediately call the callback when we observer.observe()
+							// so we need to also make sure the tile is visible for that first run
+							// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
+							if (entries[i].intersectionRatio > 0) {
+								observer.unobserve(anchorElement);
+								this.fire('initially-visible-course-tile');
+								this._load = true;
+								break;
+							}
+						}
+					};
+
+					// Small shim for Edge/IE/Safari
+					var delayFunction = window.requestIdleCallback || setTimeout;
+					delayFunction(function() {
+						if (this._load) {
+							// The tile already loaded via the IntersectionObserver
+							return;
+						}
+						// Whether we load because the tile became visible, or because we got some
+						// idle time, we want to disconnect the observer either way
+						observer.unobserve(anchorElement);
+						this._load = true;
+					}.bind(this));
+
+					var observer = new IntersectionObserver(observerCallback.bind(this));
+					observer.observe(anchorElement);
+				});
+			},
+			ready: function() {
+				Polymer.IronA11yAnnouncer.requestAvailability();
+			},
+
+			_computeCanAccessCourseInfo: function(organization) {
+				return organization
+					&& organization.hasLinkByRel(this.HypermediaRels.courseOfferingInfoPage);
+			},
+			_computeCanChangeCourseImage: function(organization) {
+				return organization
+					&& organization.hasActionByName(this.HypermediaActions.organizations.setCatalogImage);
+			},
+			_computeCourseSettingsLabel: function(organization) {
+				return organization
+					&& organization.properties
+					&& this.localize('courseSettings', 'course', organization.properties.name);
+			},
+			_computePinButtonLabel: function(organization) {
+				return organization
+					&& organization.properties
+					&& this.localize('coursePinButton', 'course', organization.properties.name);
+			},
+			_computeShowSeparator: function(semesterName) {
+				return this.showSemester && semesterName.length > 0;
+			},
+
+			_fetchEnrollmentData: function(load, enrollment) {
+				if (!load || !enrollment || !enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
+					return;
+				}
+
+				this.pinned = enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
+
+				var organizationHref = enrollment.getLinkByRel(this.HypermediaRels.organization).href;
+				organizationHref += '?embedDepth=1';
+
+				return this._fetchOrganization(organizationHref)
+					.then(this._fetchSemester.bind(this));
+			},
+			_fetchOrganization: function(url) {
+				return window.d2lfetch
+					.fetch(new Request(url, {
+						headers: {
+							'accept': 'application/vnd.siren+json',
+							// Needs no-cache so that images refresh if the users here using the back button
+							'cache-control': 'no-cache',
+							'pragma': 'no-cache'
+						}
+					}))
+					.then(this.responseToSirenEntity.bind(this))
+					.then(this._handleOrganizationResponse.bind(this));
+			},
+			_fetchSemester: function() {
+				if (!this._semesterUrl || !this.showSemester) {
+					return Promise.resolve();
+				}
+
+				return this.fetchSirenEntity(this._semesterUrl)
+					.then(function(semester) {
+						this._semesterName = (semester.properties || {}).name;
+					}.bind(this));
+			},
+			_handleOrganizationResponse: function(organization) {
+				this._organization = organization;
+
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					// Telemetry event for organization loaded, meaning tile is interactive
+					this.fire('course-tile-organization');
+				});
+
+				if (organization.hasLinkByRel(this.HypermediaRels.courseOfferingInfoPage)) {
+					this._courseInfoUrl = organization.getLinkByRel(this.HypermediaRels.courseOfferingInfoPage).href;
+				}
+				if (organization.hasLinkByRel(this.HypermediaRels.parentSemester)) {
+					this._semesterUrl = organization.getLinkByRel(this.HypermediaRels.parentSemester).href;
+				}
+				if (organization.hasLinkByRel(this.HypermediaRels.Notifications.organizationNotifications)) {
+					this._notificationsUrl = organization.getLinkByRel(this.HypermediaRels.Notifications.organizationNotifications).href;
+				}
+				if (organization.hasSubEntityByClass(this.HypermediaClasses.courseImage.courseImage)) {
+					this._image = organization.getSubEntityByClass(this.HypermediaClasses.courseImage.courseImage);
+				}
+				if (organization.hasSubEntityByRel(this.HypermediaRels.organizationHomepage)) {
+					var homepageEntity = organization.getSubEntityByRel(this.HypermediaRels.organizationHomepage);
+					this._organizationHomepageUrl = homepageEntity
+						&& homepageEntity.properties
+						&& homepageEntity.properties.path;
+				} else {
+					// If the user doens't have access, don't animate image/show menu/underline on hover
+					this._hoverEffects = '';
+					this._canAccessCourse = false;
+					this.$$('a').setAttribute('disabled', '');
+				}
+
+				return Promise.resolve();
+			}
+		});
+	</script>
+</dom-module>

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -28,6 +28,11 @@
 			courseUpdatesConfig: Object,
 			// Callback for upload in image-selector
 			courseImageUploadCb: Function,
+			// Feature flag for using d2l-course-image-tile and CSS grid view
+			cssGridView: {
+				type: Boolean,
+				value: false
+			},
 			// Feature flag (switch) for using the updated sort logic and related fetaures
 			updatedSortLogic: {
 				type: Boolean,

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -95,13 +95,15 @@
 			document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
 			this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 
-			if (this.cssGridView) {
-				window.addEventListener('resize', this._onResize.bind(this));
-				// Sets initial number of columns
-				this._onResize();
-			} else {
-				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
-			}
+			Polymer.RenderStatus.afterNextRender(this, function() {
+				if (this.cssGridView) {
+					window.addEventListener('resize', this._onResize.bind(this));
+					// Sets initial number of columns
+					this._onResize();
+				} else {
+					this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
+				}
+			});
 		},
 		detached: function() {
 			document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -83,7 +83,8 @@
 			'enrollment-unpinned': '_onEnrollmentPinAction',
 			'course-tile-organization': '_onCourseTileOrganization',
 			'course-image-loaded': '_onCourseImageLoaded',
-			'initially-visible-course-tile': '_onInitiallyVisibleCourseTile'
+			'initially-visible-course-tile': '_onInitiallyVisibleCourseTile',
+			'started-inactive': '_onStartedInactiveAlert'
 		},
 		attached: function() {
 			this.performanceMark('d2l.my-courses.attached');
@@ -92,12 +93,23 @@
 			this._onEnrollmentPinnedMessage = this._onEnrollmentPinnedMessage.bind(this);
 			document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
-			this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 			this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
+
+			if (this.cssGridView) {
+				window.addEventListener('resize', this._onResize.bind(this));
+				// Sets initial number of columns
+				this._onResize();
+			} else {
+				this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
+			}
 		},
 		detached: function() {
 			document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
+
+			if (this.cssGridView) {
+				window.removeEventListener('resize', this._onResize.bind(this));
+			}
 		},
 		observers: [
 			'_enrollmentsChanged(_enrollments)',
@@ -110,12 +122,21 @@
 		courseImageUploadCompleted: function(success) {
 			if (success) {
 				this.$['basic-image-selector-overlay'].close();
-				this.$$('d2l-course-tile-grid').refreshCourseTileImage(this._setImageOrg);
+
+				if (this.cssGridView) {
+					var courseTiles = this.$$('.course-tile-grid').querySelectorAll('d2l-course-image-tile');
+					for (var i = 0; i < courseTiles.length; i++) {
+						courseTiles[i].refreshImage(this._setImageOrg);
+					}
+				} else {
+					this.$$('d2l-course-tile-grid').refreshCourseTileImage(this._setImageOrg);
+				}
 			}
 			this.focus();
 		},
 		focus: function() {
-			if (this.$$('d2l-course-tile-grid').focus(this._setImageOrg)) {
+			var tileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
+			if (tileGrid.focus(this._setImageOrg)) {
 				return;
 			}
 			this.$.viewAllCourses.focus();
@@ -282,11 +303,29 @@
 					}
 				}.bind(this));
 		},
+		_onResize: function() {
+			var courseTileGrid = this.$$('.course-tile-grid');
+
+			var containerWidth = this.$$('.spinner-container').offsetWidth;
+			var numColumns = Math.min(Math.floor(containerWidth / 300), 4) + 1;
+			courseTileGrid.classList.remove('columns-1');
+			courseTileGrid.classList.remove('columns-2');
+			courseTileGrid.classList.remove('columns-3');
+			courseTileGrid.classList.remove('columns-4');
+			courseTileGrid.classList.add('columns-' + numColumns);
+		},
 		_onStartedInactiveAlert: function(e) {
 			var type = e && e.detail && e.detail.type;
 
 			this._removeAlert('startedInactiveCourses');
-			if (this.$$('d2l-course-tile-grid').checkForStartedInactive(type)) {
+			var hasStartedInactiveCourses = false;
+			if (this.cssGridView) {
+				hasStartedInactiveCourses = !!this.$$('.course-tile-grid d2l-course-image-tile[started-inactive]');
+			} else {
+				hasStartedInactiveCourses = this.$$('d2l-course-tile-grid').checkForStartedInactive(type);
+			}
+
+			if (hasStartedInactiveCourses) {
 				this._addAlert('warning', 'startedInactiveCourses', this.localize('startedInactiveAlert'));
 			}
 		},
@@ -314,7 +353,7 @@
 			if (this._allCoursesCreated) {
 				this.$$('d2l-all-courses').setCourseImage(e);
 			}
-			this.$$('d2l-course-tile-grid').setCourseImage(e);
+			!this.cssGridView && this.$$('d2l-course-tile-grid').setCourseImage(e);
 		},
 
 		/*
@@ -452,7 +491,8 @@
 				&& searchAction.getFieldByName('sort').value.toLowerCase() === 'current'
 			) {
 				// When using Current sort, hide past courses in the widget view
-				this.$$('d2l-course-tile-grid').setAttribute('hide-past-courses', '');
+				var tileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
+				tileGrid.setAttribute('hide-past-courses', '');
 			}
 
 			enrollmentEntities.forEach(function(enrollment) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -80,29 +80,32 @@
 						on-tap="_refreshPage">[[localize('refresh')]]</a>
 				</d2l-alert>
 			</template>
-			<div class="course-tile-grid" hidden$="[[!cssGridView]]">
-				<template is="dom-repeat" items="[[_enrollments]]">
-					<d2l-course-image-tile
-						enrollment="[[item]]"
-						tile-sizes="[[_tileSizes]]"
-						show-course-code="[[showCourseCode]]"
-						show-semester="[[showSemester]]"
-						course-updates-config="[[courseUpdatesConfig]]">
-					</d2l-course-image-tile>
-				</template>
-			</div>
-			<d2l-course-tile-grid
-				hidden$="[[cssGridView]]"
-				limit-to-12
-				enrollments="[[_enrollments]]"
-				tile-sizes="[[_tileSizes]]"
-				locale="[[locale]]"
-				show-course-code="[[showCourseCode]]"
-				show-semester="[[showSemester]]"
-				course-updates-config="[[courseUpdatesConfig]]"
-				updated-sort-logic="[[updatedSortLogic]]"
-				animate="[[_animateCourseTileGrid]]">
-			</d2l-course-tile-grid>
+			<template is="dom-if" if="[[cssGridView]]">
+				<div class="course-tile-grid">
+					<template is="dom-repeat" items="[[_enrollments]]">
+						<d2l-course-image-tile
+							enrollment="[[item]]"
+							tile-sizes="[[_tileSizes]]"
+							show-course-code="[[showCourseCode]]"
+							show-semester="[[showSemester]]"
+							course-updates-config="[[courseUpdatesConfig]]">
+						</d2l-course-image-tile>
+					</template>
+				</div>
+			</template>
+			<template is="dom-if" if="[[!cssGridView]]">
+				<d2l-course-tile-grid
+					limit-to-12
+					enrollments="[[_enrollments]]"
+					tile-sizes="[[_tileSizes]]"
+					locale="[[locale]]"
+					show-course-code="[[showCourseCode]]"
+					show-semester="[[showSemester]]"
+					course-updates-config="[[courseUpdatesConfig]]"
+					updated-sort-logic="[[updatedSortLogic]]"
+					animate="[[_animateCourseTileGrid]]">
+				</d2l-course-tile-grid>
+			</template>
 			<a
 				is="d2l-link"
 				id="viewAllCourses"

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
 <link rel="import" href="../d2l-all-courses.html">
+<link rel="import" href="../d2l-course-image-tile.html">
 <link rel="import" href="../d2l-course-tile-grid.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-my-courses-behavior.html">
@@ -37,6 +38,28 @@
 				margin-bottom: 20px;
 				clear: both;
 			}
+
+			.course-tile-grid {
+				display: grid;
+				grid-gap: 15px;
+			}
+			.course-tile-grid.columns-1 {
+				grid-template-columns: 100%;
+			}
+			.course-tile-grid.columns-2 {
+				grid-template-columns: 50% 50%;
+			}
+			.course-tile-grid.columns-3 {
+				grid-template-columns: 33% 33% 33%;
+			}
+			.course-tile-grid.columns-4 {
+				grid-template-columns: 25% 25% 25% 25%;
+			}
+
+			:host[hide-past-courses] d2l-course-image-tile[past-course]:not([pinned]),
+			d2l-course-image-tile:not([pinned]):not([past-course]):nth-child(n+13) {
+				display:none;
+			}
 		</style>
 
 		<div class="spinner-container">
@@ -57,7 +80,19 @@
 						on-tap="_refreshPage">[[localize('refresh')]]</a>
 				</d2l-alert>
 			</template>
+			<div class="course-tile-grid" hidden$="[[!cssGridView]]">
+				<template is="dom-repeat" items="[[_enrollments]]">
+					<d2l-course-image-tile
+						enrollment="[[item]]"
+						tile-sizes="[[_tileSizes]]"
+						show-course-code="[[showCourseCode]]"
+						show-semester="[[showSemester]]"
+						course-updates-config="[[courseUpdatesConfig]]">
+					</d2l-course-image-tile>
+				</template>
+			</div>
 			<d2l-course-tile-grid
+				hidden$="[[cssGridView]]"
 				limit-to-12
 				enrollments="[[_enrollments]]"
 				tile-sizes="[[_tileSizes]]"

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -19,7 +19,7 @@ describe('d2l-my-courses-content', () => {
 			}));
 	}
 
-	beforeEach(() => {
+	beforeEach(done => {
 		sandbox = sinon.sandbox.create();
 		searchAction = {
 			name: 'search-my-enrollments',
@@ -126,6 +126,10 @@ describe('d2l-my-courses-content', () => {
 
 		component = fixture('d2l-my-courses-content-fixture');
 		component.enrollmentsUrl = '/enrollments';
+
+		setTimeout(() => {
+			done();
+		});
 	});
 
 	afterEach(() => {

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -15,6 +15,7 @@ describe('d2l-my-courses', () => {
 		expect(component.courseImageUploadCompleted).to.be.a('function');
 		expect(component.getLastOrgUnitId).to.be.a('function');
 		expect(component.updatedSortLogic).to.equal(false);
+		expect(component.cssGridView).to.equal(false);
 	});
 
 	describe('Public API', () => {
@@ -30,7 +31,6 @@ describe('d2l-my-courses', () => {
 
 		it('should call d2l-my-courses-content.courseImageUploadCompleted', done => {
 			component.updatedSortLogic = true;
-
 			setTimeout(() => {
 				var stub = sandbox.stub(component.$$('d2l-my-courses-content'), 'courseImageUploadCompleted');
 				component.courseImageUploadCompleted();
@@ -51,7 +51,6 @@ describe('d2l-my-courses', () => {
 
 		it('should call d2l-my-courses-content.getLastOrgUnitId', done => {
 			component.updatedSortLogic = true;
-
 			setTimeout(() => {
 				var stub = sandbox.stub(component.$$('d2l-my-courses-content'), 'getLastOrgUnitId');
 				component.getLastOrgUnitId();


### PR DESCRIPTION
This version includes most of the basic functionality that d2l-course-tile has, but excludes functionality around course updates (fetching/displaying), pin/unpin (actually changing the state, that is), inactive/ended/not-yet-started overlays, started-inactive-pinned notification and alert, and setting/uploading course images. These will come in stages over the next PR(s).

Currently, you must set the `updated-course-tile` attribute on `d2l-my-courses` itself in order for this new component to be used in place of the old one. (Upcoming LP PR for this, too.)

TODO:

- [x] Merge LP PR with LD flag (optional really, this just won't do anything without it)
- [x] Wait for release of `d2l-tile` and update bower.json