### PR TITLE
Use padding and 100% height

### DIFF
--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -32,7 +32,8 @@
 			}
 
 			.course-tile-grid d2l-enrollment-card {
-				margin-bottom: 0.75rem;
+				height: 100%;
+				padding-bottom: 0.75rem;
 				--course-image-height: var(--course-image-tile-height);
 			}
 		</style>


### PR DESCRIPTION
Part of a fix to make the enrollment card full-height - that is, when one card has more content (longer name) than others in the same row, all of the cards in the same row should be the same height. There is also a small corresponding CSS change in `d2l-enrollment-card` itself.

See also https://github.com/BrightspaceHypermediaComponents/enrollments/pull/5