### PR TITLE
Move Chrome sauce version back to latest

### DIFF
--- a/wct.conf.json
+++ b/wct.conf.json
@@ -9,6 +9,7 @@
       }
     },
     "sauce": {
+      "idleTimeout": 300,
       "browsers": [
         {
           "browserName": "chrome",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -13,12 +13,12 @@
         {
           "browserName": "chrome",
           "platform": "OS X 10.12",
-          "version": "beta"
+          "version": ""
         },
         {
           "browserName": "chrome",
           "platform": "Windows 10",
-          "version": "beta"
+          "version": ""
         },
         {
           "browserName": "firefox",

--- a/wct.conf.json
+++ b/wct.conf.json
@@ -9,7 +9,7 @@
       }
     },
     "sauce": {
-      "idleTimeout": 300,
+      "idleTimeout": 360,
       "browsers": [
         {
           "browserName": "chrome",


### PR DESCRIPTION
Addresses https://github.com/Brightspace/d2l-my-courses-ui/issues/514.  There was a problem in the version of chrome 65 SauceLabs (`65.0.3325.146`) was using, that couldn't be reproduced locally with the latest version of chrome 65 (`65.0.3325.162`).  Now that Chrome 66 is out, we can move CI back to the latest version.