### PR TITLE
DE30513 Delay _addOnlyPastCoursesAlert

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -584,24 +584,26 @@
 				.then(this._populateEnrollments.bind(this));
 		},
 		_addOnlyPastCoursesAlert: function(hasPinnedEnrollmentArg) {
-			var courseTileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
-			var hasCurrentOrFutureSelector, hasPinnedEnrollmentSelector;
+			setTimeout(function() {
+				var courseTileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
+				var hasCurrentOrFutureSelector, hasPinnedEnrollmentSelector;
 
-			if (this.cssGridView) {
-				hasCurrentOrFutureSelector = this.$$('.course-tile-grid d2l-course-image-tile:not([past-course])');
-				hasPinnedEnrollmentSelector = this.$$('.course-tile-grid d2l-course-image-tile[pinned]');
-			} else {
-				hasCurrentOrFutureSelector = courseTileGrid.$$('d2l-course-tile:not([past-course])');
-				hasPinnedEnrollmentSelector = courseTileGrid.$$('d2l-course-tile[pinned]');
-			}
+				if (this.cssGridView) {
+					hasCurrentOrFutureSelector = this.$$('.course-tile-grid d2l-course-image-tile:not([past-course])');
+					hasPinnedEnrollmentSelector = this.$$('.course-tile-grid d2l-course-image-tile[pinned]');
+				} else {
+					hasCurrentOrFutureSelector = courseTileGrid.$$('d2l-course-tile:not([past-course])');
+					hasPinnedEnrollmentSelector = courseTileGrid.$$('d2l-course-tile[pinned]');
+				}
 
-			var hasPinnedEnrollment = hasPinnedEnrollmentArg !== undefined ? hasPinnedEnrollmentArg : hasPinnedEnrollmentSelector;
+				var hasPinnedEnrollment = hasPinnedEnrollmentArg !== undefined ? hasPinnedEnrollmentArg : hasPinnedEnrollmentSelector;
 
-			if (!hasPinnedEnrollment && this._hasEnrollments && !hasCurrentOrFutureSelector && courseTileGrid.hasAttribute('hide-past-courses')) {
-				if (!this._hasAlert('onlyPastCourses')) this._addAlert('call-to-action', 'onlyPastCourses', this.localize('onlyPastCoursesMessage'));
-			} else {
-				this._removeAlert('onlyPastCourses');
-			}
+				if (!hasPinnedEnrollment && this._hasEnrollments && !hasCurrentOrFutureSelector && courseTileGrid.hasAttribute('hide-past-courses')) {
+					if (!this._hasAlert('onlyPastCourses')) this._addAlert('call-to-action', 'onlyPastCourses', this.localize('onlyPastCoursesMessage'));
+				} else {
+					this._removeAlert('onlyPastCourses');
+				}
+			}.bind(this), 1000);
 		},
 		_setLastSearchName: function(id) {
 			var formData = new FormData();

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -42,6 +42,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			}
 			d2l-alert {
 				display: block;
+				margin-bottom: 20px;
 				clear: both;
 			}
 			.course-tile-grid:not([hide-past-courses]) > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]),

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -908,6 +908,14 @@ describe('d2l-my-courses-content', () => {
 		});
 
 		describe('Only Past Courses alert', () => {
+			beforeEach(function() {
+				clock = sinon.useFakeTimers();
+			});
+
+			afterEach(function() {
+				clock.restore();
+			});
+
 			function setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses) {
 				var courseTileGridStub = {
 					hasAttribute: function() {
@@ -931,6 +939,7 @@ describe('d2l-my-courses-content', () => {
 				this._alerts = [];
 				component._hasEnrollments = true;
 				component._addOnlyPastCoursesAlert();
+				clock.tick(1000);
 				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
 			});
 
@@ -944,6 +953,7 @@ describe('d2l-my-courses-content', () => {
 				this._alerts = [];
 				component._hasEnrollments = true;
 				component._addOnlyPastCoursesAlert();
+				clock.tick(1000);
 				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
 			});
 
@@ -957,6 +967,7 @@ describe('d2l-my-courses-content', () => {
 				this._alerts = [];
 				component._hasEnrollments = true;
 				component._addOnlyPastCoursesAlert();
+				clock.tick(1000);
 				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
 			});
 
@@ -970,6 +981,7 @@ describe('d2l-my-courses-content', () => {
 				this._alerts = [];
 				component._hasEnrollments = true;
 				component._addOnlyPastCoursesAlert();
+				clock.tick(1000);
 				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
 			});
 
@@ -983,6 +995,7 @@ describe('d2l-my-courses-content', () => {
 				this._alerts = [{ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' }];
 				component._hasEnrollments = true;
 				component._addOnlyPastCoursesAlert();
+				clock.tick(1000);
 				expect(component._alerts).to.not.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
 			});
 
@@ -1004,6 +1017,7 @@ describe('d2l-my-courses-content', () => {
 				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
 
 				component._onEnrollmentPinnedMessage(e);
+				clock.tick(1000);
 				expect(spy).to.have.been.calledWith(true);
 			});
 
@@ -1026,6 +1040,7 @@ describe('d2l-my-courses-content', () => {
 				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
 
 				component._onEnrollmentPinnedMessage(e);
+				clock.tick(1000);
 				expect(spy).to.have.been.calledWith(false);
 			});
 		});


### PR DESCRIPTION
This is a bit of a lame duck fix, but the issue we were seeing here was around timing - effectively, good browsers would not show the message when it was needed (_addOnlyPastCoursesAlert would run before the `past-course` attributes had been set). In slow browsers, it was running even before anything was added to the course tile grid, which meant it would always show. To avoid this, we can just delay the calling of the function - worst-case, this means the alert won't show up until a second after we see the content, but in practice it's far less than a second, and almost unnoticeable in any browser.

This also adds a missing `margin-bottom` that was mistakenly not copied over when some previous refactoring was done.