### PR TITLE
US98449 Remove updatedSortLogic where not needed

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -28,8 +28,7 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 				standard-department-name="[[standardDepartmentName]]"
 				standard-semester-name="[[standardSemesterName]]"
 				course-updates-config="[[courseUpdatesConfig]]"
-				course-image-upload-cb="[[courseImageUploadCb]]"
-				updated-sort-logic="[[updatedSortLogic]]">
+				course-image-upload-cb="[[courseImageUploadCb]]">
 			</d2l-my-courses-content-animated>
 		</template>
 		<template is="dom-if" if="[[updatedSortLogic]]">

--- a/src/d2l-all-courses-segregated-content.html
+++ b/src/d2l-all-courses-segregated-content.html
@@ -46,8 +46,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			locale="[[locale]]"
 			show-course-code="[[showCourseCode]]"
 			show-semester="[[showSemester]]"
-			course-updates-config="[[courseUpdatesConfig]]"
-			updated-sort-logic="[[updatedSortLogic]]">
+			course-updates-config="[[courseUpdatesConfig]]">
 		</d2l-course-tile-grid>
 
 		<h2>[[localize('unpinnedCourses')]]</h2>
@@ -79,8 +78,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			locale="[[locale]]"
 			show-course-code="[[showCourseCode]]"
 			show-semester="[[showSemester]]"
-			course-updates-config="[[courseUpdatesConfig]]"
-			updated-sort-logic="[[updatedSortLogic]]">
+			course-updates-config="[[courseUpdatesConfig]]">
 		</d2l-course-tile-grid>
 	</template>
 	<script>
@@ -90,7 +88,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				showCourseCode: Boolean,
 				showSemester: Boolean,
 				courseUpdatesConfig: Object,
-				updatedSortLogic: Boolean,
 				totalFilterCount: Number,
 				filterCounts: Object,
 				isSearched: Boolean,

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -56,7 +56,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				showCourseCode: Boolean,
 				showSemester: Boolean,
 				courseUpdatesConfig: Object,
-				updatedSortLogic: Boolean,
 				totalFilterCount: Number,
 				filterCounts: Object,
 				isSearched: Boolean,

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -122,7 +122,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 											show-course-code="[[showCourseCode]]"
 											show-semester="[[showSemester]]"
 											course-updates-config="[[courseUpdatesConfig]]"
-											updated-sort-logic="[[updatedSortLogic]]"
 											total-filter-count="[[_totalFilterCount]]"
 											filter-counts="[[_filterCounts]]"
 											is-searched="[[_isSearched]]">
@@ -141,7 +140,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 							show-course-code="[[showCourseCode]]"
 							show-semester="[[showSemester]]"
 							course-updates-config="[[courseUpdatesConfig]]"
-							updated-sort-logic="[[updatedSortLogic]]"
 							total-filter-count="[[_totalFilterCount]]"
 							filter-counts="[[_filterCounts]]"
 							is-searched="[[_isSearched]]"
@@ -154,7 +152,6 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 						show-course-code="[[showCourseCode]]"
 						show-semester="[[showSemester]]"
 						course-updates-config="[[courseUpdatesConfig]]"
-						updated-sort-logic="[[updatedSortLogic]]"
 						total-filter-count="[[_totalFilterCount]]"
 						filter-counts="[[_filterCounts]]"
 						is-searched="[[_isSearched]]"

--- a/src/d2l-course-tile-grid.html
+++ b/src/d2l-course-tile-grid.html
@@ -34,7 +34,6 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 					show-course-code="[[showCourseCode]]"
 					show-semester="[[showSemester]]"
 					course-updates-config="[[courseUpdatesConfig]]"
-					updated-sort-logic="[[updatedSortLogic]]"
 					animate="[[animate]]">
 				</d2l-course-tile>
 			</template>
@@ -83,9 +82,7 @@ This is used in `d2l-my-courses-content` (when the `us90524-my-courses-css-grid-
 				// Set to true if course code should be shown in course tiles
 				showCourseCode: Boolean,
 				// Set to true if semester should be shown in course tiles
-				showSemester: Boolean,
-				// Feature flag (switch) for using the updated sort logic and related fetaures
-				updatedSortLogic: Boolean
+				showSemester: Boolean
 			},
 			behaviors: [
 				D2L.MyCourses.CourseTileSlidingGridBehavior,

--- a/src/d2l-course-tile-styles.html
+++ b/src/d2l-course-tile-styles.html
@@ -14,7 +14,7 @@
 				--scale-fade-min-scale: 1.05;
 			}
 
-			:host(:not([updated-sort-logic])) #pin-indicator-button,
+			#pin-indicator-button,
 			.d2l-course-tile-hidden {
 				display: none;
 			}

--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -202,12 +202,6 @@ the user has in that organization - student, teacher, TA, etc.
 					type: Boolean,
 					value: false
 				},
-				// Feature flag (switch) for using the updated sort logic and related fetaures
-				updatedSortLogic: {
-					type: Boolean,
-					value: false,
-					observer: '_updatedSortLogicChanged'
-				},
 				// Indicates whether the course has the info urls
 				hasCourseInfoUrl: {
 					type: Boolean,
@@ -678,9 +672,7 @@ the user has in that organization - student, teacher, TA, etc.
 					dateObj,
 					{'format': 'medium'}
 				);
-				var courseEndedTerm = this.updatedSortLogic
-					? (type === 'courseEnded') ? 'overlay.courseClosedOn' : 'overlay.courseOpeningOn'
-					: (type === 'courseEnded') ? 'overlay.courseEndedOn' : 'overlay.courseStartingOn';
+				var courseEndedTerm = (type === 'courseEnded') ? 'overlay.courseEndedOn' : 'overlay.courseStartingOn';
 				this._courseNotificationLabel = this.localize(
 					courseEndedTerm,
 					'dateTime',
@@ -688,9 +680,7 @@ the user has in that organization - student, teacher, TA, etc.
 				);
 				this.toggleClass('notification-overlay-active', true, this.$$('.tile-container'));
 				this.$$('#courseNotificationLabel').setAttribute('aria-hidden', 'false');
-				var courseNotificationTitleTerm = this.updatedSortLogic
-					? courseNotificationTitleTerm = (type === 'courseEnded') ? 'overlay.courseClosed' : 'overlay.courseOpens'
-					: courseNotificationTitleTerm = (type === 'courseEnded') ? 'overlay.courseEnded' : 'overlay.courseStarting';
+				var courseNotificationTitleTerm = (type === 'courseEnded') ? 'overlay.courseEnded' : 'overlay.courseStarting';
 				this._notificationTitle = this.localize(courseNotificationTitleTerm);
 
 				this._notificationInactive = (type === 'courseStarting' && inactive) ? this.localize('brackets', 'content', this.localize('overlay.inactive')) : null;
@@ -788,13 +778,6 @@ the user has in that organization - student, teacher, TA, etc.
 			},
 			_computeHideSeparator: function(semesterName) {
 				return semesterName.length;
-			},
-			_updatedSortLogicChanged: function(updatedSortLogic) {
-				if (updatedSortLogic) {
-					this.setAttribute('updated-sort-logic', '');
-				} else {
-					this.removeAttribute('updated-sort-logic');
-				}
 			}
 		});
 	</script>

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -72,8 +72,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				locale="[[locale]]"
 				show-course-code="[[showCourseCode]]"
 				show-semester="[[showSemester]]"
-				course-updates-config="[[courseUpdatesConfig]]"
-				updated-sort-logic="[[updatedSortLogic]]">
+				course-updates-config="[[courseUpdatesConfig]]">
 			</d2l-course-tile-grid>
 			<d2l-link
 				id="viewAllCourses"
@@ -352,18 +351,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 				}
 			},
 			// Override for MyCoursesContentBehavior._getViewAllCoursesText
-			_getViewAllCoursesText: function(hasMoreEnrollments, allEnrollments) {
-				var viewAllCourses = this.localize('viewAllCourses');
-				if (!this.updatedSortLogic) return viewAllCourses;
-
-				// With individual fetching of courses as they get pinned, we can end
-				// up with "21+", "22+", etc., so round down to nearest 5 for >20 courses
-				var count = allEnrollments.length < 20
-					? allEnrollments.length
-					: String(allEnrollments.length - (allEnrollments.length % 5));
-				if (hasMoreEnrollments) count += '+';
-
-				return allEnrollments.length > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
+			_getViewAllCoursesText: function() {
+				return this.localize('viewAllCourses');
 			}
 		});
 	</script>

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -602,9 +602,8 @@ describe('<d2l-course-tile>', function() {
 			widget = fixture('d2l-course-tile-fixture');
 		});
 
-		it('should show the pin indicator button when a course is pinned and feature flag is on', function() {
+		it('should show the pin indicator button when a course is pinned', function() {
 			widget.pinned = true;
-			widget.updatedSortLogic = true;
 			Polymer.dom.flush();
 
 			expect(widget.pinned).to.be.true;
@@ -614,7 +613,6 @@ describe('<d2l-course-tile>', function() {
 
 		it('should not show the pin indicator button when a course is not pinned', function() {
 			widget.pinned = false;
-			widget.updatedSortLogic = true;
 			Polymer.dom.flush();
 
 			expect(widget.pinned).to.be.false;
@@ -622,21 +620,10 @@ describe('<d2l-course-tile>', function() {
 			expect(window.getComputedStyle(pinIndicatorButton).visibility).to.equal('hidden');
 		});
 
-		it('should not show the pin indicator button when a course is pinned but the feature flag is off', function() {
-			widget.pinned = true;
-			widget.updatedSortLogic = false;
-			Polymer.dom.flush();
-
-			expect(widget.pinned).to.be.true;
-			var pinIndicatorButton = widget.$$('#pin-indicator-button');
-			expect(window.getComputedStyle(pinIndicatorButton).display).to.equal('none');
-		});
-
 		it('should unpin the course when pressed', function() {
 			widget = fixture('d2l-course-tile-fixture');
 			widget._pinClickHandler = sinon.stub();
 			widget.pinned = true;
-			widget.updatedSortLogic = true;
 			Polymer.dom.flush();
 
 			var pinIndicatorButton = widget.$$('#pin-indicator-button');

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.js
@@ -405,38 +405,6 @@ describe('d2l-my-courses-content-animated', function() {
 			expect(widget._alerts).not.to.include({ alertName: 'setCourseImageFailure', alertType: 'warning', alertMessage: 'Sorry, we\'re unable to change your image right now. Please try again later.' });
 		});
 
-		it.skip('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', function() {
-			widget.updatedSortLogic = true;
-			widget._pinnedEnrollments = new Array(6);
-			widget._allEnrollments = new Array(9);
-			widget._hasMoreEnrollments = false;
-			expect(widget._viewAllCoursesText).to.equal('View All Courses (9)');
-		});
-
-		it.skip('should show 50+ with the View All Courses link when there are more than 50 courses', function() {
-			widget.updatedSortLogic = true;
-			widget._pinnedEnrollments = new Array(4);
-			widget._allEnrollments = new Array(50);
-			widget._hasMoreEnrollments = true;
-			expect(widget._viewAllCoursesText).to.equal('View All Courses (50+)');
-		});
-
-		it('should not show the count in the View All Courses link when the updated sortfeature flag is off', function() {
-			widget.updatedSortLogic = false;
-			widget._pinnedEnrollments = new Array(4);
-			widget._allEnrollments = new Array(50);
-			widget._hasMoreEnrollments = true;
-			expect(widget._viewAllCoursesText).to.equal('View All Courses');
-		});
-
-		it.skip('should round the number of courses in the View All Courses link when there are many courses', () => {
-			widget.updatedSortLogic = true;
-			widget._pinnedEnrollments = new Array(4);
-			widget._allEnrollments = new Array(23);
-			widget._hasMoreEnrollments = true;
-			expect(widget._viewAllCoursesText).to.equal('View All Courses (20+)');
-		});
-
 		describe('course image upload', function() {
 			var openChangeImageViewEvent = new CustomEvent(
 				'open-change-image-view', {
@@ -633,7 +601,6 @@ describe('d2l-my-courses-content-animated', function() {
 		it('should rescale the all courses view when it is opened', function() {
 			clock = sinon.useFakeTimers();
 			widget._enrollmentsSearchUrl = '';
-			widget.updatedSortLogic = false;
 
 			widget.$$('#viewAllCourses').click();
 			Polymer.dom.flush();


### PR DESCRIPTION
Previously, there were different cases where we'd render what, based on a couple of feature flags. Now, though, we render two almost-entirely-different views based on `updated-sort-config`. If it's on, we always render the `d2l-my-courses-content` and `d2l-all-courses-unified-view` components, both of which use `d2l-course-image-tile`. If it's off, we use the old components. In other words, we only need to know if the flag is on or off at the highest level of the widget, and anything lower down can be entirely ignorant of its existence.