### PR TITLE
DE30513 Clean up updatedSortLogic usage

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -48,7 +48,6 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 								standard-semester-name="[[standardSemesterName]]"
 								course-updates-config="[[courseUpdatesConfig]]"
 								course-image-upload-cb="[[courseImageUploadCb]]"
-								updated-sort-logic="[[updatedSortLogic]]"
 								use-saved-searches="[[useSavedSearches]]"
 								user-settings-url="[[userSettingsUrl]]"
 								tab-search-actions="[[_tabSearchActions]]"
@@ -70,7 +69,6 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 					standard-semester-name="[[standardSemesterName]]"
 					course-updates-config="[[courseUpdatesConfig]]"
 					course-image-upload-cb="[[courseImageUploadCb]]"
-					updated-sort-logic="[[updatedSortLogic]]"
 					use-saved-searches="[[useSavedSearches]]">
 				</d2l-my-courses-content>
 			</template>

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -112,7 +112,7 @@
 	};
 
 	/*
-	* @polymerBehavior D2L.MyCourses.MyCoursesContentBehavior
+	* @polymerBehavior D2L.MyCourses.MyCoursesBehavior
 	*/
 	D2L.MyCourses.MyCoursesBehavior = [
 		window.D2L.Hypermedia.HMConstantsBehavior,

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -122,6 +122,13 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 	<script>
 		Polymer({
 			is: 'd2l-my-courses-content',
+			properties: {
+				// Override for MyCoursesBehavior.updatedSortLogic
+				updatedSortLogic: {
+					type: Boolean,
+					value: true
+				}
+			},
 			behaviors: [
 				D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
 				D2L.MyCourses.MyCoursesBehavior,

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -143,7 +143,7 @@ describe('d2l-my-courses-content', () => {
 	it('should properly implement d2l-my-courses-behavior', () => {
 		expect(component.courseImageUploadCompleted).to.be.a('function');
 		expect(component.getLastOrgUnitId).to.be.a('function');
-		expect(component.updatedSortLogic).to.equal(false);
+		expect(component.updatedSortLogic).to.equal(true);
 		expect(component.cssGridView).to.equal(true);
 	});
 
@@ -922,7 +922,6 @@ describe('d2l-my-courses-content', () => {
 			}
 
 			beforeEach(() => {
-				component.updatedSortLogic = true;
 				component._hasEnrollments = true;
 			});
 


### PR DESCRIPTION
Noticed during DE30513 development, but not strictly required for it - it's only really the top-level `d2l-my-courses` component itself, along with `d2l-all-courses` itself, that needs to know what the `updated-sort-logic` value is. For example, `d2l-my-courses-content` is only ever loaded when it's true, and `d2l-my-courses-content-animated` when it's false. This means we can remove a few usage of this value, that do nothing but complicate things.