### PR TITLE
DE30246 Un-set homepage URL when no access

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -695,6 +695,7 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 					this._hoverEffects = '';
 					this._canAccessCourse = false;
 					this.$$('d2l-image-tile').setAttribute('disabled', '');
+					this._organizationHomepageUrl = null;
 				}
 
 				return Promise.resolve();

--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -598,6 +598,8 @@ the user has in that organization - student, teacher, TA, etc.
 				var homepageEntity = organization.getSubEntityByRel(this.HypermediaRels.organizationHomepage);
 				if (homepageEntity) {
 					this._organizationHomepageUrl = homepageEntity.properties.path;
+				} else {
+					this._organizationHomepageUrl = null;
 				}
 				if (!this._organizationHomepageUrl) {
 					var tileContainer = this.$$('.tile-container');


### PR DESCRIPTION
The situation where this is a problem only comes up in the all courses overlay - in particular, searching for something, then clearing the search, will mean that any course tiles that the user doesn't have access to will not have their URL un-set, meaning the course tile will end up linking to whatever course was in that tile's position. This is a weird Polymer-ism where elements are reused in some ways. To be safe, explicitly set the `_organziationHomepageUrl = null` when there isn't a homepage link on the organization's entity.