### PR TITLE
DE30695 Increase IE11 retries to 5s

### DIFF
--- a/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
@@ -60,12 +60,12 @@
 			var courseTileDivs = Polymer.dom(this.root).querySelectorAll('.course-tile-grid > div');
 			ie11retryCount = ie11retryCount || 0;
 			if (
-				ie11retryCount < 15
+				ie11retryCount < 20
 				&& courseTileDivs.length === 0
 			) {
 				// If course tiles haven't yet rendered, try again for up to one second
 				// (only happens sometimes, only in IE)
-				setTimeout(this._onResize.bind(this, ++ie11retryCount), 100);
+				setTimeout(this._onResize.bind(this, ++ie11retryCount), 250);
 				return;
 			}
 


### PR DESCRIPTION
This was already increased as part of DE29878, but a case did come up with a client where an overly-full-of-widgets homepage still sees the problem of the tiles overlapping in IE11. Increasing this timeout, and the number of retries, is a bit of a patchwork solution, but ultimately it's a quick fix, doesn't affect other browsers, and won't have any effect on faster homepages in IE11 either.