### PR TITLE
DE30421 No highlight on inaccessible course

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,7 @@
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^3.0.2",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^2.0.0",
     "d2l-tabs": "^0.2.2",
-    "d2l-tile": "^3.0.6",
+    "d2l-tile": "^3.0.8",
     "d2l-typography": "^6.1.2",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.1",
     "iron-a11y-announcer": "^2.0.0",

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -57,12 +57,12 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 			:host:focus .course-text {
 				text-decoration: underline;
 			}
-			:host:hover a[aria-disabled],
-			:host:focus a[aria-disabled] {
-				cursor: default;
+			:host:hover d2l-image-tile[disabled],
+			:host:focus d2l-image-tile[disabled] {
+				cursor: not-allowed;
 			}
-			:host:hover a[aria-disabled] .course-text,
-			:host:focus a[aria-disabled] .course-text {
+			:host:hover d2l-image-tile[disabled] .course-text,
+			:host:focus d2l-image-tile[disabled] .course-text {
 				text-decoration: none;
 			}
 
@@ -224,15 +224,14 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 
 		<d2l-image-tile
 			href="[[_organizationHomepageUrl]]"
-			aria-disabled$="[[!_canAccessCourse]]"
 			hover-effect="[[_hoverEffects]]"
 			dropdown-label="[[_courseSettingsLabel]]"
 			no-mobile-more-button>
 			<div
 				class="image-container"
-				slot="d2l-image-tile-image">
+				slot="d2l-image-tile-image"
+				aria-hidden="true">
 				<d2l-course-image
-					aria-hidden="true"
 					class="image-layer-bottom"
 					image="[[_image]]"
 					sizes="[[tileSizes]]"
@@ -342,10 +341,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 					value: function() { return {}; }
 				},
 
-				_canAccessCourse: {
-					type: Boolean,
-					value: false
-				},
 				_canAccessCourseInfo: {
 					type: Boolean,
 					computed: '_computeCanAccessCourseInfo(_organization)'
@@ -688,7 +683,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				} else {
 					// If the user doesn't have access, don't animate image/show menu/underline on hover
 					this._hoverEffects = '';
-					this._canAccessCourse = false;
 					this.$$('d2l-image-tile').setAttribute('disabled', '');
 					this._organizationHomepageUrl = null;
 				}

--- a/src/d2l-course-image-tile.html
+++ b/src/d2l-course-image-tile.html
@@ -54,7 +54,7 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				overflow-wrap: break-word; /* replaces 'word-wrap' in Firefox, Chrome, Safari */
 			}
 			:host:hover .course-text,
-			:host:focus .course-text {
+			d2l-image-tile[focused] .course-text {
 				text-decoration: underline;
 			}
 			:host:hover d2l-image-tile[disabled],


### PR DESCRIPTION
The intended behaviour of a course tile for a course that is inaccessible is that it should not appear to be interactable - that is, it should not get an underline and should not have a "pointer" cursor.

In addition, the entire `d2l-image-tile-image` slot contents should be `aria-hidden`, as this information is already conveyed when the tile is selected, via `_overlayAnnounceText`.

There is still a slight A11Y bug for a disabled link, in that it doesn't properly focus with a keyboard. In particular, the tile is rendering an anchor even if the `href` on the `d2l-image-tile` is null. This is a bug in `d2l-image-tile` itself, though, and should be remedied there (if the `href` is null, the tile should not render the `<a>` within it at all).

~Not _strictly_ required, but would be good to get https://github.com/BrightspaceUI/tile/pull/56 merged first and bump `d2l-tile`, then include that version bump with this fix.~ done