### PR TITLE
US97633 Remove css-grid-view

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -25,7 +25,6 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 				standard-semester-name="[[standardSemesterName]]"
 				course-updates-config="[[courseUpdatesConfig]]"
 				course-image-upload-cb="[[courseImageUploadCb]]"
-				css-grid-view="false"
 				updated-sort-logic="[[updatedSortLogic]]">
 			</d2l-my-courses-content-animated>
 		</template>
@@ -40,7 +39,6 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 				standard-semester-name="[[standardSemesterName]]"
 				course-updates-config="[[courseUpdatesConfig]]"
 				course-image-upload-cb="[[courseImageUploadCb]]"
-				css-grid-view="[[cssGridView]]"
 				updated-sort-logic="[[updatedSortLogic]]">
 			</d2l-my-courses-content>
 		</template>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -5,8 +5,6 @@
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-image-tile.html">
-<link rel="import" href="d2l-course-tile-grid.html">
-<link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="localize-behavior.html">
 
 <!--
@@ -45,34 +43,19 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			[[localize('noCoursesInRole')]]
 		</span>
 
-		<template is="dom-if" if="[[cssGridView]]">
-			<div class="course-tile-grid">
-				<template is="dom-repeat" items="[[filteredEnrollments]]">
-					<div>
-						<d2l-course-image-tile
-							enrollment="[[item]]"
-							tile-sizes="[[_tileSizes]]"
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]">
-						</d2l-course-image-tile>
-					</div>
-				</template>
-			</div>
-		</template>
-		<template is="dom-if" if="[[!cssGridView]]">
-			<d2l-course-tile-grid
-				id="all-courses-unified-tile-grid"
-				enrollments="[[filteredEnrollments]]"
-				tile-sizes="[[_tileSizes]]"
-				locale="[[locale]]"
-				show-course-code="[[showCourseCode]]"
-				show-semester="[[showSemester]]"
-				course-updates-config="[[courseUpdatesConfig]]"
-				updated-sort-logic="[[updatedSortLogic]]"
-				animate="[[_animate]]">
-			</d2l-course-tile-grid>
-		</template>
+		<div class="course-tile-grid">
+			<template is="dom-repeat" items="[[filteredEnrollments]]">
+				<div>
+					<d2l-course-image-tile
+						enrollment="[[item]]"
+						tile-sizes="[[_tileSizes]]"
+						show-course-code="[[showCourseCode]]"
+						show-semester="[[showSemester]]"
+						course-updates-config="[[courseUpdatesConfig]]">
+					</d2l-course-image-tile>
+				</div>
+			</template>
+		</div>
 	</template>
 	<script>
 		Polymer({
@@ -105,7 +88,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			behaviors: [
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
 				D2L.MyCourses.AlertBehavior,
-				D2L.MyCourses.CourseTileResponsiveGridBehavior,
 				D2L.MyCourses.CssGridBehavior
 			],
 			observers: [
@@ -114,19 +96,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 
 			attached: function() {
 				Polymer.RenderStatus.afterNextRender(this, function() {
-					if (this.cssGridView) {
-						this._onResize();
-					} else {
-						this._updateTileSizes();
-						this.$$('#all-courses-unified-tile-grid').getCourseTileItemCount = this.getCourseTileItemCount.bind(this);
-						window.addEventListener('resize', this._updateTileSizes.bind(this));
-					}
+					this._onResize();
 				});
-			},
-			detached: function() {
-				if (!this.cssGridView) {
-					window.removeEventListener('resize', this._updateTileSizes.bind(this));
-				}
 			},
 
 			getCourseTileItemCount: function() {
@@ -141,20 +112,11 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 					}
 				}
-				!this.cssGridView && this.$$('#all-courses-unified-tile-grid').setCourseImage(details);
 			},
 			removeSetCourseImageFailure: function() {
 				this._removeAlert('setCourseImageFailure');
 			},
 
-			_updateTileSizes: function() {
-				if (this.cssGridView) {
-					return;
-				}
-
-				this._rescaleCourseTileRegions();
-				this._tileSizes = Math.floor(100 / this._numColsOverlay) + 'vw';
-			},
 			_enrollmentsChanged: function(enrollmentLength) {
 				this._noCoursesInSearch = false;
 				this._noCoursesInSelection = false;

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -10,10 +10,8 @@
 <link rel="import" href="../../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
-<link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-management-behavior.html">
-<link rel="import" href="d2l-course-tile-grid.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-filter-menu/d2l-filter-menu.html">
 <link rel="import" href="d2l-search-widget-custom.html">
@@ -115,7 +113,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 							filter-counts="[[_filterCounts]]"
 							is-searched="[[_isSearched]]"
 							filtered-enrollments="[[_filteredEnrollments]]"
-							css-grid-view="[[cssGridView]]"
 						></d2l-all-courses-unified-content>
 					</template>
 					<template is="dom-if" if="[[!updatedSortLogic]]">
@@ -156,11 +153,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				advancedSearchUrl: String,
 				// Types of notifications to include in update count in course tile
 				courseUpdatesConfig: Object,
-				// Pass-through property to set cssGridView on d2l-all-courses-unified-content
-				cssGridView: {
-					type: Boolean,
-					value: false
-				},
 				// Default option in Sort menu
 				defaultSortValue: {
 					type: String,

--- a/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
@@ -11,7 +11,7 @@
 		properties: {
 			cssGridView: {
 				type: Boolean,
-				value: false
+				value: true
 			}
 		},
 

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -28,11 +28,6 @@
 			courseUpdatesConfig: Object,
 			// Callback for upload in image-selector
 			courseImageUploadCb: Function,
-			// Feature flag for using d2l-course-image-tile and CSS grid view
-			cssGridView: {
-				type: Boolean,
-				value: false
-			},
 			// Feature flag (switch) for using the updated sort logic and related fetaures
 			updatedSortLogic: {
 				type: Boolean,

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -113,6 +113,12 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			is: 'd2l-my-courses-content-animated',
 
 			properties: {
+				// Override for CssGridBehavior.cssGridView
+				cssGridView: {
+					type: Boolean,
+					value: false
+				},
+
 				_allEnrollments: {
 					type: Array,
 					value: function() { return []; }

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -6,11 +6,10 @@
 <link rel="import" href="../../../d2l-loading-spinner/d2l-loading-spinner.html">
 <link rel="import" href="../../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../../d2l-image-selector/d2l-basic-image-selector.html">
-<link rel="import" href="../d2l-css-grid-view/d2l-css-grid-view-styles.html">
 <link rel="import" href="../../../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../d2l-all-courses.html">
 <link rel="import" href="../d2l-course-image-tile.html">
-<link rel="import" href="../d2l-course-tile-grid.html">
+<link rel="import" href="../d2l-css-grid-view/d2l-css-grid-view-styles.html">
 <link rel="import" href="../localize-behavior.html">
 <link rel="import" href="d2l-my-courses-behavior.html">
 <link rel="import" href="d2l-my-courses-content-behavior.html">
@@ -70,34 +69,19 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 					[[item.alertMessage]]
 				</d2l-alert>
 			</template>
-			<template is="dom-if" if="[[cssGridView]]">
-				<div class="course-tile-grid">
-					<template is="dom-repeat" items="[[_enrollments]]">
-						<div>
-							<d2l-course-image-tile
-								enrollment="[[item]]"
-								tile-sizes="[[_tileSizes]]"
-								show-course-code="[[showCourseCode]]"
-								show-semester="[[showSemester]]"
-								course-updates-config="[[courseUpdatesConfig]]">
-							</d2l-course-image-tile>
-						</div>
-					</template>
-				</div>
-			</template>
-			<template is="dom-if" if="[[!cssGridView]]">
-				<d2l-course-tile-grid
-					limit-to-12
-					enrollments="[[_enrollments]]"
-					tile-sizes="[[_tileSizes]]"
-					locale="[[locale]]"
-					show-course-code="[[showCourseCode]]"
-					show-semester="[[showSemester]]"
-					course-updates-config="[[courseUpdatesConfig]]"
-					updated-sort-logic="[[updatedSortLogic]]"
-					animate="[[_animateCourseTileGrid]]">
-				</d2l-course-tile-grid>
-			</template>
+			<div class="course-tile-grid">
+				<template is="dom-repeat" items="[[_enrollments]]">
+					<div>
+						<d2l-course-image-tile
+							enrollment="[[item]]"
+							tile-sizes="[[_tileSizes]]"
+							show-course-code="[[showCourseCode]]"
+							show-semester="[[showSemester]]"
+							course-updates-config="[[courseUpdatesConfig]]">
+						</d2l-course-image-tile>
+					</div>
+				</template>
+			</div>
 			<d2l-link
 				id="viewAllCourses"
 				hidden$="[[!_hasEnrollments]]"

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
@@ -232,6 +232,10 @@ describe('d2l-my-courses-content-animated', function() {
 		expect(widget).to.exist;
 	});
 
+	it('should override the default cssGridView=true', function() {
+		expect(widget.cssGridView).to.be.false;
+	});
+
 	describe('Enrollments requests and responses', function() {
 		it('should send a search request for enrollments with the correct query params', function() {
 			var spy = sandbox.spy(widget, '_fetchEnrollments');

--- a/test/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.html
@@ -14,12 +14,6 @@
 			</template>
 		</test-fixture>
 
-		<test-fixture id="d2l-my-courses-content-css-grid-view-fixture">
-			<template>
-				<d2l-my-courses-content css-grid-view></d2l-my-courses-content>
-			</template>
-		</test-fixture>
-
 		<script src="d2l-my-courses-content.js"></script>
 	</body>
 </html>

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -143,7 +143,7 @@ describe('d2l-my-courses-content', () => {
 		expect(component.courseImageUploadCompleted).to.be.a('function');
 		expect(component.getLastOrgUnitId).to.be.a('function');
 		expect(component.updatedSortLogic).to.equal(false);
-		expect(component.cssGridView).to.equal(false);
+		expect(component.cssGridView).to.equal(true);
 	});
 
 	it('should properly implement d2l-my-courses-content-behavior', () => {
@@ -158,22 +158,10 @@ describe('d2l-my-courses-content', () => {
 		expect(component._tileSizes).to.be.an('object');
 	});
 
-	describe('When cssGridView = true', () => {
-
+	describe('Tile grid', () => {
 		beforeEach((done) => {
-			component = fixture('d2l-my-courses-content-css-grid-view-fixture');
-			component.enrollmentsUrl = '/enrollments';
-
 			component._fetchRoot();
 			setTimeout(done, 300);
-		});
-
-		it('should render the correct tile grid', () => {
-			var courseTileGrid = component.$$('.course-tile-grid');
-			expect(courseTileGrid).to.not.be.null;
-
-			var oldCourseTileGrid = component.$$('d2l-course-tile-grid');
-			expect(oldCourseTileGrid).to.be.null;
 		});
 
 		it('should set the columns-"n" class on the correct tile grid on resize', done => {
@@ -324,7 +312,7 @@ describe('d2l-my-courses-content', () => {
 			});
 
 			it('should focus on course grid when focus called after course interacted with', done => {
-				var tileGridFocusSpy = sandbox.spy(component.$$('d2l-course-tile-grid'), 'focus');
+				var tileGridFocusSpy = sandbox.spy(component.$$('.course-tile-grid'), 'focus');
 
 				component.addEventListener('open-change-image-view', function() {
 					expect(tileGridFocusSpy.called);
@@ -873,140 +861,126 @@ describe('d2l-my-courses-content', () => {
 			expect(component._viewAllCoursesText).to.equal('View All Courses (20+)');
 		});
 
-		it('should not add the Only Past Courses alert if not hiding past courses', () => {
-			var currentOrFutureCourses = false,
-				pinnedEnrollment = false,
-				hidePastCourses = false;
+		describe('Only Past Courses alert', () => {
+			function setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses) {
+				var courseTileGridStub = {
+					hasAttribute: function() {
+						return hidePastCourses;
+					}
+				};
 
-			var courseTileGridStub = sandbox.stub();
-			courseTileGridStub.$$ = sandbox.stub();
-			courseTileGridStub.$$.withArgs('d2l-course-tile:not([past-course])').returns(currentOrFutureCourses);
-			courseTileGridStub.$$.withArgs('d2l-course-tile[pinned]').returns(pinnedEnrollment);
-			courseTileGridStub.hasAttribute = sandbox.stub().returns(hidePastCourses);
-			sandbox.stub(component, '$$').returns(courseTileGridStub);
-			component.$$ = sandbox.stub().returns(courseTileGridStub);
+				sandbox.stub(component, '$$')
+					.withArgs('.course-tile-grid').returns(courseTileGridStub)
+					.withArgs('.course-tile-grid d2l-course-image-tile:not([past-course])').returns(currentOrFutureCourses)
+					.withArgs('.course-tile-grid d2l-course-image-tile[pinned]').returns(pinnedEnrollment);
+			}
 
-			this._alerts = [];
-			component._hasEnrollments = true;
-			component._addOnlyPastCoursesAlert();
-			expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-		});
+			it('should not add the Only Past Courses alert if not hiding past courses', () => {
+				var currentOrFutureCourses = false,
+					pinnedEnrollment = false,
+					hidePastCourses = false;
 
-		it('should not add the Only Past Courses alert if not there are present or future courses', () => {
-			var currentOrFutureCourses = true,
-				pinnedEnrollment = false,
-				hidePastCourses = true;
+				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
 
-			var courseTileGridStub = sandbox.stub();
-			courseTileGridStub.$$ = sandbox.stub();
-			courseTileGridStub.$$.withArgs('d2l-course-tile:not([past-course])').returns(currentOrFutureCourses);
-			courseTileGridStub.$$.withArgs('d2l-course-tile[pinned]').returns(pinnedEnrollment);
-			courseTileGridStub.hasAttribute = sandbox.stub().returns(hidePastCourses);
-			sandbox.stub(component, '$$').returns(courseTileGridStub);
-			component.$$ = sandbox.stub().returns(courseTileGridStub);
+				this._alerts = [];
+				component._hasEnrollments = true;
+				component._addOnlyPastCoursesAlert();
+				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+			});
 
-			this._alerts = [];
-			component._hasEnrollments = true;
-			component._addOnlyPastCoursesAlert();
-			expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-		});
+			it('should not add the Only Past Courses alert if not there are present or future courses', () => {
+				var currentOrFutureCourses = true,
+					pinnedEnrollment = false,
+					hidePastCourses = true;
 
-		it('should add the Only Past Courses alert if there are only past courses and hides past courses', () => {
-			var currentOrFutureCourses = false,
-				pinnedEnrollment = false,
-				hidePastCourses = true;
+				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
 
-			var courseTileGridStub = sandbox.stub();
-			courseTileGridStub.$$ = sandbox.stub();
-			courseTileGridStub.$$.withArgs('d2l-course-tile:not([past-course])').returns(currentOrFutureCourses);
-			courseTileGridStub.$$.withArgs('d2l-course-tile[pinned]').returns(pinnedEnrollment);
-			courseTileGridStub.hasAttribute = sandbox.stub().returns(hidePastCourses);
-			sandbox.stub(component, '$$').returns(courseTileGridStub);
-			component.$$ = sandbox.stub().returns(courseTileGridStub);
+				this._alerts = [];
+				component._hasEnrollments = true;
+				component._addOnlyPastCoursesAlert();
+				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+			});
 
-			this._alerts = [];
-			component._hasEnrollments = true;
-			component._addOnlyPastCoursesAlert();
-			expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-		});
+			it('should add the Only Past Courses alert if there are only past courses and hides past courses', () => {
+				var currentOrFutureCourses = false,
+					pinnedEnrollment = false,
+					hidePastCourses = true;
 
-		it('should add the Only Past Courses alert if there are only past courses, hides past courses and no pinned enrollments', () => {
-			var currentOrFutureCourses = false,
-				pinnedEnrollment = false,
-				hidePastCourses = true;
+				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
 
-			var courseTileGridStub = sandbox.stub();
-			courseTileGridStub.$$ = sandbox.stub();
-			courseTileGridStub.$$.withArgs('d2l-course-tile:not([past-course])').returns(currentOrFutureCourses);
-			courseTileGridStub.$$.withArgs('d2l-course-tile[pinned]').returns(pinnedEnrollment);
-			courseTileGridStub.hasAttribute = sandbox.stub().returns(hidePastCourses);
-			sandbox.stub(component, '$$').returns(courseTileGridStub);
-			component.$$ = sandbox.stub().returns(courseTileGridStub);
+				this._alerts = [];
+				component._hasEnrollments = true;
+				component._addOnlyPastCoursesAlert();
+				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+			});
 
-			this._alerts = [];
-			component._hasEnrollments = true;
-			component._addOnlyPastCoursesAlert();
-			expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-		});
+			it('should add the Only Past Courses alert if there are only past courses, hides past courses and no pinned enrollments', () => {
+				var currentOrFutureCourses = false,
+					pinnedEnrollment = false,
+					hidePastCourses = true;
 
-		it('should remove the Only Past Courses alert if there is a pinned enrollments', () => {
-			var currentOrFutureCourses = false,
-				pinnedEnrollment = true,
-				hidePastCourses = true;
+				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
 
-			var courseTileGridStub = sandbox.stub();
-			courseTileGridStub.$$ = sandbox.stub();
-			courseTileGridStub.$$.withArgs('d2l-course-tile:not([past-course])').returns(currentOrFutureCourses);
-			courseTileGridStub.$$.withArgs('d2l-course-tile[pinned]').returns(pinnedEnrollment);
-			courseTileGridStub.hasAttribute = sandbox.stub().returns(hidePastCourses);
-			sandbox.stub(component, '$$').returns(courseTileGridStub);
-			component.$$ = sandbox.stub().returns(courseTileGridStub);
+				this._alerts = [];
+				component._hasEnrollments = true;
+				component._addOnlyPastCoursesAlert();
+				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+			});
 
-			this._alerts = [{ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' }];
-			component._hasEnrollments = true;
-			component._addOnlyPastCoursesAlert();
-			expect(component._alerts).to.not.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-		});
+			it('should remove the Only Past Courses alert if there is a pinned enrollments', () => {
+				var currentOrFutureCourses = false,
+					pinnedEnrollment = true,
+					hidePastCourses = true;
 
-		it('should set past courses alert with pinned enrollment when a course is pinned', () => {
-			var enrollmentMock = {
-				getLinkByRel: sandbox.stub().returns({ href: 'href' })
-			};
-			var e = {
-				detail: {
-					orgUnitId: 69,
-					enrollment: enrollmentMock,
-					isPinned: true
-				}
-			};
-			component._enrollments = [];
-			component.getEntityIdentifier = sinon.stub().returns('69');
-			var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
-			sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
+				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
 
-			component._onEnrollmentPinnedMessage(e);
-			expect(spy).to.have.been.calledWith(true);
-		});
+				this._alerts = [{ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' }];
+				component._hasEnrollments = true;
+				component._addOnlyPastCoursesAlert();
+				expect(component._alerts).to.not.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+			});
 
-		it('should set past courses alert with unpinned enrollment when a course is unpinned', () => {
-			var enrollmentMock = {
-				getLinkByRel: sandbox.stub().returns({ href: 'href' }),
-				hasClass: sandbox.stub().returns(true)
-			};
-			var e = {
-				detail: {
-					orgUnitId: 69,
-					enrollment: enrollmentMock,
-					isPinned: false
-				}
-			};
-			component._enrollments = [enrollmentMock];
-			component.getEntityIdentifier = sinon.stub().returns('69');
-			var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
-			sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
+			it('should set past courses alert with pinned enrollment when a course is pinned', () => {
+				var enrollmentMock = {
+					getLinkByRel: sandbox.stub().returns({ href: 'href' })
+				};
+				var e = {
+					detail: {
+						orgUnitId: 69,
+						enrollment: enrollmentMock,
+						isPinned: true
+					}
+				};
+				component._enrollments = [];
+				component.getEntityIdentifier = sinon.stub().returns('69');
+				var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
+				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
 
-			component._onEnrollmentPinnedMessage(e);
-			expect(spy).to.have.been.calledWith(false);
+				component._onEnrollmentPinnedMessage(e);
+				expect(spy).to.have.been.calledWith(true);
+			});
+
+			it('should set past courses alert with unpinned enrollment when a course is unpinned', () => {
+				var enrollmentMock = {
+					getLinkByRel: sandbox.stub().returns({ href: 'href' }),
+					hasClass: sandbox.stub().returns(true)
+				};
+				var e = {
+					detail: {
+						orgUnitId: 69,
+						enrollment: enrollmentMock,
+						isPinned: false
+					}
+				};
+				component._enrollments = [enrollmentMock];
+				component.getEntityIdentifier = sinon.stub().returns('69');
+				var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
+				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
+
+				component._onEnrollmentPinnedMessage(e);
+				expect(spy).to.have.been.calledWith(false);
+			});
+
 		});
 
 	});

--- a/test/d2l-my-courses/d2l-my-courses.js
+++ b/test/d2l-my-courses/d2l-my-courses.js
@@ -15,7 +15,6 @@ describe('d2l-my-courses', () => {
 		expect(component.courseImageUploadCompleted).to.be.a('function');
 		expect(component.getLastOrgUnitId).to.be.a('function');
 		expect(component.updatedSortLogic).to.equal(false);
-		expect(component.cssGridView).to.equal(false);
 	});
 
 	describe('Public API', () => {


### PR DESCRIPTION
This property was being set by a feature flag, us90524-my-courses-css-grid-layout, which has been on in production for several months. By removing this flag, we remove a few code paths and simplify the codebase a bit.

There does still have to be some awareness of cssGridView, as the old tile view (`d2l-my-courses-content-behavior` and `d2l-all-courses-segregated-content`) still use the non-CSS-grid view and old course tile.