### PR TITLE
Third stage of new d2l-course-image-tile (US90524)

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../d2l-icons/d2l-icon.html">
 <link rel="import" href="../../d2l-icons/tier1-icons.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
+<link rel="import" href="../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item.html">
 <link rel="import" href="../../d2l-menu/d2l-menu-item-link.html">
 <link rel="import" href="../../d2l-offscreen/d2l-offscreen.html">
@@ -130,6 +131,53 @@
 				font-size: 0.8rem;
 			}
 
+			.icon-container {
+				height: 64px;
+				width: 64px;
+				display: flex;
+				justify-content: center;
+				align-items: center;
+				border-style: none;
+				border-radius: 100px;
+				background-color: white;
+				overflow: hidden;
+				position: absolute;
+				top: 0;
+				left: 0;
+				right: 0;
+				bottom: 0;
+				margin: auto;
+				animation-name: container;
+				animation-duration: 1s;
+				animation-fill-mode: forwards;
+			}
+			@keyframes container {
+				0% { height: 64px; width: 64px; }
+				70% { height: 64px; width: 64px; opacity: 1; }
+				90% { height: 80px; width: 80px; opacity: 0.4 }
+				100% { height: 20px; width: 20px; opacity: 0; }
+			}
+
+			.checkmark {
+				color: var(--d2l-color-olivine);
+			}
+			.fail-icon {
+				color: #ffce51;
+			}
+			.checkmark,
+			.fail-icon {
+				display: flex;
+				animation-name: inner;
+				animation-duration: 1s;
+				animation-fill-mode: forwards;
+			}
+			@keyframes inner {
+				0% { transform: scale(1); }
+				15% { transform: scale(2.30); }
+				20% { transform: scale(2.0); }
+				100% { transform: scale(2.0); }
+			}
+
 			.update-text-box {
 				border: 2px solid var(--d2l-color-carnelian);
 				color: var(--d2l-color-carnelian);
@@ -215,6 +263,12 @@
 				<div>[[_overlayInactive]]</div>
 			</div>
 			<div hidden$="[[_hasOverlay]]" class="overlay transparent"></div>
+			<div hidden$="[[!_imageLoading]]" class="overlay">
+				<d2l-loading-spinner hidden$="[[!_imageLoadingProgress]]" size="85"></d2l-loading-spinner>
+				<div class="icon-container" hidden$="[[_imageLoadingProgress]]">
+					<d2l-icon></d2l-icon>
+				</div>
+			</div>
 			<div class="alert-colour-circle" hidden$="[[!startedInactive]]"></div>
 			<div class="flex">
 				<div class="course-text">
@@ -223,10 +277,6 @@
 						<span class="course-code-text uppercase">[[_organization.properties.code]]</span>
 						<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
 						<span class="semester-text">[[_semesterName]]</span>
-					</div>
-					<div hidden$="[[!_showUpdateCount]]">
-						<d2l-offscreen>[[localize('courseTile.updates')]]</d2l-offscreen>
-						<span class="update-text-box">[[_updateCount]]</span>
 					</div>
 				</div>
 				<div hidden$="[[!_showUpdateCount]]">
@@ -289,6 +339,14 @@
 					value: 'emphasize-image lower-menu'
 				},
 				_image: Object,
+				_imageLoading: {
+					type: Boolean,
+					value: false
+				},
+				_imageLoadingProgress: {
+					type: Boolean,
+					value: false
+				},
 				_load: Boolean,
 				_organization: Object,
 				_organizationHomepageUrl: String,
@@ -334,6 +392,8 @@
 				'_fetchEnrollmentData(_load, enrollment)'
 			],
 			attached: function() {
+				document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
+
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					var imageTile = this.$$('d2l-image-tile');
 
@@ -373,8 +433,27 @@
 					observer.observe(imageTile);
 				});
 			},
+			detached: function() {
+				document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
+			},
 			ready: function() {
 				Polymer.IronA11yAnnouncer.requestAvailability();
+			},
+
+			refreshImage: function(organization) {
+				if (this.getEntityIdentifier(organization) !== this.getEntityIdentifier(this._organization)) {
+					return;
+				}
+
+				this._imageLoading = true;
+				this._imageLoadingProgress = true;
+
+				var organizationHref = organization.getLinkByRel('self').href;
+				organizationHref += '?embedDepth=1';
+
+				return this._fetchOrganization(organizationHref)
+					.then(this._displaySetImageResult.bind(this, true, true))
+					.catch(this._displaySetImageResult.bind(this, false));
 			},
 
 			_computeCanAccessCourseInfo: function(organization) {
@@ -447,6 +526,29 @@
 				return updateCount + (updateCount > 99 ? '+' : '');
 			},
 
+			_displaySetImageResult: function(success, skipSetImage) {
+				setTimeout(function() {
+					var icon = this.$$('.icon-container d2l-icon');
+					this.toggleClass('checkmark', false, icon);
+					this.toggleClass('fail-icon', false, icon);
+					var iconName = success ? 'd2l-tier2:check' : 'd2l-tier3:close';
+					var className = success ? 'checkmark' : 'fail-icon';
+					icon.setAttribute('icon', iconName);
+					this.toggleClass(className, true, icon);
+
+					// Hide the loading spinner, so that the success/failure icon shows
+					this._imageLoadingProgress = false;
+
+					if (success && !skipSetImage) {
+						this._image = this._nextImage;
+					}
+
+					setTimeout(function() {
+						// Hide the entire image-loading overlay and contents
+						this._imageLoading = false;
+					}.bind(this), 1000);
+				}.bind(this), 1000);
+			},
 			_fetchEnrollmentData: function(load, enrollment) {
 				if (!load || !enrollment || !enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
 					return;
@@ -556,6 +658,41 @@
 				}
 
 				return Promise.resolve();
+			},
+			_launchCourseImageSelector: function() {
+				this.fire('open-change-image-view', {
+					organization: this._organization
+				});
+			},
+			_onSetCourseImage: function(e) {
+				if (this.getEntityIdentifier(e.detail.organization) !== this.getEntityIdentifier(this._organization)) {
+					return;
+				}
+
+				this._imageLoading = true;
+
+				var status = e.detail.status;
+				var newImageHref = this.getDefaultImageLink(e.detail.image);
+				var newSrcSet = this.getImageSrcset(e.detail.image, 'tile');
+
+				switch (status) {
+					case 'set':
+						this._imageLoadingProgress = true;
+						// load the image while the loading spinner runs to that we have it when the spinner ends
+						this._nextImage = e.detail.image;
+						var imagePreloader = document.createElement('img');
+						imagePreloader.setAttribute('src', newImageHref);
+						imagePreloader.setAttribute('srcset', newSrcSet);
+						imagePreloader.setAttribute('sizes', this.$$('d2l-course-image').getTileSizes());
+						break;
+					case 'success':
+						this._displaySetImageResult(true);
+						break;
+					case 'failure':
+					default:
+						this._displaySetImageResult(false);
+						break;
+				}
 			},
 			_pinClickHandler: function() {
 				var pinAction = this.pinned

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -175,6 +175,10 @@
 						<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
 						<span class="semester-text">[[_semesterName]]</span>
 					</div>
+					<div hidden$="[[!_showUpdateCount]]">
+						<d2l-offscreen>[[localize('courseTile.updates')]]</d2l-offscreen>
+						<span class="update-text-box">[[_updateCount]]</span>
+					</div>
 				</div>
 				<div hidden$="[[!_showUpdateCount]]">
 					<d2l-offscreen>[[localize('courseTile.updates')]]</d2l-offscreen>

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -17,14 +17,15 @@
 	<template strip-whitespace>
 		<style>
 			:host {
-				margin-bottom: 0.75rem;
-				--course-image-height: 5rem;
+				--course-tile-height: 200px;
+				--course-image-height: 43%;
 			}
 
 			d2l-image-tile {
 				border-color: transparent;
 				text-align: inherit;
 				width: 100%;
+				height: var(--course-tile-height);
 				--d2l-image-tile-image-height: var(--course-image-height);
 			}
 			d2l-icon {
@@ -110,8 +111,10 @@
 				flex-direction: column;
 				justify-content: center;
 				position: absolute;
-				top: calc(-1 * var(--course-image-height));
-				height: var(--course-image-height);
+				/* can't do calc(--course-tile-height * --course-image-height * -1) */
+				top: -86px;
+				/* can't do calc(--course-tile-height * --course-image-height) */
+				height: 86px;
 				width: 100%;
 				border-top-left-radius: 6px;
 				border-top-right-radius: 6px;
@@ -194,9 +197,9 @@
 			}
 
 			.alert-colour-circle {
-				height: 24px;
-				width: 24px;
-				border-radius: 12px;
+				height: 20px;
+				width: 20px;
+				border-radius: 20px;
 				border: 3px solid white;
 				background-color: #ffce51;
 				position: absolute;
@@ -654,7 +657,7 @@
 					// If the user doens't have access, don't animate image/show menu/underline on hover
 					this._hoverEffects = '';
 					this._canAccessCourse = false;
-					this.$$('a').setAttribute('disabled', '');
+					this.$$('d2l-image-tile').setAttribute('disabled', '');
 				}
 
 				return Promise.resolve();

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -103,6 +103,33 @@
 				margin-right: auto;
 			}
 
+			.overlay {
+				box-sizing: border-box;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				position: absolute;
+				top: calc(-1 * var(--course-image-height));
+				height: var(--course-image-height);
+				width: 100%;
+				border-top-left-radius: 6px;
+				border-top-right-radius: 6px;
+				color: white;
+				padding: 10px;
+				text-align: center;
+				background-color: rgba(0,0,0,0.7);
+			}
+			.overlay.transparent {
+				background-color: transparent;
+			}
+			.overlay-text {
+				font-size: 1rem;
+				font-weight: bold;
+			}
+			.overlay-date {
+				font-size: 0.8rem;
+			}
+
 			.update-text-box {
 				border: 2px solid var(--d2l-color-carnelian);
 				color: var(--d2l-color-carnelian);
@@ -116,6 +143,21 @@
 				margin-top: 0.25rem;
 				align-items: center;
 				justify-content: center;
+			}
+
+			.alert-colour-circle {
+				height: 24px;
+				width: 24px;
+				border-radius: 12px;
+				border: 3px solid white;
+				background-color: #ffce51;
+				position: absolute;
+				top: calc(-1 * var(--course-image-height) - 12px);
+				right: -12px;
+			}
+			[dir="rtl"] .alert-colour-circle {
+				right: auto;
+				left: -2px;
 			}
 		</style>
 
@@ -167,6 +209,13 @@
 				<d2l-icon hidden$="[[!pinned]]" icon="d2l-tier1:pin-filled"></d2l-icon>
 			</button>
 
+			<div hidden$="[[!_hasOverlay]]" class="overlay">
+				<div class="overlay-text">[[_overlayTitle]]</div>
+				<div class="overlay-date">[[_overlayDate]]</div>
+				<div>[[_overlayInactive]]</div>
+			</div>
+			<div hidden$="[[_hasOverlay]]" class="overlay transparent"></div>
+			<div class="alert-colour-circle" hidden$="[[!startedInactive]]"></div>
 			<div class="flex">
 				<div class="course-text">
 					[[_organization.properties.name]]
@@ -231,6 +280,10 @@
 					type: String,
 					computed: '_computeCourseSettingsLabel(_organization)'
 				},
+				_hasOverlay: {
+					type: Boolean,
+					value: false
+				},
 				_hoverEffects: {
 					type: String,
 					value: 'emphasize-image lower-menu'
@@ -239,6 +292,13 @@
 				_load: Boolean,
 				_organization: Object,
 				_organizationHomepageUrl: String,
+				_overlayAnnounceText: {
+					type: String,
+					computed: '_computeOverlayAnnounceText(_organization)'
+				},
+				_overlayDate: String,
+				_overlayInactive: String,
+				_overlayTitle: String,
 				_pinButtonLabel: {
 					type: String,
 					computed: '_computePinButtonLabel(_organization)'
@@ -329,6 +389,48 @@
 				return organization
 					&& organization.properties
 					&& this.localize('courseSettings', 'course', organization.properties.name);
+			},
+			_computeOverlayAnnounceText: function(organization) {
+				var nowDate = Date.now();
+				var endDate = Date.parse(organization.properties.endDate);
+				var startDate = Date.parse(organization.properties.startDate);
+				var inactive = !organization.properties.isActive;
+
+				this.removeAttribute('past-course');
+				this._hasOverlay = true;
+
+				if (endDate < nowDate) {
+					this.setAttribute('past-course', '');
+					endDate = new Date(endDate);
+					this._overlayDate = this.formatDateTime(endDate, {format: 'medium'});
+					this._overlayInactive = null;
+					this._overlayTitle = this.localize('overlay.courseClosed');
+					return this.localize('courseEnded', 'date', this.formatDate(endDate, {format: 'MMMM d, yyyy'}), 'time', this.formatTime(endDate));
+				} else if (startDate > nowDate) {
+					startDate = new Date(startDate);
+					this._overlayDate = this.formatDateTime(startDate, {format: 'medium'});
+					this._overlayInactive = inactive ? null : this.localize('brackets', 'content', this.localize('overlay.inactive'));
+					this._overlayTitle = this.localize('overlay.courseOpens');
+					return this.localize('courseStarting', 'date', this.formatDate(startDate, {format: 'MMMM d, yyyy'}), 'time', this.formatTime(startDate));
+				} else if (startDate && inactive) {
+					this._overlayInactive = this.localize('brackets', 'content', this.localize('overlay.inactive'));
+					this._overlayTitle = this.localize('overlay.courseStarted');
+					if (this.pinned) {
+						// We only care about calling out started-inactive courses if they're pinned
+						this.startedInactive = true;
+						this.fire('started-inactive');
+					}
+					return this._overlayTitle + ' ' + this._overlayInactive;
+				} else if (inactive) {
+					this._overlayTitle = this.localize('overlay.inactive');
+					return this._overlayTitle;
+				} else {
+					this._overlayDate = null;
+					this._overlayInactive = null;
+					this._overlayTitle = null;
+					this._hasOverlay = false;
+					return null;
+				}
 			},
 			_computePinButtonLabel: function(organization) {
 				return organization

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -546,8 +546,11 @@
 				.then(this._populateEnrollments.bind(this));
 		},
 		_addOnlyPastCoursesAlert: function(hasCurrentOrFutureCourseArg, hidesPastCoursesArg) {
-			var hasCurrentOrFutureCourse = hasCurrentOrFutureCourseArg || this.$$('d2l-course-tile-grid').$$('d2l-course-tile:not([past-course])'),
-				hidesPastCourses = hidesPastCoursesArg || this.$$('d2l-course-tile-grid').hasAttribute('hide-past-courses');
+			var courseTileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
+			var selector = 'd2l-course-' + (this.cssGridView ? 'image-' : '') + 'tile:not([past-course])';
+
+			var hasCurrentOrFutureCourse = hasCurrentOrFutureCourseArg || courseTileGrid.$$(selector),
+				hidesPastCourses = hidesPastCoursesArg || courseTileGrid.hasAttribute('hide-past-courses');
 			if (this._hasEnrollments && !hasCurrentOrFutureCourse && hidesPastCourses && !this._hasAlert('onlyPastCourses')) {
 				this._addAlert('call-to-action', 'onlyPastCourses', this.localize('onlyPastCoursesMessage'));
 			}

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -47,13 +47,13 @@
 				grid-template-columns: 100%;
 			}
 			.course-tile-grid.columns-2 {
-				grid-template-columns: 50% 50%;
+				grid-template-columns: repeat(2, 1fr);
 			}
 			.course-tile-grid.columns-3 {
-				grid-template-columns: 33% 33% 33%;
+				grid-template-columns: repeat(3, 1fr);
 			}
 			.course-tile-grid.columns-4 {
-				grid-template-columns: 25% 25% 25% 25%;
+				grid-template-columns: repeat(4, 1fr);
 			}
 
 			:host[hide-past-courses] d2l-course-image-tile[past-course]:not([pinned]),


### PR DESCRIPTION
This adds the various overlays (changing image, course inactive, course ended, etc.) as well as the course image changing/uploading functionality. Much like #479, this is largely copied code from the existing `d2l-course-tile`, but with some minor updates.

Once again, this is feature flagged (default-off right now) - there are still some "outstanding things" that need to be done that will be a follow-up (eventually...), so this is a low-risk change.

TODO:

- [x] Merge #479 and rebase this