### PR TITLE
Check src and srcset before using them

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "d2l-alert": "^3.0.1",
     "d2l-colors": "^3.1.2",
-    "d2l-course-image": "Brightspace/course-image#^2.1.2",
+    "d2l-course-image": "Brightspace/course-image#^2.1.3",
     "d2l-dropdown": "^6.0.7",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.0.0",

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -707,8 +707,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				this._imageLoading = true;
 
 				var status = e.detail.status;
-				var newImageHref = this.getDefaultImageLink(e.detail.image);
-				var newSrcSet = this.getImageSrcset(e.detail.image, 'tile');
 
 				switch (status) {
 					case 'set':
@@ -716,8 +714,17 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 						// load the image while the loading spinner runs to that we have it when the spinner ends
 						this._nextImage = e.detail.image;
 						var imagePreloader = document.createElement('img');
-						imagePreloader.setAttribute('src', newImageHref);
-						imagePreloader.setAttribute('srcset', newSrcSet);
+
+						var newImageHref = this.getDefaultImageLink(e.detail.image);
+						if (newImageHref) {
+							imagePreloader.setAttribute('src', newImageHref);
+						}
+
+						var newSrcSet = this.getImageSrcset(e.detail.image, 'tile');
+						if (newSrcSet) {
+							imagePreloader.setAttribute('srcset', newSrcSet);
+						}
+
 						imagePreloader.setAttribute('sizes', this.$$('d2l-course-image').getTileSizes());
 						break;
 					case 'success':


### PR DESCRIPTION
Contributes to fixing #507 - only set the src/srcset attribute on the imagePreloader if they are defined. This prevents 404s when `getDefaultImageLink` or `getImageSrcset` fails.

See also https://github.com/Brightspace/course-image/pull/18
See also https://github.com/Brightspace/organization-hm-behavior/pull/16