### PR TITLE
DE30513 Improve "only past courses" alert logic

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -41,6 +41,10 @@
 				type: Boolean,
 				value: false
 			},
+			_courseTileOrganizationEventCount: {
+				type: Number,
+				value: 0
+			},
 			// Array of enrollments being displayed by the widget
 			_enrollments: {
 				type: Array,
@@ -60,6 +64,11 @@
 			_hasMoreEnrollments: {
 				type: Boolean,
 				value: false
+			},
+			_hasOnlyPastCourses: {
+				type: Boolean,
+				value: false,
+				computed: '_computeHasOnlyPastCourses(_courseTileOrganizationEventCount)'
 			},
 			// Lookup table of org unit ID -> enrollment, to avoid having to re-fetch enrollments
 			_orgUnitIdMap: {
@@ -161,7 +170,6 @@
 
 		_allCoursesCreated: false,
 		_courseImagesLoadedEventCount: 0,
-		_courseTileOrganizationEventCount: 0,
 		_initiallyVisibleCourseTileCount: 0,
 		_enrollmentsSearchUrl: null,
 
@@ -179,6 +187,21 @@
 				// otherwise, the fetch is initiated when a tab is selected.
 				this._fetchRoot();
 			}
+		},
+		_computeHasOnlyPastCourses: function() {
+			if (!this.updatedSortLogic) {
+				// d2l-my-courses-content-animated should never show this alert, as it doesn't use current/future courses
+				return false;
+			}
+
+			var currentOrFutureEnrollment = this.$$('.course-tile-grid d2l-course-image-tile:not([past-course])');
+			var pinnedEnrollment = this.$$('.course-tile-grid d2l-course-image-tile[pinned]');
+			var shouldHidePastCourses = this.$$('.course-tile-grid').hasAttribute('hide-past-courses');
+
+			return this._hasEnrollments
+				&& shouldHidePastCourses
+				&& !currentOrFutureEnrollment
+				&& !pinnedEnrollment;
 		},
 
 		/*
@@ -225,7 +248,6 @@
 			this._courseTileOrganizationEventCount++;
 
 			if (this._courseTileOrganizationEventCount === this._initiallyVisibleCourseTileCount) {
-				this._addOnlyPastCoursesAlert();
 				// Only show content once the last visible organization has loaded, to reduce jank
 				this._showContent = true;
 				this.performanceMark('d2l.my-courses.visible-organizations-complete');
@@ -267,8 +289,7 @@
 			var orgUnitId;
 			if (e.detail.orgUnitId) {
 				orgUnitId = e.detail.orgUnitId;
-			}
-			else if (e.detail.enrollment && e.detail.enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
+			} else if (e.detail.enrollment && e.detail.enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
 				orgUnitId = this._getOrgUnitIdFromHref(e.detail.enrollment.getLinkByRel(this.HypermediaRels.organization).href);
 			}
 
@@ -301,9 +322,6 @@
 
 			var url = enrollment.getLinkByRel('self').href;
 			url += (url.indexOf('?') === -1 ? '?' : '&') + 'bustCache=' + Math.random();
-
-			var isPinned = lastPinnedIndex === 1 ? e.detail.isPinned : true;
-			this._addOnlyPastCoursesAlert(isPinned);
 
 			return this.fetchSirenEntity(url)
 				.then(function(updatedEnrollment) {
@@ -449,7 +467,6 @@
 				.then(function() {
 					// At worst, display content 1s after we fetch enrollments
 					// (Usually set to true before that, in _onCourseTileOrganization)
-					this._addOnlyPastCoursesAlert();
 					setTimeout(showContent, 1000);
 				}.bind(this))
 				.catch(showContent);
@@ -582,26 +599,6 @@
 			this._enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(true);
 			return this.fetchSirenEntity(this._enrollmentsSearchUrl)
 				.then(this._populateEnrollments.bind(this));
-		},
-		_addOnlyPastCoursesAlert: function(hasPinnedEnrollmentArg) {
-			var courseTileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
-			var hasCurrentOrFutureSelector, hasPinnedEnrollmentSelector;
-
-			if (this.cssGridView) {
-				hasCurrentOrFutureSelector = this.$$('.course-tile-grid d2l-course-image-tile:not([past-course])');
-				hasPinnedEnrollmentSelector = this.$$('.course-tile-grid d2l-course-image-tile[pinned]');
-			} else {
-				hasCurrentOrFutureSelector = courseTileGrid.$$('d2l-course-tile:not([past-course])');
-				hasPinnedEnrollmentSelector = courseTileGrid.$$('d2l-course-tile[pinned]');
-			}
-
-			var hasPinnedEnrollment = hasPinnedEnrollmentArg !== undefined ? hasPinnedEnrollmentArg : hasPinnedEnrollmentSelector;
-
-			if (!hasPinnedEnrollment && this._hasEnrollments && !hasCurrentOrFutureSelector && courseTileGrid.hasAttribute('hide-past-courses')) {
-				if (!this._hasAlert('onlyPastCourses')) this._addAlert('call-to-action', 'onlyPastCourses', this.localize('onlyPastCoursesMessage'));
-			} else {
-				this._removeAlert('onlyPastCourses');
-			}
 		},
 		_setLastSearchName: function(id) {
 			var formData = new FormData();

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -42,6 +42,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			}
 			d2l-alert {
 				display: block;
+				margin-bottom: 20px;
 				clear: both;
 			}
 			.course-tile-grid:not([hide-past-courses]) > div:nth-child(n+13) > d2l-course-image-tile:not([pinned]),
@@ -64,6 +65,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 		</div>
 
 		<div hidden$="[[!_showContent]]" class="my-courses-content">
+			<d2l-alert hidden$="[[!_hasOnlyPastCourses]]" type="call-to-action">
+				[[localize('onlyPastCoursesMessage')]]
+			</d2l-alert>
+
 			<template is="dom-repeat" items="[[_alerts]]">
 				<d2l-alert type="[[item.alertType]]">
 					[[item.alertMessage]]

--- a/test/d2l-course-image-tile/d2l-course-image-tile.js
+++ b/test/d2l-course-image-tile/d2l-course-image-tile.js
@@ -89,7 +89,8 @@ describe('d2l-course-image-tile', () => {
 				}, {
 					rel: ['alternate'],
 					class: ['tile'],
-					href: ''
+					href: '',
+					type: 'image/jpeg'
 				}]
 			}, {
 				class: ['relative-uri'],
@@ -139,7 +140,8 @@ describe('d2l-course-image-tile', () => {
 				}, {
 					rel: ['alternate'],
 					class: ['tile'],
-					href: ''
+					href: '',
+					type: 'image/jpeg'
 				}]
 			}, {
 				class: ['relative-uri'],

--- a/test/d2l-course-tile/d2l-course-tile.js
+++ b/test/d2l-course-tile/d2l-course-tile.js
@@ -57,7 +57,8 @@ describe('<d2l-course-tile>', function() {
 				}, {
 					rel: ['alternate'],
 					class: ['tile'],
-					href: ''
+					href: '',
+					type: 'image/jpeg'
 				}]
 			}, {
 				class: ['relative-uri'],
@@ -97,7 +98,8 @@ describe('<d2l-course-tile>', function() {
 				}, {
 					rel: ['alternate'],
 					class: ['tile'],
-					href: ''
+					href: '',
+					type: 'image/jpeg'
 				}]
 			}, {
 				class: ['relative-uri'],

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -921,113 +921,55 @@ describe('d2l-my-courses-content', () => {
 					.withArgs('.course-tile-grid d2l-course-image-tile[pinned]').returns(pinnedEnrollment);
 			}
 
-			it('should not add the Only Past Courses alert if not hiding past courses', () => {
+			beforeEach(() => {
+				component.updatedSortLogic = true;
+				component._hasEnrollments = true;
+			});
+
+			it('should not add the alert if not hiding past courses (e.g. admin user)', () => {
 				var currentOrFutureCourses = false,
 					pinnedEnrollment = false,
 					hidePastCourses = false;
 
 				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
+				component._courseTileOrganizationEventCount = 1;
 
-				this._alerts = [];
-				component._hasEnrollments = true;
-				component._addOnlyPastCoursesAlert();
-				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+				expect(component._hasOnlyPastCourses).to.be.false;
 			});
 
-			it('should not add the Only Past Courses alert if not there are present or future courses', () => {
+			it('should not add the alert if user has current or future courses', () => {
 				var currentOrFutureCourses = true,
 					pinnedEnrollment = false,
 					hidePastCourses = true;
 
 				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
+				component._courseTileOrganizationEventCount = 1;
 
-				this._alerts = [];
-				component._hasEnrollments = true;
-				component._addOnlyPastCoursesAlert();
-				expect(component._alerts).not.to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+				expect(component._hasOnlyPastCourses).to.be.false;
 			});
 
-			it('should add the Only Past Courses alert if there are only past courses and hides past courses', () => {
+			it('should add the alert if there are only past courses, no pinned courses, and is hiding past courses', () => {
 				var currentOrFutureCourses = false,
 					pinnedEnrollment = false,
 					hidePastCourses = true;
 
 				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
+				component._courseTileOrganizationEventCount = 1;
 
-				this._alerts = [];
-				component._hasEnrollments = true;
-				component._addOnlyPastCoursesAlert();
-				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+				expect(component._hasOnlyPastCourses).to.be.true;
 			});
 
-			it('should add the Only Past Courses alert if there are only past courses, hides past courses and no pinned enrollments', () => {
-				var currentOrFutureCourses = false,
-					pinnedEnrollment = false,
-					hidePastCourses = true;
-
-				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
-
-				this._alerts = [];
-				component._hasEnrollments = true;
-				component._addOnlyPastCoursesAlert();
-				expect(component._alerts).to.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
-			});
-
-			it('should remove the Only Past Courses alert if there is a pinned enrollments', () => {
+			it('should not add the alert if there is a pinned course', () => {
 				var currentOrFutureCourses = false,
 					pinnedEnrollment = true,
 					hidePastCourses = true;
 
 				setUp(currentOrFutureCourses, pinnedEnrollment, hidePastCourses);
+				component._courseTileOrganizationEventCount = 1;
 
-				this._alerts = [{ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' }];
-				component._hasEnrollments = true;
-				component._addOnlyPastCoursesAlert();
-				expect(component._alerts).to.not.include({ alertName: 'onlyPastCourses', alertType: 'call-to-action', alertMessage: 'You don\'t have any current or future courses. View All Courses to browse your past courses.' });
+				expect(component._hasOnlyPastCourses).to.be.false;
 			});
 
-			it('should set past courses alert with pinned enrollment when a course is pinned', () => {
-				var enrollmentMock = {
-					getLinkByRel: sandbox.stub().returns({ href: 'href' })
-				};
-				var e = {
-					detail: {
-						orgUnitId: 69,
-						enrollment: enrollmentMock,
-						isPinned: true
-					}
-				};
-				component._orgUnitIdMap = {69: enrollmentMock};
-				component._enrollments = [];
-				component.getEntityIdentifier = sinon.stub().returns('69');
-				var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
-				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
-
-				component._onEnrollmentPinnedMessage(e);
-				expect(spy).to.have.been.calledWith(true);
-			});
-
-			it('should set past courses alert with unpinned enrollment when a course is unpinned', () => {
-				var enrollmentMock = {
-					getLinkByRel: sandbox.stub().returns({ href: 'href' }),
-					hasClass: sandbox.stub().returns(true)
-				};
-				var e = {
-					detail: {
-						orgUnitId: 69,
-						enrollment: enrollmentMock,
-						isPinned: false
-					}
-				};
-				component._orgUnitIdMap = {69: enrollmentMock};
-				component._enrollments = [enrollmentMock];
-				component.getEntityIdentifier = sinon.stub().returns('69');
-				var spy = sandbox.spy(component, '_addOnlyPastCoursesAlert');
-				sandbox.stub(component, 'fetchSirenEntity').returns(Promise.resolve(enrollmentMock));
-
-				component._onEnrollmentPinnedMessage(e);
-				expect(spy).to.have.been.calledWith(false);
-			});
 		});
 
 	});


### PR DESCRIPTION
Previously, we were calling into a function to recalculate whether or not we should be showing the "You don't have any future or past courses" alert. Instead, we can leverage computed properties to make this more resilient to the timing issues that were causing the alert to show when it shouldn't, and not show when it should. In addition, we can greatly simplify the logic, since this alert should never show when updatedSortLogic is false - i.e. it should never show in `d2l-my-courses-content-animated`.