### PR TITLE
Move alerts

### DIFF
--- a/src/d2l-all-courses-segregated-content.html
+++ b/src/d2l-all-courses-segregated-content.html
@@ -38,12 +38,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			[[localize('noPinnedCoursesInRole')]]
 		</span>
 
-		<template is="dom-repeat" items="[[_alerts]]">
-			<d2l-alert type="[[item.alertType]]">
-				[[item.alertMessage]]
-			</d2l-alert>
-		</template>
-
 		<d2l-course-tile-grid
 			id="all-courses-segregated-pinned-tile-grid"
 			enrollments="[[filteredPinnedEnrollments]]"
@@ -169,19 +163,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				return this._itemCount;
 			},
 			setCourseImage: function(details) {
-				this.removeSetCourseImageFailure();
-				if (details && details.detail) {
-					if (details.detail.status === 'failure') {
-						setTimeout(function() {
-							this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
-						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
-					}
-				}
 				this.$$('#all-courses-segregated-pinned-tile-grid').setCourseImage(details);
 				this.$$('#all-courses-segregated-unpinned-tile-grid').setCourseImage(details);
-			},
-			removeSetCourseImageFailure: function() {
-				this._removeAlert('setCourseImageFailure');
 			},
 
 			_onTileRemoveComplete: function(e) {

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -1,8 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
-<link rel="import" href="../../d2l-alert/d2l-alert.html">
 <link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-behavior.html">
 <link rel="import" href="d2l-css-grid-view/d2l-css-grid-view-styles.html">
-<link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-image-tile.html">
 <link rel="import" href="localize-behavior.html">
@@ -20,12 +18,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 	<template strip-whitespace>
 		<style include="d2l-all-courses-styles"></style>
 		<style include="d2l-css-grid-view-styles"></style>
-
-		<template is="dom-repeat" items="[[_alerts]]">
-			<d2l-alert type="[[item.alertType]]">
-				[[item.alertMessage]]
-			</d2l-alert>
-		</template>
 
 		<span class="bottom-pad" hidden$="[[!_noCoursesInSearch]]">
 			[[localize('noCoursesInSearch')]]
@@ -87,7 +79,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			},
 			behaviors: [
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
-				D2L.MyCourses.AlertBehavior,
 				D2L.MyCourses.CssGridBehavior
 			],
 			observers: [
@@ -102,19 +93,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 
 			getCourseTileItemCount: function() {
 				return this._itemCount;
-			},
-			setCourseImage: function(details) {
-				this.removeSetCourseImageFailure();
-				if (details && details.detail) {
-					if (details.detail.status === 'failure') {
-						setTimeout(function() {
-							this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
-						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
-					}
-				}
-			},
-			removeSetCourseImageFailure: function() {
-				this._removeAlert('setCourseImageFailure');
 			},
 
 			_enrollmentsChanged: function(enrollmentLength) {

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../polymer/polymer.html">
 <link rel="import" href="../../iron-scroll-threshold/iron-scroll-threshold.html">
+<link rel="import" href="../../d2l-alert/d2l-alert.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-content.html">
 <link rel="import" href="../../d2l-dropdown/d2l-dropdown-menu.html">
@@ -10,6 +11,7 @@
 <link rel="import" href="../../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
@@ -101,6 +103,12 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						<d2l-link href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</d2l-link>
 					</div>
 				</div>
+
+				<template is="dom-repeat" items="[[_alerts]]">
+					<d2l-alert type="[[item.alertType]]">
+						[[item.alertMessage]]
+					</d2l-alert>
+				</template>
 
 				<div>
 					<template is="dom-if" if="[[updatedSortLogic]]">
@@ -261,6 +269,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				window.D2L.Hypermedia.HMConstantsBehavior,
 				D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior,
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
+				D2L.MyCourses.AlertBehavior,
 				D2L.MyCourses.CourseManagementBehavior,
 				D2L.MyCourses.UtilityBehavior
 			],
@@ -329,9 +338,17 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this.load();
 			},
 			setCourseImage: function(details) {
-				if (this.updatedSortLogic) {
-					this.$$('d2l-all-courses-unified-content').setCourseImage(details);
-				} else {
+				this._removeAlert('setCourseImageFailure');
+
+				if (details && details.detail) {
+					if (details.detail.status === 'failure') {
+						setTimeout(function() {
+							this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+						}.bind(this), 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
+					}
+				}
+
+				if (!this.updatedSortLogic) {
 					this.$$('d2l-all-courses-segregated-content').setCourseImage(details);
 				}
 			},
@@ -438,11 +455,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				window.dispatchEvent(new Event('resize'));
 			},
 			_onSimpleOverlayOpening: function() {
-				if (this.updatedSortLogic) {
-					this.$$('d2l-all-courses-unified-content').removeSetCourseImageFailure();
-				} else {
-					this.$$('d2l-all-courses-segregated-content').removeSetCourseImageFailure();
-				}
+				this._removeAlert('setCourseImageFailure');
 				this._clearSearchWidget();
 				this.$.filterMenu.clearFilters();
 				this._filterText = this.localize('filtering.filter');

--- a/test/d2l-all-courses-segregated-content/d2l-all-courses-segregated-content.js
+++ b/test/d2l-all-courses-segregated-content/d2l-all-courses-segregated-content.js
@@ -81,41 +81,6 @@ describe('d2l-all-courses-segregated-content', function() {
 		sandbox.restore();
 	});
 
-	describe('setting course image', function() {
-		var setCourseImageFailureAlert = { alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' };
-
-		it('should remove and course image failure alerts before adding and new ones', function() {
-			var removeAlertSpy = sandbox.spy(widget, '_removeAlert');
-			widget.setCourseImage();
-			expect(removeAlertSpy.called);
-		});
-
-		it('should add an alert after setting the course image results in failure (after a timeout)', function() {
-			clock = sinon.useFakeTimers();
-			var setCourseImageEvent = { detail: { status: 'failure'} };
-			widget.setCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(widget._alerts).to.include(setCourseImageFailureAlert);
-		});
-
-		it('should not add a setCourseImageFailure warning alert when a request to set the image succeeds', function() {
-			var setCourseImageEvent = { detail: { status: 'success'} };
-			widget.setCourseImage(setCourseImageEvent);
-			expect(widget._alerts).not.to.include(setCourseImageFailureAlert);
-		});
-
-		it('should remove a setCourseImageFailure warning alert when a request to set the image is made', function() {
-			clock = sinon.useFakeTimers();
-			var setCourseImageEvent = { detail: { status: 'failure'} };
-			widget.setCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(widget._alerts).to.include(setCourseImageFailureAlert);
-			setCourseImageEvent = { detail: { status: 'set'} };
-			widget.setCourseImage(setCourseImageEvent);
-			expect(widget._alerts).not.to.include(setCourseImageFailureAlert);
-		});
-	});
-
 	describe('changing enrollment entities', () => {
 		it('should update the enrollments alert (_updateEnrollmentAlerts) when unpinned enrollments are updated', () => {
 			var updateEnrollmentAlertsSpy = sandbox.spy(widget, '_updateEnrollmentAlerts');

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
@@ -16,22 +16,6 @@ describe('d2l-all-courses-unified-content', function() {
 		sandbox.restore();
 	});
 
-	describe('setting course image', function() {
-		it('should remove and course image failure alerts before adding and new ones', function() {
-			var removeAlertSpy = sandbox.spy(widget, '_removeAlert');
-			widget.setCourseImage();
-			expect(removeAlertSpy.called);
-		});
-
-		it('should add an alert after setting the course image results in failure (after a timeout)', function() {
-			clock = sinon.useFakeTimers();
-			var setCourseImageEvent = { detail: { status: 'failure'} };
-			widget.setCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
-		});
-	});
-
 	describe('changing enrollment entities', function() {
 		[
 			{ isSearched: true, totalFilterCount: 0, enrollmentsChanged: 0, noCoursesInSearch: true, noCoursesInSelection: false },

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -172,14 +172,45 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('Alerts', function() {
+		var setCourseImageFailureAlert = { alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' };
 
 		it('should remove a setCourseImageFailure alert when the overlay is opened', function() {
-			widget.$$('d2l-all-courses-segregated-content')._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
-			expect(widget.$$('d2l-all-courses-segregated-content')._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
+			widget._addAlert('warning', 'setCourseImageFailure', 'failed to do that thing it should do');
+			expect(widget._alerts).to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
 			widget.$$('d2l-simple-overlay')._renderOpened();
-			expect(widget.$$('d2l-all-courses-segregated-content')._alerts).to.not.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
+			expect(widget._alerts).to.not.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'failed to do that thing it should do' });
 		});
 
+		it('should remove and course image failure alerts before adding and new ones', function() {
+			var removeAlertSpy = sandbox.spy(widget, '_removeAlert');
+			widget.setCourseImage();
+			expect(removeAlertSpy.called);
+		});
+
+		it('should add an alert after setting the course image results in failure (after a timeout)', function() {
+			clock = sinon.useFakeTimers();
+			var setCourseImageEvent = { detail: { status: 'failure'} };
+			widget.setCourseImage(setCourseImageEvent);
+			clock.tick(1001);
+			expect(widget._alerts).to.include(setCourseImageFailureAlert);
+		});
+
+		it('should not add a setCourseImageFailure warning alert when a request to set the image succeeds', function() {
+			var setCourseImageEvent = { detail: { status: 'success'} };
+			widget.setCourseImage(setCourseImageEvent);
+			expect(widget._alerts).not.to.include(setCourseImageFailureAlert);
+		});
+
+		it('should remove a setCourseImageFailure warning alert when a request to set the image is made', function() {
+			clock = sinon.useFakeTimers();
+			var setCourseImageEvent = { detail: { status: 'failure'} };
+			widget.setCourseImage(setCourseImageEvent);
+			clock.tick(1001);
+			expect(widget._alerts).to.include(setCourseImageFailureAlert);
+			setCourseImageEvent = { detail: { status: 'set'} };
+			widget.setCourseImage(setCourseImageEvent);
+			expect(widget._alerts).not.to.include(setCourseImageFailureAlert);
+		});
 	});
 
 	describe('opening the overlay', function() {


### PR DESCRIPTION
Previously, both `d2l-all-courses-segregated-content` and `d2l-all-courses-unified-content` had basically the same implementation of the same thing - being able to handle when a course image fails to be set correctly. While removing the duplicate code is nice, the actual reason for this change is to make adding the tabs to this view easier - it's just easier to have the alerts exist in one place - the over-arching `d2l-all-courses` component - rather than having it in two places, and needing to keep both up to date.