### PR TITLE
US97068 Save last search

### DIFF
--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -13,15 +13,15 @@
 <link rel="import" href="../../d2l-simple-overlay/d2l-simple-overlay.html">
 <link rel="import" href="../../d2l-tabs/d2l-tabs.html">
 <link rel="import" href="d2l-alert-behavior.html">
+<link rel="import" href="d2l-all-courses-segregated-content.html">
 <link rel="import" href="d2l-all-courses-styles.html">
+<link rel="import" href="d2l-all-courses-unified-content.html">
 <link rel="import" href="d2l-course-management-behavior.html">
 <link rel="import" href="d2l-course-tile-responsive-grid-behavior.html">
 <link rel="import" href="d2l-filter-menu/d2l-filter-menu.html">
 <link rel="import" href="d2l-search-widget-custom.html">
 <link rel="import" href="d2l-utility-behavior.html">
 <link rel="import" href="localize-behavior.html">
-<link rel="import" href="d2l-all-courses-segregated-content.html">
-<link rel="import" href="d2l-all-courses-unified-content.html">
 
 <!--
 `d2l-all-courses`
@@ -221,6 +221,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					type: Boolean,
 					value: false
 				},
+				userSettingsUrl: String,
 
 				/*
 				* Private Polymer properties
@@ -519,6 +520,15 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					embedDepth: 1,
 					sort: this._sortParameter || (this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId')
 				});
+
+				var formData = new FormData();
+				formData.append('mostRecentEnrollmentsSearchType', '0');
+				formData.append('mostRecentEnrollmentsSearchName', tabAction.enrollmentsSearchAction.name);
+				return window.d2lfetch
+					.fetch(new Request(this.userSettingsUrl, {
+						method: 'PUT',
+						body: formData
+					}));
 			},
 
 			/*

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -497,6 +497,7 @@
 			allCourses.tabSearchActions = this.tabSearchActions;
 			allCourses.tabSearchType = this.tabSearchType;
 			allCourses.useSavedSearches = this.useSavedSearches;
+			allCourses.userSettingsUrl = this.userSettingsUrl;
 			allCourses.locale = this.locale;
 			allCourses.showCourseCode = this.showCourseCode;
 			allCourses.showSemester = this.showSemester;

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -346,14 +346,24 @@
 					.then(function() {
 						window.dispatchEvent(new Event('resize'));
 					});
-			}
-			else {
+			} else {
 				setTimeout(function() {
 					// Force redraw of course tiles.
 					window.dispatchEvent(new Event('resize'));
 				}, 10);
 			}
 			this._setLastSearchName(this.enrollmentsSearchAction.name);
+
+			// Whenever the selected tab changes, update tabSearchActions so
+			// All Courses will have the same tab selected when it opens
+			this.tabSearchActions = this.tabSearchActions.map(function(action) {
+				return {
+					name: action.name,
+					title: action.title,
+					selected: action.name === this.enrollmentsSearchAction.name,
+					enrollmentsSearchAction: action.enrollmentsSearchAction
+				};
+			}.bind(this));
 		},
 		_checkIfStartedInactiveCourses: function(e) {
 			var type = e && e.detail && e.detail.type;

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -271,6 +271,7 @@ describe('d2l-all-courses', function() {
 	describe('Tabbed view', function() {
 		beforeEach(function() {
 			widget.updatedSortLogic = true;
+			widget.userSettingsUrl = '/example/user-settings';
 			widget.tabSearchActions = [{
 				name: '12345',
 				title: 'Search Foo Action',
@@ -313,6 +314,18 @@ describe('d2l-all-courses', function() {
 			});
 
 			expect(widget._searchUrl).to.equal('/example/foo?autoPinCourses=false&embedDepth=1&sort=SortOrder');
+		});
+
+		it('should save the user\'s preferred search when a tab is clicked', function() {
+			var spy = sandbox.spy(window.d2lfetch, 'fetch');
+
+			widget._onTabSelected({
+				target: { id: 'all-courses-tab-12345' },
+				stopPropagation: function() {}
+			});
+
+			expect(spy).to.have.been.calledWith(sinon.match.has('url', sinon.match(/\/example\/user-settings$/)));
+			expect(spy).to.have.been.calledWith(sinon.match.has('method', 'PUT'));
 		});
 	});
 

--- a/test/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.html
@@ -14,6 +14,14 @@
 			</template>
 		</test-fixture>
 
+		<test-fixture id="tab-event-fixture">
+			<template>
+				<div id="foo">
+					<d2l-my-courses-content use-saved-searches="true"></d2l-my-courses-content>
+				</div>
+			</template>
+		</test-fixture>
+
 		<script src="d2l-my-courses-content.js"></script>
 	</body>
 </html>

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -275,6 +275,52 @@ describe('d2l-my-courses-content', () => {
 
 	describe('Events', () => {
 
+		describe('d2l-tab-panel-selected', () => {
+			beforeEach(() => {
+				var parentComponent = fixture('tab-event-fixture');
+				component = parentComponent.querySelector('d2l-my-courses-content');
+				component.enrollmentsSearchAction = searchAction;
+				component._hasEnrollments = true;
+				component.tabSearchActions = [];
+			});
+
+			[true, false].forEach(hasEnrollments => {
+				it('should ' + (hasEnrollments ? '' : 'not ') + 'fetch enrollments', () => {
+					component._hasEnrollments = hasEnrollments;
+
+					var stub = sandbox.stub(component, '_fetchRoot').returns(Promise.resolve());
+
+					component._onTabSelected({
+						target: { id: 'foo' }
+					});
+
+					expect(stub.called).to.equal(!hasEnrollments);
+				});
+			});
+
+			it('should update the tabSearchActions to select the currently-active tab', () => {
+				component.tabSearchActions = [{
+					name: searchAction.name,
+					title: '',
+					selected: false,
+					enrollmentsSearchAction: searchAction
+				}, {
+					name: 'foo',
+					title: '',
+					selected: true,
+					enrollmentsSearchAction: searchAction
+				}];
+
+				component._onTabSelected({
+					target: { id: 'foo' }
+				});
+
+				component.tabSearchActions.forEach(function(action) {
+					expect(action.selected).to.equal(action.name !== 'foo');
+				});
+			});
+		});
+
 		describe('open-change-image-view', () => {
 			var event;
 


### PR DESCRIPTION
When a user clicks a tab, we save that as the most recent search. This behaviour exists in both the widget view and the all courses view - an attempt to combine the behaviours was made, but it ended up being a significantly larger change for very little benefit.