### PR TITLE
Fire perf measure event

### DIFF
--- a/performance-timing.md
+++ b/performance-timing.md
@@ -32,7 +32,7 @@ performance.getEntriesByType('measure')
 | `d2l.my-courses.root-enrollments` | Duration of the enrollments root API request. Often includes time to fetch token. | `d2l.my-courses.root-enrollments.request` | `d2l.my-courses.root-enrollments.response` |
 | `d2l.my-courses.search-enrollments` | Duration of the enrollments search API request. | `d2l.my-courses.search-enrollments.request` | `d2l.my-courses.search-enrollments.response` |
 | `d2l.my-courses.meaningful.visible` | Approximation of total time for my-courses to be usable for a sighted user (visible organizations, excludes course images). | `d2l.my-courses.attached` | `d2l.my-courses.visible-organizations-complete` |
-| `d2l.my-courses` | Approximation of total time for my-courses to complete loading for a sighted user (visible organizations and course images). | `d2l.my-courses.attached` | `d2l.my-courses.visible-images-complete` |
+| `d2l.my-courses.hero` | Approximation of total time for my-courses to complete loading for a sighted user (visible organizations and course images). Roughly corresponds to "hero element" timing. | `d2l.my-courses.attached` | `d2l.my-courses.visible-images-complete` |
 | `d2l.my-courses.meaningful.all` | Approximation of total time for my-courses to complete loading for a screenreader user (all organizations, excludes course images) | `d2l.my-courses.attached` | `d2l.my-courses.all-organizations-complete` |
 
 Course images are lazy-loaded only once they become visible in the viewport. Because of this, we do not track "last course image loaded" as it's possible that this would never occur, should the user not scroll down far enough for all images to enter the viewport and therefore load.

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -202,7 +202,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 					this.performanceMeasure(
 						'd2l.my-courses.hero',
 						'd2l.my-courses.attached',
-						'd2l.my-courses.visible-images-complete'
+						'd2l.my-courses.visible-images-complete',
+						true
 					);
 				}
 

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -200,7 +200,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 					);
 					this.performanceMark('d2l.my-courses.visible-images-complete');
 					this.performanceMeasure(
-						'd2l.my-courses',
+						'd2l.my-courses.hero',
 						'd2l.my-courses.attached',
 						'd2l.my-courses.visible-images-complete'
 					);

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -205,7 +205,8 @@
 				this.performanceMeasure(
 					'd2l.my-courses.hero',
 					'd2l.my-courses.attached',
-					'd2l.my-courses.visible-images-complete'
+					'd2l.my-courses.visible-images-complete',
+					true
 				);
 			}
 

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -203,7 +203,7 @@
 				);
 				this.performanceMark('d2l.my-courses.visible-images-complete');
 				this.performanceMeasure(
-					'd2l.my-courses',
+					'd2l.my-courses.hero',
 					'd2l.my-courses.attached',
 					'd2l.my-courses.visible-images-complete'
 				);

--- a/src/d2l-utility-behavior.html
+++ b/src/d2l-utility-behavior.html
@@ -61,9 +61,19 @@
 				window.performance.mark(name);
 			}
 		},
-		performanceMeasure: function(name, startMark, endMark) {
+		performanceMeasure: function(name, startMark, endMark, fireEvent) {
 			if (window.performance && window.performance.measure) {
 				window.performance.measure(name, startMark, endMark);
+				var measure = window.performance.getEntriesByName(name, 'measure');
+				if (measure.length === 1 && fireEvent) {
+					document.dispatchEvent(new CustomEvent('D2LPerformanceMeasure', {
+						bubbles: true,
+						detail: {
+							name: name,
+							value: measure[0]
+						}
+					}));
+				}
 			}
 		},
 		responseToSirenEntity: function(response) {


### PR DESCRIPTION
Two things happening here:

1. I've renamed the `d2l.my-courses` measure to `d2l.my-courses.hero`. Mostly this is so that all the measures are named under `d2l.my-courses.*`, but also because it roughly corresponds to the "hero element" timing event for the widget.
2. This is now firing the `D2LPerformanceMeasure` custom event for the hero measure. This will get captured by BSI's timing debug code, but also the Google Analytics plugin will pick it up (if enabled) and send this measure along to GA.