### PR TITLE
US97068 Update sort from enrollmentsSearchAction

### DIFF
--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -462,7 +462,62 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					return;
 				}
 
-				this._enrollmentsSearchAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
+				var searchAction = myEnrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
+				this._enrollmentsSearchAction = searchAction;
+
+				if (searchAction && searchAction.hasFieldByName('sort')) {
+					var sortParameter = searchAction.getFieldByName('sort').value;
+					if (!sortParameter) {
+						return;
+					}
+
+					var sortMap = {
+						'OrgUnitName,OrgUnitId': {
+							name: 'OrgUnitName',
+							langterm: 'sorting.sortCourseName'
+						},
+						// Only used if updatedSortLogic = false
+						'-PinDate,OrgUnitName,OrgUnitId': {
+							name: 'OrgUnitName',
+							langterm: 'sorting.sortCourseName'
+						},
+						'OrgUnitCode,OrgUnitId': {
+							name: 'OrgUnitCode',
+							langterm: 'sorting.sortCourseCode'
+						},
+						// Only used if updatedSortLogic = false
+						'-PinDate,OrgUnitCode,OrgUnitId': {
+							name: 'OrgUnitCode',
+							langterm: 'sorting.sortCourseCode'
+						},
+						'-PinDate,OrgUnitId': {
+							name: 'PinDate',
+							langterm: 'sorting.sortDatePinned'
+						},
+						'LastAccessed': {
+							name: 'LastAccessed',
+							langterm: 'sorting.sortLastAccessed'
+						},
+						'-LastModifiedDate,OrgUnitId': {
+							name: 'EnrollmentDate',
+							langterm: 'sorting.sortEnrollmentDate'
+						},
+						'Current': {
+							name: 'Default',
+							langterm: 'sorting.sortDefault'
+						}
+					};
+
+					var sort = sortMap[sortParameter];
+					if (sort) {
+						this.$.sortText.textContent = this.localize(sort.langterm || '');
+						this._selectSortOption(sort.name);
+					} else {
+						var langterm = this.updatedSortLogic ? 'sorting.sortDefault' : 'sorting.sortCourseName';
+						this.$.sortText.textContent = this.localize(langterm);
+						this._selectSortOption(this.defaultSortValue);
+					}
+				}
 			},
 
 			/*
@@ -489,12 +544,20 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				return !!link;
 			},
 			_resetSortDropdown: function() {
-				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').click();
+				this._selectSortOption(this.defaultSortValue);
 
 				var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');
 				if (content) {
 					content.close();
 				}
+			},
+			_selectSortOption: function(sortName) {
+				var items = this.$.sortDropdownMenu.querySelectorAll('d2l-menu-item-radio');
+				for (var i = 0; i < items.length; i++) {
+					items[i].selected = false;
+				}
+
+				this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + sortName + ']').selected = true;
 			},
 			_updateFilteredEnrollments: function(enrollments, append) {
 				var enrollmentEntities = enrollments.getSubEntitiesByClass(this.HypermediaClasses.enrollments.enrollment);
@@ -549,7 +612,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 			_updatedSortLogicChanged: function(updatedSortLogic) {
 				if (this._updatedSortLogicInitallyObserved) {
 					this.defaultSortValue = updatedSortLogic ? 'Default' : 'OrgUnitName';
-					this.$.sortDropdownMenu.querySelector('d2l-menu-item-radio[value=' + this.defaultSortValue + ']').selected = true;
+					this._selectSortOption(this.defaultSortValue);
 					var langterm = updatedSortLogic ? 'sorting.sortDefault' : 'sorting.sortCourseName';
 					this.$.sortText.textContent = this.localize(langterm || '');
 				} else {

--- a/src/d2l-search-widget-custom.html
+++ b/src/d2l-search-widget-custom.html
@@ -236,13 +236,17 @@ Polymer-based web component for the search widget.
 					this.$$('iron-pages').select('recent-searches-page');
 				}
 
-				// Checking for _searchAction required here to avoid problems on init
-				if (this._searchAction && !this.$.dropdown.opened) {
-					// If a user enters a new key after having searched, re-open dropdown
-					this.$.dropdown.open();
-				}
-				if (this._listboxes) {
-					this.debounce('liveSearchJob', this._liveSearch, 750);
+				// If the search input has changed programmatically (e.g. via
+				// searchAction changing), the input won't be focused, and we
+				// don't want to open the dropdown or live search
+				if (document.activeElement === this.$$('input')) {
+					if (!this.$.dropdown.opened) {
+						// If a user enters a new key after having searched, re-open dropdown
+						this.$.dropdown.open();
+					}
+					if (this._listboxes) {
+						this.debounce('liveSearchJob', this._liveSearch, 750);
+					}
 				}
 			},
 			_onSearchInputKeyPressed: function(e) {


### PR DESCRIPTION
When a set of enrollments is returned, we were previously just updating the local `_enrollmentsSearchAction` from the response. Now, we also want to update the search/filter/sort with the Field values from the returned action. This commit adds this functionality for `sort`, so that an `_enrollmentsSearchAction`'s `sort` field value is applied to the sort menu when it's received.

Also included is a minor fix that is a followup to https://github.com/Brightspace/d2l-search-widget-ui/pull/44, which prevents the live-search-dropdown from opening if the search input value changes programmatically (i.e. by the `_enrollmentsSearchAction` being updated, rather than by somebody clicking/typing in it).