### PR TITLE
Close overlay when image is changed

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -378,6 +378,7 @@
 			this.$['basic-image-selector-overlay'].open();
 		},
 		_onSetCourseImage: function(e) {
+			this.$['basic-image-selector-overlay'].close();
 			this._removeAlert('setCourseImageFailure');
 			if (e && e.detail) {
 				if (e.detail.status === 'failure') {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -575,6 +575,20 @@ describe('d2l-my-courses-content', () => {
 				});
 			});
 		});
+
+		describe('set-course-image', () => {
+			it('should close the image-selector overlay', done => {
+				var spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'close');
+
+				var event = new CustomEvent('set-course-image');
+				document.body.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(spy).to.have.been.called;
+					done();
+				});
+			});
+		});
 	});
 
 	describe('Performance measures', () => {


### PR DESCRIPTION
Previously, this was being accomplished by an event listener inside d2l-simple-overlay, but it was specific to this case. So, it will be removed from there, which means we have to explicitly close the overlay when a set-course-image event occurs.

(The change to `d2l-simple-overlay` to remove this behavior is in https://github.com/Brightspace/simple-overlay/pull/16, so this needs to merge + release before that merges + releases.)

See also https://github.com/Brightspace/d2l-image-banner-overlay/pull/54.