### PR TITLE
Second stage turbine blade of d2l-course-image-tile (US90524)

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -371,6 +371,49 @@
 				}
 
 				return Promise.resolve();
+			},
+			_pinClickHandler: function() {
+				var pinAction = this.pinned
+					? this.enrollment.getActionByName(this.HypermediaActions.enrollments.unpinCourse)
+					: this.enrollment.getActionByName(this.HypermediaActions.enrollments.pinCourse);
+
+				var body = '';
+				var fields = pinAction.fields || [];
+				fields.forEach(function(field) {
+					body = body + encodeURIComponent(field.name) + '=' + encodeURIComponent(field.value) + '&';
+				});
+
+				this.fire(this.pinned ? 'enrollment-pinned' : 'enrollment-unpinned', {
+					enrollment: this.enrollment,
+					organization: this._organization
+				});
+
+				var localizeKey = this.pinned ? 'unpinActionResult' : 'pinActionResult';
+				this.fire('iron-announce', {
+					text: this.localize(localizeKey, 'course', this._organization.properties.name)
+				}, { bubbles: true });
+
+				return window.d2lfetch
+					.fetch(new Request(pinAction.href, {
+						method: pinAction.method,
+						body: body,
+						headers: {
+							'accept':'application/vnd.siren+json',
+							'content-type':'application/x-www-form-urlencoded'
+						}
+					}))
+					.then(this.responseToSirenEntity.bind(this))
+					.then(function(enrollment) {
+						this.enrollment = enrollment;
+					}.bind(this))
+					.then(function() {
+						// Wait until after PUT has finished to fire, so that
+						// listeners are guaranteed to fetch updated entity
+						this.fire('d2l-course-pinned-change', {
+							enrollment: this.enrollment,
+							isPinned: this.pinned
+						});
+					}.bind(this));
 			}
 		});
 	</script>

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item-link.html">
+<link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-tile/d2l-image-tile.html">
 <link rel="import" href="localize-behavior.html">
@@ -101,6 +102,21 @@
 				margin-left: 10px;
 				margin-right: auto;
 			}
+
+			.update-text-box {
+				border: 2px solid var(--d2l-color-carnelian);
+				color: var(--d2l-color-carnelian);
+				border-radius: 0.25rem;
+				font-size: 1rem;
+				font-weight: 700;
+				width: 2rem;
+				height: 2rem;
+				line-height: 2rem;
+				display: inline-flex;
+				margin-top: 0.25rem;
+				align-items: center;
+				justify-content: center;
+			}
 		</style>
 
 		<d2l-image-tile
@@ -159,6 +175,10 @@
 						<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
 						<span class="semester-text">[[_semesterName]]</span>
 					</div>
+				</div>
+				<div hidden$="[[!_showUpdateCount]]">
+					<d2l-offscreen>[[localize('courseTile.updates')]]</d2l-offscreen>
+					<span class="update-text-box">[[_updateCount]]</span>
 				</div>
 			</div>
 		</d2l-image-tile>
@@ -225,6 +245,19 @@
 					type: Boolean,
 					value: false,
 					computed: '_computeShowSeparator(_semesterName)'
+				},
+				_showUpdateCount: {
+					type: Boolean,
+					value: false,
+					computed: '_computeShowUpdateCount(courseUpdatesConfig, _updateCount)'
+				},
+				_updateString: {
+					type: String,
+					computed: '_computeUpdateString(_updateCount)'
+				},
+				_updateCount: {
+					type: Number,
+					value: 0
 				}
 			},
 			behaviors: [
@@ -301,6 +334,12 @@
 			_computeShowSeparator: function(semesterName) {
 				return this.showSemester && semesterName.length > 0;
 			},
+			_computeShowUpdateCount: function(courseUpdatesConfig, updateCount) {
+				return !!courseUpdatesConfig && updateCount > 0;
+			},
+			_computeUpdateString: function(updateCount) {
+				return updateCount + (updateCount > 99 ? '+' : '');
+			},
 
 			_fetchEnrollmentData: function(load, enrollment) {
 				if (!load || !enrollment || !enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
@@ -313,7 +352,12 @@
 				organizationHref += '?embedDepth=1';
 
 				return this._fetchOrganization(organizationHref)
-					.then(this._fetchSemester.bind(this));
+					.then(function() {
+						return Promise.all([
+							this._fetchSemester(),
+							this._fetchNotifications()
+						]);
+					}.bind(this));
 			},
 			_fetchOrganization: function(url) {
 				return window.d2lfetch
@@ -327,6 +371,41 @@
 					}))
 					.then(this.responseToSirenEntity.bind(this))
 					.then(this._handleOrganizationResponse.bind(this));
+			},
+			_fetchNotifications: function() {
+				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
+					return Promise.resolve();
+				}
+
+				return this.fetchSirenEntity(this._notificationsUrl)
+					.then(function(notifications) {
+						if (!notifications) {
+							return;
+						}
+
+						var total = 0;
+						if (this.courseUpdatesConfig.showUnattemptedQuizzes) {
+							total += notifications.properties.UnattemptedQuizzes;
+						}
+						if (this.courseUpdatesConfig.showDropboxUnreadFeedback) {
+							total += notifications.properties.UnreadAssignmentFeedback;
+						}
+						if (this.courseUpdatesConfig.showUngradedQuizAttempts) {
+							total += notifications.properties.UngradedQuizzes;
+						}
+						if (this.courseUpdatesConfig.showUnreadDiscussionMessages) {
+							total += notifications.properties.UnreadDiscussions + notifications.properties.UnapprovedDiscussions;
+						}
+						if (this.courseUpdatesConfig.showUnreadDropboxSubmissions) {
+							total += notifications.properties.UnreadAssignmentSubmissions;
+						}
+
+						this._updateCount = total;
+					}.bind(this))
+					.catch(function() {
+						// If we fail to fetch notifications, hide the orange box (via computed _showUpdateCount)
+						this._updateCount = 0;
+					});
 			},
 			_fetchSemester: function() {
 				if (!this._semesterUrl || !this.showSemester) {


### PR DESCRIPTION
~Currently pointing at the first-phase branch, will be updated once that's merged.~

This adds the course update/notification count fetching and displaying, as well as the ability to pin/unpin via the menu or button. Like 99% recycled code from `d2l-course-tile`, with a few minor cleanups here and there.

TODO:

- [x] Merge #478 and rebase this