### PR TITLE
DE30396 Use the use-saved-searches attribute

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -33,29 +33,48 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 			</d2l-my-courses-content-animated>
 		</template>
 		<template is="dom-if" if="[[updatedSortLogic]]">
-			<d2l-tabs>
-				<template items="[[_tabSearchActions]]" is="dom-repeat">
-					<!-- item.name is an OrgUnitId, and querySelector does not work with components with ids that start with a number -->
-					<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
-						<d2l-my-courses-content
-							advanced-search-url="[[advancedSearchUrl]]"
-							enrollments-url="[[enrollmentsUrl]]"
-							enrollments-search-action="[[item.enrollmentsSearchAction]]"
-							image-catalog-location="[[imageCatalogLocation]]"
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							standard-department-name="[[standardDepartmentName]]"
-							standard-semester-name="[[standardSemesterName]]"
-							course-updates-config="[[courseUpdatesConfig]]"
-							course-image-upload-cb="[[courseImageUploadCb]]"
-							updated-sort-logic="[[updatedSortLogic]]"
-							user-settings-url="[[userSettingsUrl]]"
-							tab-search-actions="[[_tabSearchActions]]"
-							tab-search-type="[[_tabSearchType]]">
-						</d2l-my-courses-content>
-					</d2l-tab-panel>
-				</template>
-			</d2l-tabs>
+			<template is="dom-if" if="[[useSavedSearches]]">
+				<d2l-tabs>
+					<template items="[[_tabSearchActions]]" is="dom-repeat">
+						<!-- item.name is an OrgUnitId, and querySelector does not work with components with ids that start with a number -->
+						<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
+							<d2l-my-courses-content
+								advanced-search-url="[[advancedSearchUrl]]"
+								enrollments-url="[[enrollmentsUrl]]"
+								enrollments-search-action="[[item.enrollmentsSearchAction]]"
+								image-catalog-location="[[imageCatalogLocation]]"
+								show-course-code="[[showCourseCode]]"
+								show-semester="[[showSemester]]"
+								standard-department-name="[[standardDepartmentName]]"
+								standard-semester-name="[[standardSemesterName]]"
+								course-updates-config="[[courseUpdatesConfig]]"
+								course-image-upload-cb="[[courseImageUploadCb]]"
+								updated-sort-logic="[[updatedSortLogic]]"
+								use-saved-searches="[[useSavedSearches]]"
+								user-settings-url="[[userSettingsUrl]]"
+								tab-search-actions="[[_tabSearchActions]]"
+								tab-search-type="[[_tabSearchType]]">
+							</d2l-my-courses-content>
+						</d2l-tab-panel>
+					</template>
+				</d2l-tabs>
+			</template>
+			<template is="dom-if" if="[[!useSavedSearches]]">
+				<d2l-my-courses-content
+					advanced-search-url="[[advancedSearchUrl]]"
+					enrollments-url="[[enrollmentsUrl]]"
+					enrollments-search-action="[[_enrollmentsSearchAction]]"
+					image-catalog-location="[[imageCatalogLocation]]"
+					show-course-code="[[showCourseCode]]"
+					show-semester="[[showSemester]]"
+					standard-department-name="[[standardDepartmentName]]"
+					standard-semester-name="[[standardSemesterName]]"
+					course-updates-config="[[courseUpdatesConfig]]"
+					course-image-upload-cb="[[courseImageUploadCb]]"
+					updated-sort-logic="[[updatedSortLogic]]"
+					use-saved-searches="[[useSavedSearches]]">
+				</d2l-my-courses-content>
+			</template>
 		</template>
 	</template>
 	<script>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -35,7 +35,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			[[localize('noCoursesInRole')]]
 		</span>
 
-		<template is="dom-if" if="[[_renderContents]]">
+		<template is="dom-if" if="[[renderContents]]">
 			<div class="course-tile-grid">
 				<template is="dom-repeat" items="[[filteredEnrollments]]">
 					<div>
@@ -63,6 +63,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				filterCounts: Object,
 				isSearched: Boolean,
 				filteredEnrollments: Array,
+				renderContents: {
+					type: Boolean,
+					value: false
+				},
 
 				_animate: {
 					type: Boolean,
@@ -73,10 +77,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				_noCoursesInDepartment: Boolean,
 				_noCoursesInSemester: Boolean,
 				_noCoursesInRole: Boolean,
-				_renderContents: {
-					type: Boolean,
-					value: false
-				},
 				_tileSizes: Object,
 				_itemCount: {
 					type: Number,
@@ -142,7 +142,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 					// for a large number of tabs right away, the page lags.
 					// Instead, only render a tab when it's selected for the
 					// first time.
-					this._renderContents = true;
+					this.renderContents = true;
 				}
 			}
 		});

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -113,28 +113,43 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				</template>
 
 				<template is="dom-if" if="[[updatedSortLogic]]">
-					<d2l-tabs>
-						<template items="[[tabSearchActions]]" is="dom-repeat">
-							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
-								<div hidden$="[[!_showTabContent]]">
-									<d2l-all-courses-unified-content
-										show-course-code="[[showCourseCode]]"
-										show-semester="[[showSemester]]"
-										course-updates-config="[[courseUpdatesConfig]]"
-										updated-sort-logic="[[updatedSortLogic]]"
-										total-filter-count="[[_totalFilterCount]]"
-										filter-counts="[[_filterCounts]]"
-										is-searched="[[_isSearched]]"
-										filtered-enrollments="[[_filteredEnrollments]]">
-									</d2l-all-courses-unified-content>
-								</div>
-								<d2l-loading-spinner
-									hidden$="[[_showTabContent]]"
-									size="100">
-								</d2l-loading-spinner>
-							</d2l-tab-panel>
-						</template>
-					</d2l-tabs>
+					<template is="dom-if" if="[[useSavedSearches]]">
+						<d2l-tabs>
+							<template items="[[tabSearchActions]]" is="dom-repeat">
+								<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
+									<div hidden$="[[!_showTabContent]]">
+										<d2l-all-courses-unified-content
+											show-course-code="[[showCourseCode]]"
+											show-semester="[[showSemester]]"
+											course-updates-config="[[courseUpdatesConfig]]"
+											updated-sort-logic="[[updatedSortLogic]]"
+											total-filter-count="[[_totalFilterCount]]"
+											filter-counts="[[_filterCounts]]"
+											is-searched="[[_isSearched]]"
+											filtered-enrollments="[[_filteredEnrollments]]">
+										</d2l-all-courses-unified-content>
+									</div>
+									<d2l-loading-spinner
+										hidden$="[[_showTabContent]]"
+										size="100">
+									</d2l-loading-spinner>
+								</d2l-tab-panel>
+							</template>
+						</d2l-tabs>
+					</template>
+					<template is="dom-if" if="[[!useSavedSearches]]">
+						<d2l-all-courses-unified-content
+							show-course-code="[[showCourseCode]]"
+							show-semester="[[showSemester]]"
+							course-updates-config="[[courseUpdatesConfig]]"
+							updated-sort-logic="[[updatedSortLogic]]"
+							total-filter-count="[[_totalFilterCount]]"
+							filter-counts="[[_filterCounts]]"
+							is-searched="[[_isSearched]]"
+							filtered-enrollments="[[_filteredEnrollments]]"
+							render-contents="true">
+						</d2l-all-courses-unified-content>
+					</template>
 				</template>
 				<template is="dom-if" if="[[!updatedSortLogic]]">
 					<d2l-all-courses-segregated-content
@@ -201,6 +216,10 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					type: Boolean,
 					value: false,
 					observer: '_updatedSortLogicChanged'
+				},
+				useSavedSearches: {
+					type: Boolean,
+					value: false
 				},
 
 				/*
@@ -335,6 +354,15 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					this._filteredUnpinnedEnrollments.forEach(function(enrollment) {
 						this._unpinnedCoursesMap[this.getEntityIdentifier(enrollment)] = true;
 					}, this);
+				}
+
+				if (!this.useSavedSearches) {
+					this._showTabContent = true;
+					this._searchUrl = this.createActionUrl(this.enrollmentsSearchAction, {
+						autoPinCourses: false,
+						embedDepth: 1,
+						sort: this._sortParameter || (this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId')
+					});
 				}
 			},
 			open: function() {

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -29,14 +29,21 @@
 			courseUpdatesConfig: Object,
 			// Callback for upload in image-selector
 			courseImageUploadCb: Function,
-
+			// URL to fetch promoted searches for tabs
 			promotedSearches: String,
+			// URL to fetch a user's settings (e.g. default tab to select)
 			userSettingsUrl: String,
+			// Feature flag for using promoted searches tabbed view
+			useSavedSearches: {
+				type: Boolean,
+				value: false
+			},
 			// Feature flag (switch) for using the updated sort logic and related fetaures
 			updatedSortLogic: {
 				type: Boolean,
 				value: false
 			},
+
 			_enrollmentsSearchAction: Object,
 			_tabSearchActions: {
 				type: Array,
@@ -45,7 +52,18 @@
 			_tabSearchType: String
 		},
 		attached: function() {
-			this._fetchTabSearchActions();
+			if (!this.useSavedSearches) {
+				this.fetchSirenEntity(this.enrollmentsUrl)
+					.then(function(enrollmentsRootEntity) {
+						if (!enrollmentsRootEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
+							return;
+						}
+
+						this._enrollmentsSearchAction = enrollmentsRootEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)
+					}.bind(this));
+			} else {
+				this._fetchTabSearchActions();
+			}
 		},
 		courseImageUploadCompleted: function(success) {
 			return this.updatedSortLogic
@@ -71,9 +89,9 @@
 					var mostRecentSearchName = userSettingsEntity
 						&& userSettingsEntity.properties
 						&& userSettingsEntity.properties.MostRecentEnrollmentsSearchName;
-					if (enrollmentsRootEntity && enrollmentsRootEntity.hasAction(this.HypermediaActions.enrollments.searchMyEnrollments)) {
+					if (enrollmentsRootEntity && enrollmentsRootEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
 						var searchAction = enrollmentsRootEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
-						this._enrollmentsSearchAction = searchAction;	// For d2l-my-courses-content-animated
+						this._enrollmentsSearchAction = searchAction;
 						tabSearchActions = [{name: searchAction.name, title: this.localize('allTab'), selected: false, enrollmentsSearchAction: searchAction}];
 					}
 					if (promotedSearchesEntity) {

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -59,7 +59,7 @@
 							return;
 						}
 
-						this._enrollmentsSearchAction = enrollmentsRootEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)
+						this._enrollmentsSearchAction = enrollmentsRootEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
 					}.bind(this));
 			} else {
 				this._fetchTabSearchActions();

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -157,8 +157,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			},
 			observers: [
 				// Override for MyCoursesContentBehavior observer
-				'_enrollmentsChanged(_pinnedEnrollments.length, _allEnrollments.length)',
-				'_enrollmentSearchActionChanged(enrollmentsSearchAction)',
+				'_enrollmentsChanged(_pinnedEnrollments.length, _allEnrollments.length)'
 			],
 
 			/*
@@ -264,9 +263,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				} else {
 					this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
 				}
-			},
-			_enrollmentSearchActionChanged: function() {
-				this._fetchRoot();
 			},
 
 			/*

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -26,6 +26,10 @@
 			tabSearchActions: Array,
 			tabSearchType: String,
 			userSettingsUrl: String,
+			useSavedSearches: {
+				type: Boolean,
+				value: false
+			},
 
 			// Alerts to display in widget, above course tiles
 			_alerts: {
@@ -116,6 +120,7 @@
 		},
 		observers: [
 			'_enrollmentsChanged(_enrollments)',
+			'_enrollmentSearchActionChanged(enrollmentsSearchAction)',
 		],
 
 		/*
@@ -166,6 +171,12 @@
 			this._clearAlerts();
 			if (!this._hasEnrollments) {
 				this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
+			}
+		},
+		_enrollmentSearchActionChanged: function() {
+			if (!this.useSavedSearches) {
+				// If we're using saved searches, we fetch when the tab is selected
+				this._fetchRoot();
 			}
 		},
 
@@ -481,8 +492,10 @@
 
 			var allCourses = this.$$('d2l-all-courses');
 
+			allCourses.enrollmentsSearchAction = this.enrollmentsSearchAction;
 			allCourses.tabSearchActions = this.tabSearchActions;
 			allCourses.tabSearchType = this.tabSearchType;
+			allCourses.useSavedSearches = this.useSavedSearches;
 			allCourses.locale = this.locale;
 			allCourses.showCourseCode = this.showCourseCode;
 			allCourses.showSemester = this.showSemester;

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -175,7 +175,8 @@
 		},
 		_enrollmentSearchActionChanged: function() {
 			if (!this.useSavedSearches) {
-				// If we're using saved searches, we fetch when the tab is selected
+				// We only need to manually fetch if we're not using tabs;
+				// otherwise, the fetch is initiated when a tab is selected.
 				this._fetchRoot();
 			}
 		},

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
@@ -13,6 +13,7 @@
 		<test-fixture id="d2l-all-courses-unified-content-fixture">
 			<template>
 				<d2l-all-courses-unified-content
+					use-saved-searches="true"
 					filtered-enrollments='[]'>
 				</d2l-all-courses-unified-content>
 			</template>
@@ -23,6 +24,7 @@
 				<div id="foo">
 					<div>
 						<d2l-all-courses-unified-content
+							use-saved-searches="true"
 							filtered-enrollments='[]'>
 						</d2l-all-courses-unified-content>
 					</div>

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
@@ -22,13 +22,13 @@ describe('d2l-all-courses-unified-content', function() {
 		it('should render the contents on a d2l-tab-panel-selected event', function(done) {
 			widget = fixture('event-test-fixture').querySelector('d2l-all-courses-unified-content');
 			expect(widget.$$('div.course-tile-grid')).to.be.null;
-			expect(widget._renderContents).to.be.false;
+			expect(widget.renderContents).to.be.false;
 
 			widget._onTabSelected({
 				target: { id: 'foo' }
 			});
 
-			expect(widget._renderContents).to.be.true;
+			expect(widget.renderContents).to.be.true;
 			setTimeout(function() {
 				expect(widget.$$('div.course-tile-grid')).to.not.be.null;
 				done();

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -15,7 +15,8 @@
 				<d2l-all-courses
 					pinned-enrollments='[]'
 					unpinned-enrollments='[]'
-					advanced-search-url="/test/url/">
+					advanced-search-url="/test/url/"
+					use-saved-searches="true">
 				</d2l-all-courses>
 			</template>
 		</test-fixture>

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
@@ -623,6 +623,13 @@ describe('d2l-my-courses-content-animated', function() {
 	});
 
 	describe('User interaction', function() {
+		beforeEach(function() {
+			widget.fetchSirenEntity.withArgs(sinon.match('/enrollments/users/169?search=')).returns(Promise.resolve(
+				window.D2L.Hypermedia.Siren.Parse(noEnrollmentsResponse)
+			));
+			widget.enrollmentsSearchAction = enrollmentsSearchEntity.actions[0];
+		});
+
 		it('should rescale the all courses view when it is opened', function() {
 			clock = sinon.useFakeTimers();
 			widget._enrollmentsSearchUrl = '';

--- a/test/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.html
@@ -10,7 +10,7 @@
 	<body>
 		<test-fixture id="d2l-my-courses-content-fixture">
 			<template>
-				<d2l-my-courses-content></d2l-my-courses-content>
+				<d2l-my-courses-content use-saved-searches="true"></d2l-my-courses-content>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-my-courses/d2l-my-courses.html
+++ b/test/d2l-my-courses/d2l-my-courses.html
@@ -10,7 +10,7 @@
 	<body>
 		<test-fixture id="d2l-my-courses-fixture">
 			<template>
-				<d2l-my-courses></d2l-my-courses>
+				<d2l-my-courses use-saved-searches="true"></d2l-my-courses>
 			</template>
 		</test-fixture>
 


### PR DESCRIPTION
Previously, we were always rendering the tabbed view of both the widget and all courses when `updated-sort-logic` was true. However, there is also the feature flag for the tabbed view itself, `use-saved-searches`. This changes both views to also take this flag's value into account.

In effect, the change here is that when the flag is off, the widget and the overlay both need to kick off their respective `_fetchRoot` calls more manually.