### PR TITLE
Remove cache bust and extra `embedDepth`

### DIFF
--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -479,9 +479,9 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				this._imageLoadingProgress = true;
 
 				var organizationHref = organization.getLinkByRel('self').href;
-				organizationHref += '?embedDepth=1';
 
-				return this._fetchOrganization(organizationHref)
+				return this.fetchSirenEntity(organizationHref)
+					.then(this._handleOrganizationResponse.bind(this))
 					.then(this._displaySetImageResult.bind(this, true, true))
 					.catch(this._displaySetImageResult.bind(this, false));
 			},
@@ -597,28 +597,15 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				this.pinned = enrollment.hasClass(this.HypermediaClasses.enrollments.pinned);
 
 				var organizationHref = enrollment.getLinkByRel(this.HypermediaRels.organization).href;
-				organizationHref += '?embedDepth=1';
 
-				return this._fetchOrganization(organizationHref)
+				return this.fetchSirenEntity(organizationHref)
+					.then(this._handleOrganizationResponse.bind(this))
 					.then(function() {
 						return Promise.all([
 							this._fetchSemester(),
 							this._fetchNotifications()
 						]);
 					}.bind(this));
-			},
-			_fetchOrganization: function(url) {
-				return window.d2lfetch
-					.fetch(new Request(url, {
-						headers: {
-							'accept': 'application/vnd.siren+json',
-							// Needs no-cache so that images refresh if the users here using the back button
-							'cache-control': 'no-cache',
-							'pragma': 'no-cache'
-						}
-					}))
-					.then(this.responseToSirenEntity.bind(this))
-					.then(this._handleOrganizationResponse.bind(this));
 			},
 			_fetchNotifications: function() {
 				if (!this._notificationsUrl || !this.courseUpdatesConfig) {
@@ -683,7 +670,15 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 					this._notificationsUrl = organization.getLinkByRel(this.HypermediaRels.Notifications.organizationNotifications).href;
 				}
 				if (organization.hasSubEntityByClass(this.HypermediaClasses.courseImage.courseImage)) {
-					this._image = organization.getSubEntityByClass(this.HypermediaClasses.courseImage.courseImage);
+					var imageEntity = organization.getSubEntityByClass(this.HypermediaClasses.courseImage.courseImage);
+					if (imageEntity.href) {
+						this.fetchSirenEntity(imageEntity.href)
+							.then(function(hydratedImageEntity) {
+								this._image = hydratedImageEntity;
+							}.bind(this));
+					} else {
+						this._image = imageEntity;
+					}
 				}
 				if (organization.hasSubEntityByRel(this.HypermediaRels.organizationHomepage)) {
 					var homepageEntity = organization.getSubEntityByRel(this.HypermediaRels.organizationHomepage);

--- a/test/d2l-course-image-tile/d2l-course-image-tile.js
+++ b/test/d2l-course-image-tile/d2l-course-image-tile.js
@@ -150,9 +150,7 @@ describe('d2l-course-image-tile', () => {
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		SetupFetchStub(/\/organizations\/1$/, organizationEntity);
-		SetupFetchStub(/\/organizations\/1\?embedDepth=1$/, organizationEntity);
 		SetupFetchStub(/\/organizations\/2$/, semesterOrganizationEntity);
-		SetupFetchStub(/\/organizations\/2\?embedDepth=1$/, semesterOrganizationEntity);
 		SetupFetchStub(/\/organizations\/1\/image/, {});
 		SetupFetchStub(/\/organizations\/1\/my-notifications$/, { properties: {} });
 


### PR DESCRIPTION
There were cache-busting headers on the request to fetch an organization, but this isn't actually necessary - first, because the request is only cached on the page (via `d2l-fetch`) anyway, so navigating away and then back will reload the organization response. In addition, it's only the image entity we wanted to cache-bust anyway, which leads to...

...not fetching the image right away. Rather than tacking an `embedDepth=1` on to the Link (which is dirty), we should be able to handle both cases: a hydrated image entity, and a linked image entity. It's actually slightly preferable to fetch the linked organization entity, since we don't even _need_ the image initially - we only load it when the course tile scrolls into view, which it may not ever do.

The performance impact of this is immediately noticeable - while it doesn't really speed up initial load much (only really by the amount of time embedding the course image entity took, which wasn't much), it does make opening the All Courses overlay significantly faster, as we're able to use the (likely already fetched) organization and organization image responses, rather than re-fetching them.