### PR TITLE
DE30477 Check returned action for sort

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -45,7 +45,7 @@
     "d2l-search-widget": "git://github.com/Brightspace/d2l-search-widget-ui.git#^3.0.2",
     "d2l-simple-overlay": "git://github.com/Brightspace/simple-overlay#^2.0.0",
     "d2l-tabs": "^0.2.2",
-    "d2l-tile": "^3.0.8",
+    "d2l-tile": "^3.0.9",
     "d2l-typography": "^6.1.2",
     "d2l-organization-hm-behavior": "git://github.com/Brightspace/organization-hm-behavior.git#^2.0.1",
     "iron-a11y-announcer": "^2.0.0",

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -527,10 +527,11 @@
 			this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
 			var newEnrollments = [];
 
+			var searchAction = enrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
 			if (
-				this.enrollmentsSearchAction
-				&& this.enrollmentsSearchAction.hasFieldByName('sort')
-				&& this.enrollmentsSearchAction.getFieldByName('sort').value.toLowerCase() === 'current'
+				searchAction
+				&& searchAction.hasFieldByName('sort')
+				&& searchAction.getFieldByName('sort').value.toLowerCase() === 'current'
 			) {
 				// When using Current sort, hide past courses in the widget view
 				var tileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');


### PR DESCRIPTION
The action we initially get that translates into a tab in the widget doesn't (necessarily) have the sort order set. However, the updated action we receive after fetching the enrollments for said tab-action should have the updated sort on it. This is what we use to determine whether to hide past courses, so by using the _initial_ action rather than the _updated_ action, the `sort` value was always empty, and we were always showing past courses.