### PR TITLE
US94430 - Use CSS grid in all courses overlay

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -25,6 +25,7 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 				standard-semester-name="[[standardSemesterName]]"
 				course-updates-config="[[courseUpdatesConfig]]"
 				course-image-upload-cb="[[courseImageUploadCb]]"
+				css-grid-view="false"
 				updated-sort-logic="[[updatedSortLogic]]">
 			</d2l-my-courses-content-animated>
 		</template>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -1,5 +1,7 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../d2l-alert/d2l-alert.html">
+<link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-behavior.html">
+<link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-styles.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-tile-grid.html">
@@ -18,6 +20,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 <dom-module id="d2l-all-courses-unified-content">
 	<template strip-whitespace>
 		<style include="d2l-all-courses-styles"></style>
+		<style include="d2l-css-grid-view-styles"></style>
 
 		<template is="dom-repeat" items="[[_alerts]]">
 			<d2l-alert type="[[item.alertType]]">
@@ -84,7 +87,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			behaviors: [
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
 				D2L.MyCourses.AlertBehavior,
-				D2L.MyCourses.CourseTileResponsiveGridBehavior
+				D2L.MyCourses.CourseTileResponsiveGridBehavior,
+				D2L.MyCourses.CssGridBehavior
 			],
 			observers: [
 				'_enrollmentsChanged(filteredEnrollments.length)'
@@ -92,10 +96,19 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 
 			ready: function() {
 				this.$$('#all-courses-unified-tile-grid').getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
-				this._updateTileSizes();
+				if (!this.cssGridView) {
+					this._updateTileSizes();
+				}
 			},
 			attached: function() {
-				window.addEventListener('resize', this._updateTileSizes.bind(this));
+				if (!this.cssGridView) {
+					window.addEventListener('resize', this._updateTileSizes.bind(this));
+				}
+			},
+			detached: function() {
+				if (!this.cssGridView) {
+					window.removeEventListener('resize', this._updateTileSizes.bind(this));
+				}
 			},
 
 			getCourseTileItemCount: function() {

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -4,6 +4,7 @@
 <link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-styles.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
+<link rel="import" href="d2l-course-image-tile.html">
 <link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
@@ -44,17 +45,34 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			[[localize('noCoursesInRole')]]
 		</span>
 
-		<d2l-course-tile-grid
-			id="all-courses-unified-tile-grid"
-			enrollments="[[filteredEnrollments]]"
-			tile-sizes="[[_tileSizes]]"
-			locale="[[locale]]"
-			show-course-code="[[showCourseCode]]"
-			show-semester="[[showSemester]]"
-			course-updates-config="[[courseUpdatesConfig]]"
-			updated-sort-logic="[[updatedSortLogic]]"
-			animate="[[_animate]]">
-		</d2l-course-tile-grid>
+		<template is="dom-if" if="[[cssGridView]]">
+			<div class="course-tile-grid">
+				<template is="dom-repeat" items="[[filteredEnrollments]]">
+					<div>
+						<d2l-course-image-tile
+							enrollment="[[item]]"
+							tile-sizes="[[_tileSizes]]"
+							show-course-code="[[showCourseCode]]"
+							show-semester="[[showSemester]]"
+							course-updates-config="[[courseUpdatesConfig]]">
+						</d2l-course-image-tile>
+					</div>
+				</template>
+			</div>
+		</template>
+		<template is="dom-if" if="[[!cssGridView]]">
+			<d2l-course-tile-grid
+				id="all-courses-unified-tile-grid"
+				enrollments="[[filteredEnrollments]]"
+				tile-sizes="[[_tileSizes]]"
+				locale="[[locale]]"
+				show-course-code="[[showCourseCode]]"
+				show-semester="[[showSemester]]"
+				course-updates-config="[[courseUpdatesConfig]]"
+				updated-sort-logic="[[updatedSortLogic]]"
+				animate="[[_animate]]">
+			</d2l-course-tile-grid>
+		</template>
 	</template>
 	<script>
 		Polymer({
@@ -94,16 +112,16 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				'_enrollmentsChanged(filteredEnrollments.length)'
 			],
 
-			ready: function() {
-				this.$$('#all-courses-unified-tile-grid').getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
-				if (!this.cssGridView) {
-					this._updateTileSizes();
-				}
-			},
 			attached: function() {
-				if (!this.cssGridView) {
-					window.addEventListener('resize', this._updateTileSizes.bind(this));
-				}
+				Polymer.RenderStatus.afterNextRender(this, function() {
+					if (this.cssGridView) {
+						this._onResize();
+					} else {
+						this._updateTileSizes();
+						this.$$('#all-courses-unified-tile-grid').getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
+						window.addEventListener('resize', this._updateTileSizes.bind(this));
+					}
+				});
 			},
 			detached: function() {
 				if (!this.cssGridView) {
@@ -123,13 +141,17 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 					}
 				}
-				this.$$('#all-courses-unified-tile-grid').setCourseImage(details);
+				!this.cssGridView && this.$$('#all-courses-unified-tile-grid').setCourseImage(details);
 			},
 			removeSetCourseImageFailure: function() {
 				this._removeAlert('setCourseImageFailure');
 			},
 
 			_updateTileSizes: function() {
+				if (this.cssGridView) {
+					return;
+				}
+
 				this._rescaleCourseTileRegions();
 				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
 			},

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -10,6 +10,7 @@
 <link rel="import" href="../../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-grid.html">
@@ -114,6 +115,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 							filter-counts="[[_filterCounts]]"
 							is-searched="[[_isSearched]]"
 							filtered-enrollments="[[_filteredEnrollments]]"
+							css-grid-view="[[cssGridView]]"
 						></d2l-all-courses-unified-content>
 					</template>
 					<template is="dom-if" if="[[!updatedSortLogic]]">

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -156,6 +156,11 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				advancedSearchUrl: String,
 				// Types of notifications to include in update count in course tile
 				courseUpdatesConfig: Object,
+				// Pass-through property to set cssGridView on d2l-all-courses-unified-content
+				cssGridView: {
+					type: Boolean,
+					value: false
+				},
 				// Default option in Sort menu
 				defaultSortValue: {
 					type: String,
@@ -436,6 +441,9 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this.myEnrollmentsEntity = e.detail;
 				this.fire('recalculate-columns');
 				this._showContent = true;
+
+				// Forces recalculation of columns in d2l-all-courses-content-unified
+				window.dispatchEvent(new Event('resize'));
 			},
 			_onSimpleOverlayOpening: function() {
 				if (this.updatedSortLogic) {

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -27,7 +27,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 		<style>
 			:host {
 				display: block;
-				--course-image-height: 6rem;
 			}
 
 			d2l-image-tile {
@@ -416,9 +415,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				window.addEventListener('set-course-image', this._boundOnSetCourseImage);
 
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					this._onResize();
-					window.addEventListener('resize', this._onResize.bind(this));
-
 					var imageTile = this.$$('d2l-image-tile');
 
 					var observerCallback = function(entries, observer) {
@@ -459,7 +455,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 			},
 			detached: function() {
 				window.removeEventListener('set-course-image', this._boundOnSetCourseImage);
-				window.removeEventListener('resize', this._onResize.bind(this));
 			},
 
 			refreshImage: function(organization) {
@@ -695,9 +690,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				this.fire('open-change-image-view', {
 					organization: this._organization
 				});
-			},
-			_onResize: function() {
-				this.updateStyles({'--course-image-height': this.offsetWidth * 0.43 + 'px'});
 			},
 			_onSetCourseImage: function(e) {
 				if (this.getEntityIdentifier(e.detail.organization) !== this.getEntityIdentifier(this._organization)) {

--- a/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
@@ -1,0 +1,80 @@
+<link rel="import" href="../../../polymer/polymer.html">
+
+<script>
+	window.D2L = window.D2L || {};
+	window.D2L.MyCourses = window.D2L.MyCourses || {};
+
+	/*
+	* @polymerBehavior D2L.MyCourses.CssGridBehavior
+	*/
+	D2L.MyCourses.CssGridBehavior = {
+		properties: {
+			cssGridView: {
+				type: Boolean,
+				value: false
+			}
+		},
+
+		attached: function() {
+			Polymer.RenderStatus.afterNextRender(this, function() {
+				if (this.cssGridView) {
+					window.addEventListener('resize', this._onResize.bind(this));
+					// Sets initial number of columns
+					this._onResize();
+				}
+			});
+		},
+
+		detached: function() {
+			if (this.cssGridView) {
+				window.removeEventListener('resize', this._onResize.bind(this));
+			}
+		},
+
+		_onResize: function(ie11retryCount) {
+			var courseTileGrid = this.$$('.course-tile-grid');
+			if (!courseTileGrid) {
+				return;
+			}
+
+			var containerWidth = this.offsetWidth;
+			var numColumns = Math.min(Math.floor(containerWidth / 350), 4) + 1;
+			var columnClass = 'columns-' + numColumns;
+			if (courseTileGrid.classList.toString().indexOf(columnClass) === -1) {
+				courseTileGrid.classList.remove('columns-1');
+				courseTileGrid.classList.remove('columns-2');
+				courseTileGrid.classList.remove('columns-3');
+				courseTileGrid.classList.remove('columns-4');
+				courseTileGrid.classList.add('columns-' + numColumns);
+			}
+
+			var cssGridStyle = document.body.style['grid-template-columns'];
+			// Can be empty string, hence the strict comparison
+			if (cssGridStyle !== undefined) {
+				// Non-IE11 browsers support grid-template-columns, so we're done
+				return;
+			}
+
+			var courseTileDivs = this.querySelectorAll('.course-tile-grid > div');
+			ie11retryCount = ie11retryCount || 0;
+			if (
+				ie11retryCount < 10
+				&& courseTileDivs.length === 0
+			) {
+				// If course tiles haven't yet rendered, try again for up to one second
+				// (only happens sometimes, only in IE)
+				setTimeout(this._onResize.bind(this, ie11retryCount++), 100);
+				return;
+			}
+
+			for (var i = 0; i < courseTileDivs.length; i++) {
+				var div = courseTileDivs[i];
+				// The (* 2 - 1) accounts for the grid-gap-esque columns
+				var column = (i % numColumns + 1) * 2 - 1;
+				var row = Math.floor(i / numColumns) + 1;
+				div.style['-ms-grid-column'] = column;
+				div.style['-ms-grid-row'] = row;
+			}
+		}
+	};
+</script>

--- a/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
@@ -48,6 +48,8 @@
 				courseTileGrid.classList.add('columns-' + numColumns);
 			}
 
+			this.updateStyles({'--course-image-tile-height': containerWidth / numColumns * 0.43 + 'px'});
+
 			var cssGridStyle = document.body.style['grid-template-columns'];
 			// Can be empty string, hence the strict comparison
 			if (cssGridStyle !== undefined) {

--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -1,6 +1,10 @@
 <dom-module id="d2l-css-grid-view-styles">
 	<template strip-whitespace>
 		<style>
+			:host {
+				/* Recalculated in _onResize, so initial value is meaningless */
+				--course-image-tile-height: 0;
+			}
 			.course-tile-grid {
 				display: -ms-grid;
 				display: grid;
@@ -25,6 +29,7 @@
 
 			.course-tile-grid d2l-course-image-tile {
 				margin-bottom: 0.75rem;
+				--course-image-height: var(--course-image-tile-height);
 			}
 			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]) {
 				display: none;

--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -26,9 +26,8 @@
 			.course-tile-grid d2l-course-image-tile {
 				margin-bottom: 0.75rem;
 			}
-			:host([hide-past-courses]) .course-tile-grid d2l-course-image-tile[past-course]:not([pinned]),
-			.course-tile-grid > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
-				display:none;
+			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]) {
+				display: none;
 			}
 		</style>
 	</template>

--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -31,9 +31,6 @@
 				margin-bottom: 0.75rem;
 				--course-image-height: var(--course-image-tile-height);
 			}
-			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]) {
-				display: none;
-			}
 		</style>
 	</template>
 </dom-module>

--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -1,0 +1,35 @@
+<dom-module id="d2l-css-grid-view-styles">
+	<template strip-whitespace>
+		<style>
+			.course-tile-grid {
+				display: -ms-grid;
+				display: grid;
+				grid-column-gap: 15px;
+			}
+			.course-tile-grid.columns-1 {
+				grid-template-columns: 100%;
+				-ms-grid-columns: 100%;
+			}
+			.course-tile-grid.columns-2 {
+				grid-template-columns: repeat(2, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr;
+			}
+			.course-tile-grid.columns-3 {
+				grid-template-columns: repeat(3, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr 15px 1fr;
+			}
+			.course-tile-grid.columns-4 {
+				grid-template-columns: repeat(4, 1fr);
+				-ms-grid-columns: 1fr 15px 1fr 15px 1fr 15px 1fr;
+			}
+
+			.course-tile-grid d2l-course-image-tile {
+				margin-bottom: 0.75rem;
+			}
+			:host([hide-past-courses]) .course-tile-grid d2l-course-image-tile[past-course]:not([pinned]),
+			.course-tile-grid > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
+				display:none;
+			}
+		</style>
+	</template>
+</dom-module>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -1,6 +1,7 @@
 <link rel="import" href="../../../polymer/polymer.html">
 <link rel="import" href="../../../d2l-hm-constants-behavior/d2l-hm-constants-behavior.html">
 <link rel="import" href="../d2l-all-courses.html">
+<link rel="import" href="../d2l-css-grid-view/d2l-css-grid-view-behavior.html">
 <link rel="import" href="../d2l-alert-behavior.html">
 <link rel="import" href="../d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="../d2l-interaction-detection-behavior.html">
@@ -97,11 +98,7 @@
 			this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 
 			Polymer.RenderStatus.afterNextRender(this, function() {
-				if (this.cssGridView) {
-					window.addEventListener('resize', this._onResize.bind(this));
-					// Sets initial number of columns
-					this._onResize();
-				} else {
+				if (!this.cssGridView) {
 					this.$$('d2l-course-tile-grid').addEventListener('startedInactiveAlert', this._onStartedInactiveAlert.bind(this));
 				}
 			});
@@ -109,10 +106,6 @@
 		detached: function() {
 			document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
-
-			if (this.cssGridView) {
-				window.removeEventListener('resize', this._onResize.bind(this));
-			}
 		},
 		observers: [
 			'_enrollmentsChanged(_enrollments)',
@@ -311,47 +304,6 @@
 					}
 				}.bind(this));
 		},
-		_onResize: function(ie11retryCount) {
-			var courseTileGrid = this.$$('.course-tile-grid');
-
-			var containerWidth = this.$$('.spinner-container').offsetWidth;
-			var numColumns = Math.min(Math.floor(containerWidth / 350), 4) + 1;
-			var columnClass = 'columns-' + numColumns;
-			if (courseTileGrid.classList.toString().indexOf(columnClass) === -1) {
-				courseTileGrid.classList.remove('columns-1');
-				courseTileGrid.classList.remove('columns-2');
-				courseTileGrid.classList.remove('columns-3');
-				courseTileGrid.classList.remove('columns-4');
-				courseTileGrid.classList.add('columns-' + numColumns);
-			}
-
-			var cssGridStyle = document.body.style['grid-template-columns'];
-			// Can be empty string, hence the strict comparison
-			if (cssGridStyle !== undefined) {
-				return;
-			}
-
-			var courseTileDivs = this.querySelectorAll('.course-tile-grid > div');
-			ie11retryCount = ie11retryCount || 0;
-			if (
-				ie11retryCount < 10
-				&& courseTileDivs.length === 0
-			) {
-				// If course tiles haven't yet rendered, try again for up to one second
-				// (only happens sometimes, only in IE)
-				setTimeout(this._onResize.bind(this, ie11retryCount++), 100);
-				return;
-			}
-
-			for (var i = 0; i < courseTileDivs.length; i++) {
-				var div = courseTileDivs[i];
-				// The (* 2 - 1) accounts for the grid-gap-esque columns
-				var column = (i % numColumns + 1) * 2 - 1;
-				var row = Math.floor(i / numColumns) + 1;
-				div.style['-ms-grid-column'] = column;
-				div.style['-ms-grid-row'] = row;
-			}
-		},
 		_onStartedInactiveAlert: function(e) {
 			this._removeAlert('startedInactiveCourses');
 			if (this._checkIfStartedInactiveCourses(e)) {
@@ -514,6 +466,7 @@
 			allCourses.filterStandardDepartmentName = this.standardDepartmentName;
 			allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
 			allCourses.updatedSortLogic = this.updatedSortLogic;
+			allCourses.cssGridView = this.cssGridView;
 
 			allCourses.open();
 
@@ -614,6 +567,7 @@
 		D2L.MyCourses.InteractionDetectionBehavior,
 		D2L.MyCourses.AlertBehavior,
 		D2L.MyCourses.UtilityBehavior,
+		D2L.MyCourses.CssGridBehavior,
 		D2L.MyCourses.MyCoursesContentBehaviorImpl
 	];
 </script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -49,7 +49,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				clear: both;
 			}
 			.course-tile-grid:not([hide-past-courses]) > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]),
-			/* If hide-past-courses, past courses are already hidden (in d2l-css-grid-view-styles), so exclude them from the n+13 count */
+			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]),
+			/* If hide-past-courses, past courses are already hidden, so exclude them from the n+13 count */
 			.course-tile-grid[hide-past-courses] > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
 				display: none;
 			}

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -6,6 +6,7 @@
 <link rel="import" href="../../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
+<link rel="import" href="../d2l-css-grid-view/d2l-css-grid-view-styles.html">
 <link rel="import" href="../d2l-all-courses.html">
 <link rel="import" href="../d2l-course-image-tile.html">
 <link rel="import" href="../d2l-course-tile-grid.html">
@@ -24,7 +25,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 
 <dom-module id="d2l-my-courses-content">
 	<template strip-whitespace>
-		<style>
+		<style include="d2l-css-grid-view-styles">
 			:host {
 				display: block;
 			}
@@ -46,36 +47,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				display: block;
 				margin-bottom: 20px;
 				clear: both;
-			}
-
-			.course-tile-grid {
-				display: -ms-grid;
-				display: grid;
-				grid-column-gap: 15px;
-			}
-			.course-tile-grid.columns-1 {
-				grid-template-columns: 100%;
-				-ms-grid-columns: 100%;
-			}
-			.course-tile-grid.columns-2 {
-				grid-template-columns: repeat(2, 1fr);
-				-ms-grid-columns: 1fr 15px 1fr;
-			}
-			.course-tile-grid.columns-3 {
-				grid-template-columns: repeat(3, 1fr);
-				-ms-grid-columns: 1fr 15px 1fr 15px 1fr;
-			}
-			.course-tile-grid.columns-4 {
-				grid-template-columns: repeat(4, 1fr);
-				-ms-grid-columns: 1fr 15px 1fr 15px 1fr 15px 1fr;
-			}
-
-			d2l-course-image-tile {
-				margin-bottom: 0.75rem;
-			}
-			:host([hide-past-courses]) d2l-course-image-tile[past-course]:not([pinned]),
-			div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
-				display:none;
 			}
 		</style>
 

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -48,6 +48,11 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				margin-bottom: 20px;
 				clear: both;
 			}
+			.course-tile-grid:not([hide-past-courses]) > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]),
+			/* If hide-past-courses, past courses are already hidden (in d2l-css-grid-view-styles), so exclude them from the n+13 count */
+			.course-tile-grid[hide-past-courses] > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
+				display: none;
+			}
 		</style>
 
 		<div class="spinner-container">

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
@@ -1,9 +1,12 @@
 describe('d2l-all-courses-unified-content', function() {
 	var widget, sandbox, clock;
 
-	beforeEach(function() {
+	beforeEach(function(done) {
 		sandbox = sinon.sandbox.create();
 		widget = fixture('d2l-all-courses-unified-content-fixture');
+		setTimeout(function() {
+			done();
+		});
 	});
 
 	afterEach(function() {


### PR DESCRIPTION
Kind of... kind of completely forgot about this. This first factors out the the CSS grid that was introduced in #478/#479/#480 into it's behaviour and styles, and then uses it within the `d2l-all-courses-unified-content` element.

If this is a pain to review, I can split it up - all three commits were actually distinct chunks of work.