### PR TITLE
DE29423 - Fix the styling on the "View All Courses" link in Polymer 2

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -47,6 +47,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				margin-bottom: 20px;
 				clear: both;
 			}
+			.d2l-body-standard {
+				@apply --d2l-body-standard-text;
+				margin: 0;
+			}
 		</style>
 
 		<div class="spinner-container">

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -7,6 +7,7 @@
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
 <link rel="import" href="../d2l-css-grid-view/d2l-css-grid-view-styles.html">
+<link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../d2l-all-courses.html">
 <link rel="import" href="../d2l-course-image-tile.html">
 <link rel="import" href="../d2l-course-tile-grid.html">
@@ -53,6 +54,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			/* If hide-past-courses, past courses are already hidden, so exclude them from the n+13 count */
 			.course-tile-grid[hide-past-courses] > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]) {
 				display: none;
+			}
+			.d2l-body-standard {
+				@apply --d2l-body-standard-text;
+				margin: 0;
 			}
 		</style>
 


### PR DESCRIPTION
- Shady dom was allowing the` bsi.css` styles to apply, whereas Shadow dom does not.
- This fixes the font styling when the `UpdatedSortLogic` config is both on and off.

Current behaviour (left is Polymer 2, right is Polymer 1): 
![image](https://user-images.githubusercontent.com/13419300/37410785-b86a4866-2777-11e8-94b4-fd40d0ef4f36.png)

With the fix:
![image](https://user-images.githubusercontent.com/13419300/37419197-4b388858-278a-11e8-9045-e2dd872a364b.png)
