### PR TITLE
Fix tests

### DIFF
--- a/test/d2l-course-image-tile/d2l-course-image-tile.js
+++ b/test/d2l-course-image-tile/d2l-course-image-tile.js
@@ -88,6 +88,7 @@ describe('d2l-course-image-tile', () => {
 					href: '/organizations/1/image'
 				}, {
 					rel: ['alternate'],
+					class: ['tile'],
 					href: ''
 				}]
 			}, {
@@ -137,6 +138,7 @@ describe('d2l-course-image-tile', () => {
 					href: '/organizations/2/image'
 				}, {
 					rel: ['alternate'],
+					class: ['tile'],
 					href: ''
 				}]
 			}, {

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -56,6 +56,7 @@ describe('<d2l-course-tile>', function() {
 					href: '/organizations/1/image'
 				}, {
 					rel: ['alternate'],
+					class: ['tile'],
 					href: ''
 				}]
 			}, {
@@ -95,6 +96,7 @@ describe('<d2l-course-tile>', function() {
 					href: '/organizations/1/image'
 				}, {
 					rel: ['alternate'],
+					class: ['tile'],
 					href: ''
 				}]
 			}, {


### PR DESCRIPTION
A small change to hm-organization-behavior now requires that course image entities have a class on them. This is part of the response spec anyway, so only manifested in the tests, where we're sending in technically-incomplete data.

This should fix master, which broke on this.