### PR TITLE
US97924 Improve All Courses tabbed view perf

### DIFF
--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -35,21 +35,19 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			[[localize('noCoursesInRole')]]
 		</span>
 
-		<template is="dom-if" if="[[renderContents]]">
-			<div class="course-tile-grid">
-				<template is="dom-repeat" items="[[filteredEnrollments]]">
-					<div>
-						<d2l-course-image-tile
-							enrollment="[[item]]"
-							tile-sizes="[[_tileSizes]]"
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]">
-						</d2l-course-image-tile>
-					</div>
-				</template>
-			</div>
-		</template>
+		<div class="course-tile-grid">
+			<template is="dom-repeat" items="[[filteredEnrollments]]">
+				<div>
+					<d2l-course-image-tile
+						enrollment="[[item]]"
+						tile-sizes="[[_tileSizes]]"
+						show-course-code="[[showCourseCode]]"
+						show-semester="[[showSemester]]"
+						course-updates-config="[[courseUpdatesConfig]]">
+					</d2l-course-image-tile>
+				</div>
+			</template>
+		</div>
 	</template>
 	<script>
 		Polymer({
@@ -63,15 +61,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				filterCounts: Object,
 				isSearched: Boolean,
 				filteredEnrollments: Array,
-				renderContents: {
-					type: Boolean,
-					value: false
-				},
 
-				_animate: {
-					type: Boolean,
-					value: false
-				},
 				_noCoursesInSearch: Boolean,
 				_noCoursesInSelection: Boolean,
 				_noCoursesInDepartment: Boolean,
@@ -92,13 +82,9 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			],
 
 			attached: function() {
-				document.body.addEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 				Polymer.RenderStatus.afterNextRender(this, function() {
 					this._onResize();
 				});
-			},
-			detached: function() {
-				document.body.removeEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 			},
 
 			getCourseTileItemCount: function() {
@@ -129,20 +115,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 					if (!this.isSearched && this.totalFilterCount === 0) {
 						this._itemCount = enrollmentLength;
 					}
-				}
-			},
-			_onTabSelected: function(e) {
-				// Component is within a `div` inside the `d2l-tab-panel`, so we
-				// need the parent's parent's ID.
-				var tabPanelId = this.parentElement
-					&& this.parentElement.parentElement
-					&& this.parentElement.parentElement.id;
-				if (e.target.id === tabPanelId) {
-					// If we try to render the `d2l-all-courses-unified-content`
-					// for a large number of tabs right away, the page lags.
-					// Instead, only render a tab when it's selected for the
-					// first time.
-					this.renderContents = true;
 				}
 			}
 		});

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -125,8 +125,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 											updated-sort-logic="[[updatedSortLogic]]"
 											total-filter-count="[[_totalFilterCount]]"
 											filter-counts="[[_filterCounts]]"
-											is-searched="[[_isSearched]]"
-											filtered-enrollments="[[_filteredEnrollments]]">
+											is-searched="[[_isSearched]]">
 										</d2l-all-courses-unified-content>
 									</div>
 									<d2l-loading-spinner
@@ -146,7 +145,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 							total-filter-count="[[_totalFilterCount]]"
 							filter-counts="[[_filterCounts]]"
 							is-searched="[[_isSearched]]"
-							filtered-enrollments="[[_filteredEnrollments]]"
 							render-contents="true">
 						</d2l-all-courses-unified-content>
 					</template>
@@ -239,10 +237,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					value: function() { return []; }
 				},
 				_filteredUnpinnedEnrollments: {
-					type: Array,
-					value: function() { return []; }
-				},
-				_filteredEnrollments: {
 					type: Array,
 					value: function() { return []; }
 				},
@@ -495,6 +489,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				this._resetSortDropdown();
 			},
 			_onTabSelected: function(e) {
+				this._selectedTabId = e.target.id;
 				var actionName = e.target.id.replace('all-courses-tab-', '');
 				var tabAction = this.tabSearchActions.find(function(action) {
 					return action.name === actionName;
@@ -637,10 +632,13 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				var enrollmentEntities = enrollments.getSubEntitiesByClass(this.HypermediaClasses.enrollments.enrollment);
 
 				if (this.updatedSortLogic) {
+					var unifiedContent = this.useSavedSearches
+						? this.$$('#' + this._selectedTabId + ' d2l-all-courses-unified-content')
+						: this.$$('d2l-all-courses-unified-content');
 					if (append) {
-						this._filteredEnrollments = this._filteredEnrollments.concat(enrollmentEntities);
+						unifiedContent.filteredEnrollments = unifiedContent.filteredEnrollments.concat(enrollmentEntities);
 					} else {
-						this._filteredEnrollments = enrollmentEntities;
+						unifiedContent.filteredEnrollments = enrollmentEntities;
 					}
 				} else {
 					var newPinnedEnrollments = [];

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.js
@@ -14,28 +14,6 @@ describe('d2l-all-courses-unified-content', function() {
 		sandbox.restore();
 	});
 
-	describe('initial load', function() {
-		it('should not render contents initially', function() {
-			expect(widget.$$('div.course-tile-grid')).to.be.null;
-		});
-
-		it('should render the contents on a d2l-tab-panel-selected event', function(done) {
-			widget = fixture('event-test-fixture').querySelector('d2l-all-courses-unified-content');
-			expect(widget.$$('div.course-tile-grid')).to.be.null;
-			expect(widget.renderContents).to.be.false;
-
-			widget._onTabSelected({
-				target: { id: 'foo' }
-			});
-
-			expect(widget.renderContents).to.be.true;
-			setTimeout(function() {
-				expect(widget.$$('div.course-tile-grid')).to.not.be.null;
-				done();
-			});
-		});
-	});
-
 	describe('changing enrollment entities', function() {
 		[
 			{ isSearched: true, totalFilterCount: 0, enrollmentsChanged: 0, noCoursesInSearch: true, noCoursesInSelection: false },


### PR DESCRIPTION
Previously, all tabs in the All Courses view were actually sharing the same _filteredEnrollments array. This meant we were only ever dealing with a single array, which has some advantages. The downside, however, is that each time the array is rendered, each tab is going to have to update itself to reflect the new state of the array. This resulted in noticeable jank when selecting a tab with a large number of enrollments.

Instead, only the `filtered-enrollments` of the newly-selected tab should be set/updated whenever the user switches tabs. The upside to this is that there is no more UI lag, even with large numbers of enrollments. The downside is that it is possible, if switching to and from tabs very quickly for the first time (i.e. before they're cached), to end up with the wrong tab being selected for the enrollments you're seeing. Fortunately, this can be fixed by just switching to another tab, then back (as at that point, everything has loaded and is cached, so things are speedy-speedy).

This also means we no longer need to delay rendering of the `d2l-all-courses-unified-content` component via the `renderContents` flag, since when it's initially created it'll always be empty anyway.