### PR TITLE
US97068 - All Courses tabs

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -50,7 +50,8 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 							course-image-upload-cb="[[courseImageUploadCb]]"
 							updated-sort-logic="[[updatedSortLogic]]"
 							user-settings-url="[[userSettingsUrl]]"
-							tab-search-actions="[[_tabSearchActions]]">
+							tab-search-actions="[[_tabSearchActions]]"
+							tab-search-type="[[_tabSearchType]]">
 						</d2l-my-courses-content>
 					</d2l-tab-panel>
 				</template>

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="../d2l-tabs/d2l-tabs.html">
 <link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-content.html">
 <link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-content-animated.html">
 <link rel="import" href="src/d2l-my-courses-content/d2l-my-courses-behavior.html">
-<link rel="import" href="../d2l-tabs/d2l-tabs.html">
 <link rel="import" href="src/d2l-utility-behavior.html">
 <link rel="import" href="src/localize-behavior.html">
 

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -49,7 +49,8 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 							course-updates-config="[[courseUpdatesConfig]]"
 							course-image-upload-cb="[[courseImageUploadCb]]"
 							updated-sort-logic="[[updatedSortLogic]]"
-							user-settings-url="[[userSettingsUrl]]">
+							user-settings-url="[[userSettingsUrl]]"
+							tab-search-actions="[[_tabSearchActions]]">
 						</d2l-my-courses-content>
 					</d2l-tab-panel>
 				</template>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -35,19 +35,21 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			[[localize('noCoursesInRole')]]
 		</span>
 
-		<div class="course-tile-grid">
-			<template is="dom-repeat" items="[[filteredEnrollments]]">
-				<div>
-					<d2l-course-image-tile
-						enrollment="[[item]]"
-						tile-sizes="[[_tileSizes]]"
-						show-course-code="[[showCourseCode]]"
-						show-semester="[[showSemester]]"
-						course-updates-config="[[courseUpdatesConfig]]">
-					</d2l-course-image-tile>
-				</div>
-			</template>
-		</div>
+		<template is="dom-if" if="[[_renderContents]]">
+			<div class="course-tile-grid">
+				<template is="dom-repeat" items="[[filteredEnrollments]]">
+					<div>
+						<d2l-course-image-tile
+							enrollment="[[item]]"
+							tile-sizes="[[_tileSizes]]"
+							show-course-code="[[showCourseCode]]"
+							show-semester="[[showSemester]]"
+							course-updates-config="[[courseUpdatesConfig]]">
+						</d2l-course-image-tile>
+					</div>
+				</template>
+			</div>
+		</template>
 	</template>
 	<script>
 		Polymer({
@@ -71,6 +73,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				_noCoursesInDepartment: Boolean,
 				_noCoursesInSemester: Boolean,
 				_noCoursesInRole: Boolean,
+				_renderContents: {
+					type: Boolean,
+					value: false
+				},
 				_tileSizes: Object,
 				_itemCount: {
 					type: Number,
@@ -86,9 +92,13 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			],
 
 			attached: function() {
+				document.body.addEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this._onResize();
 				});
+			},
+			detached: function() {
+				document.body.removeEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 			},
 
 			getCourseTileItemCount: function() {
@@ -119,6 +129,20 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 					if (!this.isSearched && this.totalFilterCount === 0) {
 						this._itemCount = enrollmentLength;
 					}
+				}
+			},
+			_onTabSelected: function(e) {
+				// Component is within a `div` inside the `d2l-tab-panel`, so we
+				// need the parent's parent's ID.
+				var tabPanelId = this.parentElement
+					&& this.parentElement.parentElement
+					&& this.parentElement.parentElement.id;
+				if (e.target.id === tabPanelId) {
+					// If we try to render the `d2l-all-courses-unified-content`
+					// for a large number of tabs right away, the page lags.
+					// Instead, only render a tab when it's selected for the
+					// first time.
+					this._renderContents = true;
 				}
 			}
 		});

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -400,49 +400,49 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				return this.$.filterMenu.open();
 			},
 			_onSortOrderChanged: function(e) {
-				var langterm;
+				var sortParameter, langterm;
 				var promotePins = false;
 
 				switch (e.detail.value) {
 					case 'OrgUnitName':
 						langterm = 'sorting.sortCourseName';
-						this._sortParameter = this.updatedSortLogic ? 'OrgUnitName,OrgUnitId' : '-PinDate,OrgUnitName,OrgUnitId';
+						sortParameter = this.updatedSortLogic ? 'OrgUnitName,OrgUnitId' : '-PinDate,OrgUnitName,OrgUnitId';
 						break;
 					case 'OrgUnitCode':
 						langterm = 'sorting.sortCourseCode';
-						this._sortParameter = this.updatedSortLogic ? 'OrgUnitCode,OrgUnitId' : '-PinDate,OrgUnitCode,OrgUnitId';
+						sortParameter = this.updatedSortLogic ? 'OrgUnitCode,OrgUnitId' : '-PinDate,OrgUnitCode,OrgUnitId';
 						break;
 					case 'PinDate':
 						langterm = 'sorting.sortDatePinned';
-						this._sortParameter = '-PinDate,OrgUnitId';
+						sortParameter = '-PinDate,OrgUnitId';
 						promotePins = this.updatedSortLogic;
 						break;
 					case 'LastAccessed':
 						langterm = 'sorting.sortLastAccessed';
-						this._sortParameter = this.updatedSortLogic ? 'LastAccessed' : 'LastAccessed';
+						sortParameter = this.updatedSortLogic ? 'LastAccessed' : 'LastAccessed';
 						break;
 					case 'EnrollmentDate':
 						langterm = 'sorting.sortEnrollmentDate';
-						this._sortParameter = '-LastModifiedDate,OrgUnitId';
+						sortParameter = '-LastModifiedDate,OrgUnitId';
 						break;
 					case 'Default':
 						langterm = 'sorting.sortDefault';
-						this._sortParameter = 'Current';
+						sortParameter = 'Current';
 						promotePins = true;
 						break;
 					default:
 						langterm = this.updatedSortLogic ? 'sorting.sortDefault' : 'sorting.sortCourseName';
-						this._sortParameter =  this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId';
+						sortParameter =  this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId';
 						promotePins = this.updatedSortLogic;
 						break;
 				}
 
-
 				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
-					sort: this._sortParameter,
+					sort: sortParameter,
 					promotePins: promotePins
 				}) + '&bustCache=' + Math.random();
 
+				this._sortParameter = sortParameter;
 				this.$.sortText.textContent = this.localize(langterm || '');
 				this.$.sortDropdown.toggleOpen();
 			},
@@ -499,7 +499,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this._searchUrl = this.createActionUrl(tabAction.enrollmentsSearchAction, {
 					autoPinCourses: false,
 					embedDepth: 1,
-					sort: this._sortParameter || this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId'
+					sort: this._sortParameter || (this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId')
 				});
 
 				e.stopPropagation();
@@ -526,8 +526,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					if (!sortParameter) {
 						return;
 					}
-
-					this._sortParameter = sortParameter;
 
 					var sortMap = {
 						'OrgUnitName,OrgUnitId': {
@@ -566,10 +564,11 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						}
 					};
 
-					var sort = sortMap[this._sortParameter];
+					var sort = sortMap[sortParameter];
 					if (sort) {
 						this.$.sortText.textContent = this.localize(sort.langterm || '');
 						this._selectSortOption(sort.name);
+						this._sortParameter = sortParameter;
 					} else {
 						var langterm = this.updatedSortLogic ? 'sorting.sortDefault' : 'sorting.sortCourseName';
 						this.$.sortText.textContent = this.localize(langterm);

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -11,6 +11,7 @@
 <link rel="import" href="../../d2l-menu/d2l-menu-item-radio.html">
 <link rel="import" href="../../d2l-organization-hm-behavior/d2l-organization-hm-behavior.html">
 <link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
+<link rel="import" href="../../d2l-tabs/d2l-tabs.html">
 <link rel="import" href="d2l-alert-behavior.html">
 <link rel="import" href="d2l-all-courses-styles.html">
 <link rel="import" href="d2l-course-management-behavior.html">
@@ -110,33 +111,42 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					</d2l-alert>
 				</template>
 
-				<div>
-					<template is="dom-if" if="[[updatedSortLogic]]">
-						<d2l-all-courses-unified-content
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]"
-							updated-sort-logic="[[updatedSortLogic]]"
-							total-filter-count="[[_totalFilterCount]]"
-							filter-counts="[[_filterCounts]]"
-							is-searched="[[_isSearched]]"
-							filtered-enrollments="[[_filteredEnrollments]]"
-						></d2l-all-courses-unified-content>
-					</template>
-					<template is="dom-if" if="[[!updatedSortLogic]]">
-						<d2l-all-courses-segregated-content
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]"
-							updated-sort-logic="[[updatedSortLogic]]"
-							total-filter-count="[[_totalFilterCount]]"
-							filter-counts="[[_filterCounts]]"
-							is-searched="[[_isSearched]]"
-							filtered-pinned-enrollments="[[_filteredPinnedEnrollments]]"
-							filtered-unpinned-enrollments="[[_filteredUnpinnedEnrollments]]"
-						></d2l-all-courses-segregated-content>
-					</template>
-				</div>
+				<template is="dom-if" if="[[updatedSortLogic]]">
+					<d2l-tabs>
+						<template items="[[tabSearchActions]]" is="dom-repeat">
+							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]></d2l-tab-panel>
+						</template>
+						<div hidden$="[[!_showTabContent]]">
+							<d2l-all-courses-unified-content
+								show-course-code="[[showCourseCode]]"
+								show-semester="[[showSemester]]"
+								course-updates-config="[[courseUpdatesConfig]]"
+								updated-sort-logic="[[updatedSortLogic]]"
+								total-filter-count="[[_totalFilterCount]]"
+								filter-counts="[[_filterCounts]]"
+								is-searched="[[_isSearched]]"
+								filtered-enrollments="[[_filteredEnrollments]]"
+							></d2l-all-courses-unified-content>
+						</div>
+						<d2l-loading-spinner
+							hidden$="[[_showTabContent]]"
+							size="100">
+						</d2l-loading-spinner>
+					</d2l-tabs>
+				</template>
+				<template is="dom-if" if="[[!updatedSortLogic]]">
+					<d2l-all-courses-segregated-content
+						show-course-code="[[showCourseCode]]"
+						show-semester="[[showSemester]]"
+						course-updates-config="[[courseUpdatesConfig]]"
+						updated-sort-logic="[[updatedSortLogic]]"
+						total-filter-count="[[_totalFilterCount]]"
+						filter-counts="[[_filterCounts]]"
+						is-searched="[[_isSearched]]"
+						filtered-pinned-enrollments="[[_filteredPinnedEnrollments]]"
+						filtered-unpinned-enrollments="[[_filteredUnpinnedEnrollments]]"
+					></d2l-all-courses-segregated-content>
+				</template>
 				<d2l-loading-spinner
 					id="lazyLoadSpinner"
 					hidden$="[[!_hasMoreEnrollments]]"
@@ -178,9 +188,10 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					value: function() { return {}; },
 					observer: '_myEnrollmentsEntityChanged'
 				},
-				searchUrl: String,
 				showCourseCode: Boolean,
 				showSemester: Boolean,
+				// Siren Actions corresponding to each tab that is displayed
+				tabSearchActions: Array,
 				// Feature flag (switch) for using the updated sort logic and related fetaures
 				updatedSortLogic: {
 					type: Boolean,
@@ -216,7 +227,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				// True when there are more enrollments to fetch (i.e. current page of enrollments has a `next` link)
 				_hasMoreEnrollments: {
 					type: Boolean,
-					computed: '_computeHasMoreEnrollments(lastEnrollmentsSearchResponse)'
+					computed: '_computeHasMoreEnrollments(lastEnrollmentsSearchResponse, _showTabContent)'
 				},
 				// Object containing the IDs of previously loaded pinned enrollments, to avoid duplicates
 				_pinnedCoursesMap: {
@@ -241,6 +252,10 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					computed: '_computeShowAdvancedSearchLink(advancedSearchUrl)'
 				},
 				_showContent: {
+					type: Boolean,
+					value: false
+				},
+				_showTabContent: {
 					type: Boolean,
 					value: false
 				},
@@ -274,7 +289,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				D2L.MyCourses.UtilityBehavior
 			],
 			listeners: {
-				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening'
+				'd2l-simple-overlay-opening': '_onSimpleOverlayOpening',
+				'd2l-tab-panel-selected': '_onTabSelected'
 			},
 			observers: [
 				'_enrollmentsChanged(_filteredPinnedEnrollments.length, _filteredUnpinnedEnrollments.length)'
@@ -316,18 +332,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 					}, this);
 				}
-
-				var url;
-				// We never want to autopin results in the overlay
-				url = this.searchUrl.replace('autoPinCourses=true', 'autoPinCourses=false');
-				// Busts d2l-fetch cache, since enrollments may have been pinned/unpinned
-				// since last time this URL was fetched
-				url += '&bustCache=' + Math.random();
-				this._searchUrl = url;
-
-				requestAnimationFrame(function() {
-					this.fire('recalculate-columns');
-				}.bind(this));
 			},
 			open: function() {
 				// Initially hide the content, until we have some data to show
@@ -393,45 +397,46 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				return this.$.filterMenu.open();
 			},
 			_onSortOrderChanged: function(e) {
-				var sortParameter, langterm;
+				var langterm;
 				var promotePins = false;
 
 				switch (e.detail.value) {
 					case 'OrgUnitName':
 						langterm = 'sorting.sortCourseName';
-						sortParameter = this.updatedSortLogic ? 'OrgUnitName,OrgUnitId' : '-PinDate,OrgUnitName,OrgUnitId';
+						this._sortParameter = this.updatedSortLogic ? 'OrgUnitName,OrgUnitId' : '-PinDate,OrgUnitName,OrgUnitId';
 						break;
 					case 'OrgUnitCode':
 						langterm = 'sorting.sortCourseCode';
-						sortParameter = this.updatedSortLogic ? 'OrgUnitCode,OrgUnitId' : '-PinDate,OrgUnitCode,OrgUnitId';
+						this._sortParameter = this.updatedSortLogic ? 'OrgUnitCode,OrgUnitId' : '-PinDate,OrgUnitCode,OrgUnitId';
 						break;
 					case 'PinDate':
 						langterm = 'sorting.sortDatePinned';
-						sortParameter = '-PinDate,OrgUnitId';
+						this._sortParameter = '-PinDate,OrgUnitId';
 						promotePins = this.updatedSortLogic;
 						break;
 					case 'LastAccessed':
 						langterm = 'sorting.sortLastAccessed';
-						sortParameter = this.updatedSortLogic ? 'LastAccessed' : 'LastAccessed';
+						this._sortParameter = this.updatedSortLogic ? 'LastAccessed' : 'LastAccessed';
 						break;
 					case 'EnrollmentDate':
 						langterm = 'sorting.sortEnrollmentDate';
-						sortParameter = '-LastModifiedDate,OrgUnitId';
+						this._sortParameter = '-LastModifiedDate,OrgUnitId';
 						break;
 					case 'Default':
 						langterm = 'sorting.sortDefault';
-						sortParameter = 'Current';
+						this._sortParameter = 'Current';
 						promotePins = true;
 						break;
 					default:
 						langterm = this.updatedSortLogic ? 'sorting.sortDefault' : 'sorting.sortCourseName';
-						sortParameter =  this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId';
+						this._sortParameter =  this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId';
 						promotePins = this.updatedSortLogic;
 						break;
 				}
 
+
 				this._searchUrl = this.createActionUrl(this._enrollmentsSearchAction, {
-					sort: sortParameter,
+					sort: this._sortParameter,
 					promotePins: promotePins
 				}) + '&bustCache=' + Math.random();
 
@@ -449,10 +454,27 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this._updateFilteredEnrollments(e.detail, false);
 				this.myEnrollmentsEntity = e.detail;
 				this.fire('recalculate-columns');
-				this._showContent = true;
 
-				// Forces recalculation of columns in d2l-all-courses-content-unified
-				window.dispatchEvent(new Event('resize'));
+				if (!this.updatedSortLogic) {
+					this._showContent = true;
+
+					// Forces recalculation of columns in d2l-all-courses-content-unified
+					window.dispatchEvent(new Event('resize'));
+					return;
+				}
+
+				this._showTabContent = true;
+
+				// On initial load, search-results-changed will fire immediately
+				// when the search component is rendered. We want to wait until
+				// the second time is fired, after completing the default tab
+				// search, before showing any content.
+				this._showContent = !!this.tabSearchActions;
+
+				setTimeout(function() {
+					// Triggers the course tiles to resize after switching tab
+					window.dispatchEvent(new Event('resize'));
+				}, 10);
 			},
 			_onSimpleOverlayOpening: function() {
 				this._removeAlert('setCourseImageFailure');
@@ -460,6 +482,24 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this.$.filterMenu.clearFilters();
 				this._filterText = this.localize('filtering.filter');
 				this._resetSortDropdown();
+			},
+			_onTabSelected: function(e) {
+				var actionName = e.target.id.replace('all-courses-tab-', '');
+				var tabAction = this.tabSearchActions.find(function(action) {
+					return action.name === actionName;
+				});
+				if (!tabAction) {
+					return;
+				}
+
+				this._showTabContent = false;
+				this._searchUrl = this.createActionUrl(tabAction.enrollmentsSearchAction, {
+					autoPinCourses: false,
+					embedDepth: 1,
+					sort: this._sortParameter || this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId'
+				});
+
+				e.stopPropagation();
 			},
 
 			/*
@@ -483,6 +523,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					if (!sortParameter) {
 						return;
 					}
+
+					this._sortParameter = sortParameter;
 
 					var sortMap = {
 						'OrgUnitName,OrgUnitId': {
@@ -521,7 +563,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						}
 					};
 
-					var sort = sortMap[sortParameter];
+					var sort = sortMap[this._sortParameter];
 					if (sort) {
 						this.$.sortText.textContent = this.localize(sort.langterm || '');
 						this._selectSortOption(sort.name);
@@ -549,7 +591,11 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this.$['search-widget'].clear();
 				this._clearFilteredCourses();
 			},
-			_computeHasMoreEnrollments: function(lastResponse) {
+			_computeHasMoreEnrollments: function(lastResponse, showTabContent) {
+				if (!showTabContent) {
+					return false;
+				}
+
 				lastResponse = this.parseEntity(lastResponse);
 				return lastResponse.hasLinkByRel('next');
 			},

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -115,24 +115,25 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				<template is="dom-if" if="[[updatedSortLogic]]">
 					<d2l-tabs>
 						<template items="[[tabSearchActions]]" is="dom-repeat">
-							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]></d2l-tab-panel>
+							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
+								<div hidden$="[[!_showTabContent]]">
+									<d2l-all-courses-unified-content
+										show-course-code="[[showCourseCode]]"
+										show-semester="[[showSemester]]"
+										course-updates-config="[[courseUpdatesConfig]]"
+										updated-sort-logic="[[updatedSortLogic]]"
+										total-filter-count="[[_totalFilterCount]]"
+										filter-counts="[[_filterCounts]]"
+										is-searched="[[_isSearched]]"
+										filtered-enrollments="[[_filteredEnrollments]]">
+									</d2l-all-courses-unified-content>
+								</div>
+								<d2l-loading-spinner
+									hidden$="[[_showTabContent]]"
+									size="100">
+								</d2l-loading-spinner>
+							</d2l-tab-panel>
 						</template>
-						<div hidden$="[[!_showTabContent]]">
-							<d2l-all-courses-unified-content
-								show-course-code="[[showCourseCode]]"
-								show-semester="[[showSemester]]"
-								course-updates-config="[[courseUpdatesConfig]]"
-								updated-sort-logic="[[updatedSortLogic]]"
-								total-filter-count="[[_totalFilterCount]]"
-								filter-counts="[[_filterCounts]]"
-								is-searched="[[_isSearched]]"
-								filtered-enrollments="[[_filteredEnrollments]]"
-							></d2l-all-courses-unified-content>
-						</div>
-						<d2l-loading-spinner
-							hidden$="[[_showTabContent]]"
-							size="100">
-						</d2l-loading-spinner>
 					</d2l-tabs>
 				</template>
 				<template is="dom-if" if="[[!updatedSortLogic]]">
@@ -145,8 +146,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						filter-counts="[[_filterCounts]]"
 						is-searched="[[_isSearched]]"
 						filtered-pinned-enrollments="[[_filteredPinnedEnrollments]]"
-						filtered-unpinned-enrollments="[[_filteredUnpinnedEnrollments]]"
-					></d2l-all-courses-segregated-content>
+						filtered-unpinned-enrollments="[[_filteredUnpinnedEnrollments]]">
+					</d2l-all-courses-segregated-content>
 				</template>
 				<d2l-loading-spinner
 					id="lazyLoadSpinner"
@@ -193,7 +194,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				showSemester: Boolean,
 				// Siren Actions corresponding to each tab that is displayed
 				tabSearchActions: Array,
-				// Type of tabs being displayed - that should be excluded from filter menu
+				// Type of tabs being displayed (BySemester, ByDepartment, ByRoleAlias)
 				tabSearchType: String,
 				// Feature flag (switch) for using the updated sort logic and related fetaures
 				updatedSortLogic: {
@@ -338,8 +339,10 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 			},
 			open: function() {
 				// Initially hide the content, until we have some data to show
-				// (set back to true in _onSearchResultsChanged)
-				this._showContent = false;
+				// (set back to true in _onSearchResultsChanged). The exception
+				// to this is when the overlay is closed then reopened - we want
+				// to immediately show the already-loaded content.
+				this._showContent = !!this._searchUrl;
 
 				this.$$('#all-courses').open();
 				this.load();
@@ -458,21 +461,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this.myEnrollmentsEntity = e.detail;
 				this.fire('recalculate-columns');
 
-				if (!this.updatedSortLogic) {
-					this._showContent = true;
-
-					// Forces recalculation of columns in d2l-all-courses-content-unified
-					window.dispatchEvent(new Event('resize'));
-					return;
-				}
-
+				this._showContent = true;
 				this._showTabContent = true;
-
-				// On initial load, search-results-changed will fire immediately
-				// when the search component is rendered. We want to wait until
-				// the second time is fired, after completing the default tab
-				// search, before showing any content.
-				this._showContent = !!this.tabSearchActions;
 
 				setTimeout(function() {
 					// Triggers the course tiles to resize after switching tab
@@ -501,8 +491,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					embedDepth: 1,
 					sort: this._sortParameter || (this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId')
 				});
-
-				e.stopPropagation();
 			},
 
 			/*

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -70,8 +70,9 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 								<d2l-dropdown-content id="filterDropdownContent" no-padding min-width="350" render-content>
 									<d2l-filter-menu
 										id="filterMenu"
-										my-enrollments-entity="[[myEnrollmentsEntity]]",
-										filter-standard-semester-name="[[filterStandardSemesterName]]",
+										tab-search-type="[[tabSearchType]]"
+										my-enrollments-entity="[[myEnrollmentsEntity]]"
+										filter-standard-semester-name="[[filterStandardSemesterName]]"
 										filter-standard-department-name="[[filterStandardDepartmentName]]">
 									</d2l-filter-menu>
 								</d2l-dropdown-content>
@@ -192,6 +193,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				showSemester: Boolean,
 				// Siren Actions corresponding to each tab that is displayed
 				tabSearchActions: Array,
+				// Type of tabs being displayed - that should be excluded from filter menu
+				tabSearchType: String,
 				// Feature flag (switch) for using the updated sort logic and related fetaures
 				updatedSortLogic: {
 					type: Boolean,

--- a/src/d2l-filter-menu/d2l-filter-menu.html
+++ b/src/d2l-filter-menu/d2l-filter-menu.html
@@ -229,10 +229,10 @@ Polymer-based web component for the filter menu.
 
 			open: function() {
 				// If My Courses is grouped by semesters/departments, don't show either of these tabs
-				this._semestersTabHidden = this.tabSearchType === 'semesters' || this.tabSearchType === 'departments';
+				this._semestersTabHidden = this.tabSearchType === 'BySemester' || this.tabSearchType === 'ByDepartment';
 				this._departmentsTabHidden = this._semestersTabHidden;
 				// If My Courses is grouped by role alias, don't show the Role tab
-				this._rolesTabHidden = this.tabSearchType === 'roles';
+				this._rolesTabHidden = this.tabSearchType === 'ByRoleAlias';
 
 				var defaultTab = this._semestersTabHidden ? 'roles' : 'semesters';
 

--- a/src/d2l-filter-menu/d2l-filter-menu.html
+++ b/src/d2l-filter-menu/d2l-filter-menu.html
@@ -80,8 +80,8 @@ Polymer-based web component for the filter menu.
 
 		<div id="contentView">
 			<div class="dropdown-content-tabs" role="tablist">
-				<div class="dropdown-content-tab" role="tab" aria-controls="semestersTab">
-					<div class="dropdown-content-tab-highlight" hidden$="[[!_semestersTabVisible]]"></div>
+				<div class="dropdown-content-tab" role="tab" aria-controls="semestersTab" hidden$="[[_semestersTabHidden]]">
+					<div class="dropdown-content-tab-highlight" hidden$="[[!_semestersTabSelected]]"></div>
 					<button
 						id="semestersTabButton"
 						class="dropdown-content-tab-button"
@@ -89,8 +89,8 @@ Polymer-based web component for the filter menu.
 						data-tab-name="semesters"
 						aria-pressed="true">[[_semestersTabText]]</button>
 				</div>
-				<div class="dropdown-content-tab" role="tab" aria-controls="departmentsTab">
-					<div class="dropdown-content-tab-highlight" hidden$="[[!_departmentsTabVisible]]"></div>
+				<div class="dropdown-content-tab" role="tab" aria-controls="departmentsTab" hidden$="[[_departmentsTabHidden]]">
+					<div class="dropdown-content-tab-highlight" hidden$="[[!_departmentsTabSelected]]"></div>
 					<button
 						id="departmentsTabButton"
 						class="dropdown-content-tab-button"
@@ -98,8 +98,8 @@ Polymer-based web component for the filter menu.
 						data-tab-name="departments"
 						aria-pressed="false">[[_departmentsTabText]]</button>
 				</div>
-				<div class="dropdown-content-tab" role="tab" aria-controls="rolesTab">
-					<div class="dropdown-content-tab-highlight" hidden$="[[!_rolesTabVisible]]"></div>
+				<div class="dropdown-content-tab" role="tab" aria-controls="rolesTab" hidden$="[[_rolesTabHidden]]">
+					<div class="dropdown-content-tab-highlight" hidden$="[[!_rolesTabSelected]]"></div>
 					<button
 						id="rolesTabButton"
 						class="dropdown-content-tab-button"
@@ -119,7 +119,8 @@ Polymer-based web component for the filter menu.
 				no-filters-text="[[localize('filtering.noSemesters', 'semester', filterStandardSemesterName)]]"
 				search-action="[[_searchSemestersAction]]"
 				search-placeholder-text="[[_semestersSearchPlaceholderText]]"
-				selected-filters="{{_semesterFilters}}">
+				selected-filters="{{_semesterFilters}}"
+				hidden$="[[_semestersTabHidden]]">
 			</d2l-filter-menu-tab>
 
 			<d2l-filter-menu-tab
@@ -130,7 +131,8 @@ Polymer-based web component for the filter menu.
 				no-filters-text="[[localize('filtering.noDepartments', 'department', filterStandardDepartmentName)]]"
 				search-action="[[_searchDepartmentsAction]]"
 				search-placeholder-text="[[_departmentsSearchPlaceholderText]]"
-				selected-filters="{{_departmentFilters}}">
+				selected-filters="{{_departmentFilters}}"
+				hidden$="[[_departmentsTabHidden]]">
 			</d2l-filter-menu-tab>
 
 			<d2l-filter-menu-tab-roles
@@ -138,7 +140,8 @@ Polymer-based web component for the filter menu.
 				data-tab-name="roles"
 				aria-labelledby="rolesTabButton"
 				no-filters-text="[[localize('filtering.noRoles')]]"
-				my-enrollments-entity="[[myEnrollmentsEntity]]">
+				my-enrollments-entity="[[myEnrollmentsEntity]]"
+				hidden$="[[_rolesTabHidden]]">
 			</d2l-filter-menu-tab-roles>
 		</iron-pages>
 	</template>
@@ -153,6 +156,8 @@ Polymer-based web component for the filter menu.
 					type: Object,
 					observer: '_myEnrollmentsEntityChanged'
 				},
+				tabSearchType: String,
+
 				_departmentFilters: {
 					type: Array,
 					value: function() { return []; }
@@ -168,15 +173,15 @@ Polymer-based web component for the filter menu.
 				_searchDepartmentsAction: Object,
 				_searchSemestersAction: Object,
 				_searchMyEnrollmentsAction: Object,
-				_semestersTabVisible: {
+				_semestersTabSelected: {
 					type: Boolean,
 					value: false
 				},
-				_departmentsTabVisible: {
+				_departmentsTabSelected: {
 					type: Boolean,
 					value: false
 				},
-				_rolesTabVisible: {
+				_rolesTabSelected: {
 					type: Boolean,
 					value: false
 				},
@@ -204,7 +209,10 @@ Polymer-based web component for the filter menu.
 				_departmentsSearchPlaceholderText: {
 					type: String,
 					computed: '_computeSearchPlaceholderText(filterStandardDepartmentName)'
-				}
+				},
+				_semestersTabHidden: Boolean,
+				_departmentsTabHidden: Boolean,
+				_rolesTabHidden: Boolean
 			},
 			behaviors: [
 				window.D2L.Hypermedia.HMConstantsBehavior,
@@ -220,7 +228,15 @@ Polymer-based web component for the filter menu.
 			},
 
 			open: function() {
-				this._selectTab({ target: { dataset: { tabName: 'semesters' }}});
+				// If My Courses is grouped by semesters/departments, don't show either of these tabs
+				this._semestersTabHidden = this.tabSearchType === 'semesters' || this.tabSearchType === 'departments';
+				this._departmentsTabHidden = this._semestersTabHidden;
+				// If My Courses is grouped by role alias, don't show the Role tab
+				this._rolesTabHidden = this.tabSearchType === 'roles';
+
+				var defaultTab = this._semestersTabHidden ? 'roles' : 'semesters';
+
+				this._selectTab({ target: { dataset: { tabName: defaultTab }}});
 
 				return Promise.all([
 					this.$.semestersTab.load(),
@@ -235,9 +251,9 @@ Polymer-based web component for the filter menu.
 				this._roleFiltersCount = 0;
 
 				// Clear button is removed via dom-if, so need to manually set focus to next element
-				if (this._semestersTabVisible) {
+				if (this._semestersTabSelected) {
 					this.$.semestersTabButton.focus();
-				} else if (this._departmentsTabVisible) {
+				} else if (this._departmentsTabSelected) {
 					this.$.departmentsTabButton.focus();
 				} else {
 					this.$.rolesTabButton.focus();
@@ -248,10 +264,17 @@ Polymer-based web component for the filter menu.
 					return;
 				}
 
-				var searchUrl = this.createActionUrl(this._searchMyEnrollmentsAction, {
-					parentOrganizations: '',
-					roles: ''
-				});
+				var params = {};
+				if (!this._semestersTabHidden || !this._departmentsTabHidden) {
+					// Only clear semesters/departments when My Courses is grouped by role
+					params.parentOrganizations = '';
+				}
+				if (!this._rolesTabHidden) {
+					// Only clear roles when My Courses is grouped by semester/department
+					params.roles = '';
+				}
+
+				var searchUrl = this.createActionUrl(this._searchMyEnrollmentsAction, params);
 
 				this.fire('d2l-filter-menu-change', {
 					url: searchUrl,
@@ -315,17 +338,17 @@ Polymer-based web component for the filter menu.
 
 				this.$$('iron-pages').select(tabName);
 
-				this._semestersTabVisible = tabName === 'semesters';
-				this._departmentsTabVisible = tabName === 'departments';
-				this._rolesTabVisible = tabName === 'roles';
+				this._semestersTabSelected = tabName === 'semesters';
+				this._departmentsTabSelected = tabName === 'departments';
+				this._rolesTabSelected = tabName === 'roles';
 
 				this.$.semestersTab.resize();
 				this.$.departmentsTab.resize();
 				this.$.rolesTab.resize();
 
-				this.$.semestersTabButton.setAttribute('aria-pressed', this._semestersTabVisible);
-				this.$.departmentsTabButton.setAttribute('aria-pressed', this._departmentsTabVisible);
-				this.$.rolesTabButton.setAttribute('aria-pressed', this._rolesTabVisible);
+				this.$.semestersTabButton.setAttribute('aria-pressed', this._semestersTabSelected);
+				this.$.departmentsTabButton.setAttribute('aria-pressed', this._departmentsTabSelected);
+				this.$.rolesTabButton.setAttribute('aria-pressed', this._rolesTabSelected);
 			},
 			_computeHasFilters: function(departmentFiltersLength, semesterFiltersLength, roleFiltersCount) {
 				return departmentFiltersLength + semesterFiltersLength + roleFiltersCount > 0;

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -76,16 +76,19 @@
 						this._enrollmentsSearchAction = searchAction;	// For d2l-my-courses-content-animated
 						tabSearchActions = [{name: searchAction.name, title: this.localize('allTab'), selected: false, enrollmentsSearchAction: searchAction}];
 					}
-					if (promotedSearchesEntity && promotedSearchesEntity.actions) {
-						var promotedSearchesArray = promotedSearchesEntity.actions.map(function(action) {
-							var selected = action.name === mostRecentSearchName;
-							return { name: action.name, title: action.title, selected: selected, enrollmentsSearchAction: action };
-						});
-						tabSearchActions = tabSearchActions.concat(promotedSearchesArray);
+					if (promotedSearchesEntity) {
+						if (promotedSearchesEntity.actions) {
+							var promotedSearchesArray = promotedSearchesEntity.actions.map(function(action) {
+								var selected = action.name === mostRecentSearchName;
+								return { name: action.name, title: action.title, selected: selected, enrollmentsSearchAction: action };
+							});
+							tabSearchActions = tabSearchActions.concat(promotedSearchesArray);
+						}
+						if (promotedSearchesEntity.properties) {
+							this._tabSearchType = promotedSearchesEntity.properties.UserEnrollmentsSearchType;
+						}
 					}
 					this._tabSearchActions = tabSearchActions;
-					// TODO: Populate with actual value from response
-					this._tabSearchType = 'departments';
 				}.bind(this));
 		}
 	};

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -41,7 +41,8 @@
 			_tabSearchActions: {
 				type: Array,
 				value: []
-			}
+			},
+			_tabSearchType: String
 		},
 		attached: function() {
 			this._fetchTabSearchActions();
@@ -83,6 +84,8 @@
 						tabSearchActions = tabSearchActions.concat(promotedSearchesArray);
 					}
 					this._tabSearchActions = tabSearchActions;
+					// TODO: Populate with actual value from response
+					this._tabSearchType = 'departments';
 				}.bind(this));
 		}
 	};

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -24,6 +24,7 @@
 		properties: {
 			enrollmentsSearchAction: Object,
 			tabSearchActions: Array,
+			tabSearchType: String,
 			userSettingsUrl: String,
 
 			// Alerts to display in widget, above course tiles
@@ -481,6 +482,7 @@
 			var allCourses = this.$$('d2l-all-courses');
 
 			allCourses.tabSearchActions = this.tabSearchActions;
+			allCourses.tabSearchType = this.tabSearchType;
 			allCourses.locale = this.locale;
 			allCourses.showCourseCode = this.showCourseCode;
 			allCourses.showSemester = this.showSemester;

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -23,7 +23,9 @@
 	D2L.MyCourses.MyCoursesContentBehaviorImpl = {
 		properties: {
 			enrollmentsSearchAction: Object,
+			tabSearchActions: Array,
 			userSettingsUrl: String,
+
 			// Alerts to display in widget, above course tiles
 			_alerts: {
 				type: Array,
@@ -478,7 +480,7 @@
 
 			var allCourses = this.$$('d2l-all-courses');
 
-			allCourses.searchUrl = this._enrollmentsSearchUrl;
+			allCourses.tabSearchActions = this.tabSearchActions;
 			allCourses.locale = this.locale;
 			allCourses.showCourseCode = this.showCourseCode;
 			allCourses.showSemester = this.showSemester;

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
@@ -18,6 +18,18 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="event-test-fixture">
+			<template>
+				<div id="foo">
+					<div>
+						<d2l-all-courses-unified-content
+							filtered-enrollments='[]'>
+						</d2l-all-courses-unified-content>
+					</div>
+				</div>
+			</template>
+		</test-fixture>
+
 		<script src="d2l-all-courses-unified-content.js"></script>
 	</body>
 </html>

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
@@ -1,19 +1,39 @@
 describe('d2l-all-courses-unified-content', function() {
-	var widget, sandbox, clock;
+	var widget, sandbox;
 
 	beforeEach(function(done) {
 		sandbox = sinon.sandbox.create();
 		widget = fixture('d2l-all-courses-unified-content-fixture');
+
 		setTimeout(function() {
 			done();
 		});
 	});
 
 	afterEach(function() {
-		if (clock) {
-			clock.restore();
-		}
 		sandbox.restore();
+	});
+
+	describe('initial load', function() {
+		it('should not render contents initially', function() {
+			expect(widget.$$('div.course-tile-grid')).to.be.null;
+		});
+
+		it('should render the contents on a d2l-tab-panel-selected event', function(done) {
+			widget = fixture('event-test-fixture').querySelector('d2l-all-courses-unified-content');
+			expect(widget.$$('div.course-tile-grid')).to.be.null;
+			expect(widget._renderContents).to.be.false;
+
+			widget._onTabSelected({
+				target: { id: 'foo' }
+			});
+
+			expect(widget._renderContents).to.be.true;
+			setTimeout(function() {
+				expect(widget.$$('div.course-tile-grid')).to.not.be.null;
+				done();
+			});
+		});
 	});
 
 	describe('changing enrollment entities', function() {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -214,43 +214,9 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('opening the overlay', function() {
-		it('should set _searchUrl from the public property', function() {
-			widget.searchUrl = '/foo';
-
-			widget.open();
-
-			expect(widget._searchUrl).to.match(/\/foo/);
-		});
-
-		it('should not request auto-pinned courses', function() {
-			widget.searchUrl = '/foo?autoPinCourses=true';
-
-			widget.open();
-
-			expect(widget._searchUrl).to.match(/\/foo\?autoPinCourses=false/);
-		});
-
 		it('should initially hide content', function() {
-			widget.searchUrl = '';
 			widget.open();
-
 			expect(widget._showContent).to.be.false;
-		});
-
-		it('should show content once search results have loaded', function(done) {
-			window.d2lfetch.fetch = sinon.stub().returns(Promise.resolve({
-				ok: true,
-				json: function() {}
-			}));
-			var spy = sinon.spy(widget, '_onSearchResultsChanged');
-			widget.searchUrl = '/foo';
-			widget.open();
-
-			setTimeout(function() {
-				expect(spy).to.have.been.called;
-				expect(widget._showContent).to.be.true;
-				done();
-			});
 		});
 	});
 
@@ -292,7 +258,6 @@ describe('d2l-all-courses', function() {
 				value: 'OrgUnitCode'
 			};
 
-			widget.searchUrl = '';
 			widget.load();
 			widget.$$('d2l-dropdown-menu').fire('d2l-menu-item-change', event);
 			expect(widget._searchUrl).to.contain('-PinDate,OrgUnitCode,OrgUnitId');
@@ -301,6 +266,54 @@ describe('d2l-all-courses', function() {
 			expect(spy.called).to.be.true;
 		});
 
+	});
+
+	describe.only('Tabbed view', function() {
+		beforeEach(function() {
+			widget.updatedSortLogic = true;
+			widget.tabSearchActions = [{
+				name: '12345',
+				title: 'Search Foo Action',
+				selected: false,
+				enrollmentsSearchAction: {
+					name: 'search-foo',
+					href: '/example/foo',
+					fields: [{
+						name: 'autoPinCourses',
+						value: true
+					}, {
+						name: 'embedDepth',
+						value: 0
+					}, {
+						name: 'sort',
+						value: 'foobar'
+					}]
+				}
+			}];
+			Polymer.dom.flush();
+		});
+
+		it('should hide tab contents when loading a tab\'s contents', function() {
+			widget._showTabContent = true;
+
+			widget._onTabSelected({
+				target: { id: 'all-courses-tab-12345' },
+				stopPropagation: function() {}
+			});
+
+			expect(widget._showTabContent).to.be.false;
+		});
+
+		it('should set the _searchUrl based on the selected tab\'s action', function() {
+			widget._sortParameter = 'SortOrder';
+
+			widget._onTabSelected({
+				target: { id: 'all-courses-tab-12345' },
+				stopPropagation: function() {}
+			});
+
+			expect(widget._searchUrl).to.equal('/example/foo?autoPinCourses=false&embedDepth=1&sort=SortOrder');
+		});
 	});
 
 });

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -268,7 +268,7 @@ describe('d2l-all-courses', function() {
 
 	});
 
-	describe.only('Tabbed view', function() {
+	describe('Tabbed view', function() {
 		beforeEach(function() {
 			widget.updatedSortLogic = true;
 			widget.tabSearchActions = [{


### PR DESCRIPTION
This adds tabs to the All Courses view. These tabs should match the ones being used in the main widget, as they are just passed in as attributes. No real surprises here - switching tabs fetches the courses associated with that tab and updates the `d2l-allcourses-unified-content` view.

Something I realized partway through this work: when a user has their enrollments already grouped by semester/department via the My Courses widget settings, we aren't able to then use the filter menu to further filter them, as it does a logical OR on all the `parentOrganizations` that are sent to the API. When this is the case, we can simply hide those two tabs. Similarly, if the user has tabs to group their enrollments by RoleAlias, we should hide the Role tab in the filter menu.

~Note that this is WIP-ish, as I haven't looked at tests yet, and this requires both #538 and #539 to be in first.~