### PR TITLE
DE29409 - Fix Hidden For Overlays in Polymer 2

### DIFF
--- a/src/d2l-all-courses-styles.html
+++ b/src/d2l-all-courses-styles.html
@@ -21,8 +21,8 @@
 			d2l-loading-spinner {
 				margin-bottom: 30px;
 				padding-bottom: 30px;
-				display: block;
 				margin: auto;
+				width: 100%;
 			}
 			.bottom-pad {
 				padding-bottom: 20px;

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -128,6 +128,9 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				text-align: center;
 				background-color: rgba(0,0,0,0.7);
 			}
+			.overlay[hidden] {
+				display: none;
+			}
 			.overlay-text {
 				font-size: 1rem;
 				font-weight: bold;

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,12 +13,12 @@
         {
           "browserName": "chrome",
           "platform": "OS X 10.12",
-          "version": ""
+          "version": "beta"
         },
         {
           "browserName": "chrome",
           "platform": "Windows 10",
-          "version": ""
+          "version": "beta"
         },
         {
           "browserName": "firefox",


### PR DESCRIPTION
- Fix hidden attribute on overlays in Polymer 2
- Remove the `display` setting for the loading spinner so the hidden attribute works as expected in Polymer 2