### PR TITLE
Fix long course names

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -52,6 +52,7 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				overflow: hidden;
 				word-wrap: break-word; /* IE/Edge */
 				overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
+				word-break: break-word;
 			}
 			:host:hover .course-text,
 			:host:focus .course-text {


### PR DESCRIPTION
When a course name was sufficiently long, and had no breakable characters (e.g. spaces), it would break the widget as the tile would be the width of the name. Fixed by adding a word-break: break-word, which allows the browser to break the text by word if possible, or by non-breakable characters if necessary.