### PR TITLE
US90524 IE11 support (CSS grid)

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -44,7 +44,7 @@
     "d2l-polymer-behaviors": "^1.1.0",
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^2.2.0",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^1.1.2",
-    "d2l-tile": "^3.0.1",
+    "d2l-tile": "^3.0.2",
     "d2l-typography": "^5.5.0",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.0",
     "iron-a11y-announcer": "^1.0.6",

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -18,6 +18,7 @@
 	<template strip-whitespace>
 		<style>
 			:host {
+				display: block;
 				--course-image-height: 6rem;
 			}
 
@@ -249,7 +250,7 @@
 				hidden$="[[!pinned]]"
 				class="pin-indicator"
 				on-tap="_pinClickHandler"
-				on-keypress="_pinClickHandler"
+				on-keypress="_pinPressHandler"
 				aria-label$="[[_pinButtonLabel]]">
 				<d2l-icon icon="d2l-tier1:pin-filled"></d2l-icon>
 			</button>
@@ -761,6 +762,11 @@
 							isPinned: this.pinned
 						});
 					}.bind(this));
+			},
+			_pinPressHandler: function(e) {
+				if (e.code === 'Space' || e.code === 'Enter') {
+					this._pinClickHandler();
+				}
 			}
 		});
 	</script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -308,16 +308,43 @@
 					}
 				}.bind(this));
 		},
-		_onResize: function() {
+		_onResize: function(ie11retryCount) {
 			var courseTileGrid = this.$$('.course-tile-grid');
 
 			var containerWidth = this.$$('.spinner-container').offsetWidth;
-			var numColumns = Math.min(Math.floor(containerWidth / 300), 4) + 1;
+			var numColumns = Math.min(Math.floor(containerWidth / 350), 4) + 1;
 			courseTileGrid.classList.remove('columns-1');
 			courseTileGrid.classList.remove('columns-2');
 			courseTileGrid.classList.remove('columns-3');
 			courseTileGrid.classList.remove('columns-4');
 			courseTileGrid.classList.add('columns-' + numColumns);
+
+			var cssGridStyle = document.body.style['grid-template-columns'];
+			// Can be empty string, hence the strict comparison
+			if (cssGridStyle !== undefined) {
+				return;
+			}
+
+			var courseTileDivs = this.querySelectorAll('.course-tile-grid > div');
+			ie11retryCount = ie11retryCount || 0;
+			if (
+				ie11retryCount < 10
+				&& courseTileDivs.length === 0
+			) {
+				// If course tiles haven't yet rendered, try again for up to one second
+				// (only happens sometimes, only in IE)
+				setTimeout(this._onResize.bind(this, ie11retryCount++), 100);
+				return;
+			}
+
+			for (var i = 0; i < courseTileDivs.length; i++) {
+				var div = courseTileDivs[i];
+				// The (* 2 - 1) accounts for the grid-gap-esque columns
+				var column = (i % numColumns + 1) * 2 - 1;
+				var row = Math.floor(i / numColumns) + 1;
+				div.style['-ms-grid-column'] = column;
+				div.style['-ms-grid-row'] = row;
+			}
 		},
 		_onStartedInactiveAlert: function(e) {
 			this._removeAlert('startedInactiveCourses');

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -313,11 +313,14 @@
 
 			var containerWidth = this.$$('.spinner-container').offsetWidth;
 			var numColumns = Math.min(Math.floor(containerWidth / 350), 4) + 1;
-			courseTileGrid.classList.remove('columns-1');
-			courseTileGrid.classList.remove('columns-2');
-			courseTileGrid.classList.remove('columns-3');
-			courseTileGrid.classList.remove('columns-4');
-			courseTileGrid.classList.add('columns-' + numColumns);
+			var columnClass = 'columns-' + numColumns;
+			if (courseTileGrid.classList.toString().indexOf(columnClass) === -1) {
+				courseTileGrid.classList.remove('columns-1');
+				courseTileGrid.classList.remove('columns-2');
+				courseTileGrid.classList.remove('columns-3');
+				courseTileGrid.classList.remove('columns-4');
+				courseTileGrid.classList.add('columns-' + numColumns);
+			}
 
 			var cssGridStyle = document.body.style['grid-template-columns'];
 			// Can be empty string, hence the strict comparison

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -40,24 +40,32 @@
 			}
 
 			.course-tile-grid {
+				display: -ms-grid;
 				display: grid;
-				grid-gap: 15px;
+				grid-column-gap: 15px;
 			}
 			.course-tile-grid.columns-1 {
 				grid-template-columns: 100%;
+				-ms-grid-columns: 100%;
 			}
 			.course-tile-grid.columns-2 {
 				grid-template-columns: repeat(2, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr;
 			}
 			.course-tile-grid.columns-3 {
 				grid-template-columns: repeat(3, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr 15px 1fr;
 			}
 			.course-tile-grid.columns-4 {
 				grid-template-columns: repeat(4, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr 15px 1fr 15px 1fr;
 			}
 
+			d2l-course-image-tile {
+				margin-bottom: 0.75rem;
+			}
 			:host[hide-past-courses] d2l-course-image-tile[past-course]:not([pinned]),
-			d2l-course-image-tile:not([pinned]):not([past-course]):nth-child(n+13) {
+			div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
 				display:none;
 			}
 		</style>
@@ -78,13 +86,15 @@
 			<template is="dom-if" if="[[cssGridView]]">
 				<div class="course-tile-grid">
 					<template is="dom-repeat" items="[[_enrollments]]">
-						<d2l-course-image-tile
-							enrollment="[[item]]"
-							tile-sizes="[[_tileSizes]]"
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]">
-						</d2l-course-image-tile>
+						<div>
+							<d2l-course-image-tile
+								enrollment="[[item]]"
+								tile-sizes="[[_tileSizes]]"
+								show-course-code="[[showCourseCode]]"
+								show-semester="[[showSemester]]"
+								course-updates-config="[[courseUpdatesConfig]]">
+							</d2l-course-image-tile>
+						</div>
 					</template>
 				</div>
 			</template>


### PR DESCRIPTION
This allows for the CSS grid layout to work in IE11. Unfortunately IE11 uses an old CSS grid spec, so we only use this when required, but it works, and is ignored by all other browsers. This does include a bit of a hack, but only in IE - sometimes it takes a moment for the _enrollments array to get populated, and therefore there are no course tiles to select. In this case, we simply re-_onResize a few times (for up to a second) until things get properly rendered. (Tested this fairly extensively - it only occurs once in a while, but the provided solution worked in all cases.)

This change did require ditching the `grid-gap`, in favour of `grid-gap-column` and `margin-bottom` on the course tiles. This is because the method by which below-the-fold tiles are hidden has changed slightly. If we continue to use grid-gap, it adds space between the last visible course tile and the View All Course link, since the tile-surrounding divs are still technically visible (albeit empty). The new method is pretty much visually identical, and prevents the extra space.

Two other small changes:

- Increased the tile width to 350px for breaking - this avoids the circumstance where a two-column layout occurs and the "Course Closed <date>"-type overlay is too large for the tile.
- Added _pinPressHandler - otherwise tabbing off the pin button will always unpin the course (forgot this in the initial version of d2l-course-image-tile)