### PR TITLE
DE29766 Fix long names with CSS grid

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -52,7 +52,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				overflow: hidden;
 				word-wrap: break-word; /* IE/Edge */
 				overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
-				word-break: break-word;
 			}
 			:host:hover .course-text,
 			:host:focus .course-text {

--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -27,6 +27,10 @@
 				-ms-grid-columns: 1fr 15px 1fr 15px 1fr 15px 1fr;
 			}
 
+			.course-tile-grid > div {
+				min-width: 0;
+			}
+
 			.course-tile-grid d2l-course-image-tile {
 				margin-bottom: 0.75rem;
 				--course-image-height: var(--course-image-tile-height);


### PR DESCRIPTION
This is a second attempt at this fix - this time verified across browsers. Turns out, `break-word` is not supported anywhere except Chrome and Opera, so the previous fix didn't help all that much.

In fact, the _actual_ issue is that CSS grid items have a default min-width: auto, which means that the tile cannot be smaller than its contents. To fix this, we can set min-width: 0, which allows for them to basically force-shrink themselves even if the course text is long and non-breaking. See https://www.w3.org/TR/css3-grid-layout/#min-size-auto for more information. Defects where you have to read the HTML spec to fix them are the best kind of defects.

I'll be releasing this separately as v4.3.2 as well (I did 4.3.1 yesterday with a fix that worked on Chrome, adding `word-break`, but didn't work on other browsers).