### PR TITLE
Update Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Brightspace/d2l-my-courses-ui.svg?branch=master)](https://travis-ci.org/Brightspace/d2l-my-courses-ui)
+[![Build Status](https://travis-ci.com/Brightspace/d2l-my-courses-ui.svg?branch=master)](https://travis-ci.com/Brightspace/d2l-my-courses-ui)
 
 # d2l-my-courses-ui
 


### PR DESCRIPTION
This was confusing, as it was always red. It was always red, because it was pointing to the old .org account. Now, it's pointing to the new .com one. Yay!