### PR TITLE
Call _onResize initially to set correct tile size

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -408,6 +408,7 @@
 				window.addEventListener('set-course-image', this._boundOnSetCourseImage);
 
 				Polymer.RenderStatus.afterNextRender(this, function() {
+					this._onResize();
 					window.addEventListener('resize', this._onResize.bind(this));
 
 					var imageTile = this.$$('d2l-image-tile');


### PR DESCRIPTION
Not a huge deal, but forgot this in my previous PR. The 6rem default height is a bit off the correct 43% ratio in some cases (close enough for a default), but if possible then we should set the correct size right away.