### PR TITLE
Disable Sauce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ node_js: 9
 script:
 - npm run lint
 - polymer test --skip-plugin sauce
-- 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then polymer test --skip-plugin local; fi'
+# Sauce tests are too flakey (constant timeouts) - need to investigate further when time permits.
+# - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then polymer test --skip-plugin local; fi'
 env:
   global:
     # SAUCE_USERNAME


### PR DESCRIPTION
Been down this road before, but it's time to visit it again - Sauce tests are timing out constantly, effectively rendering them useless. Looking into the performance of these tests might be a good inspiration sprint idea - not overly inspiring, but might glean some useful insight into Polymer _test_ performance, specifically.