### PR TITLE
DE29531 - Fix updates notification box size in Polymer 2

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -190,6 +190,7 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				border: 2px solid var(--d2l-color-carnelian);
 				color: var(--d2l-color-carnelian);
 				border-radius: 0.25rem;
+				box-sizing: border-box;
 				font-size: 1rem;
 				font-weight: 700;
 				width: 2rem;

--- a/src/d2l-course-tile-styles.html
+++ b/src/d2l-course-tile-styles.html
@@ -159,6 +159,7 @@
 				border: 2px solid var(--d2l-color-carnelian);
 				color: var(--d2l-color-carnelian);
 				border-radius: 0.25rem;
+				box-sizing: border-box;
 				font-size: 1rem;
 				font-weight: 700;
 				width: 2rem;


### PR DESCRIPTION
- Defect: https://rally1.rallydev.com/#/15545167705d/detail/defect/208109710932?fdp=true
- Shady Dom allowed this style to be applied for free from `homepages.min.css`:
```
.homepage-container * {
    box-sizing: border-box;
}
```
- For Shadow Dom, adding this explicitly to the `update-text-box` class
- Fixed for when `SortUpdatedLogic` is both on and off
