### PR TITLE
Majones/us98454/covert d2l enrollment card to entity driven component

### DIFF
--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -40,6 +40,7 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 							<d2l-my-courses-content
 								advanced-search-url="[[advancedSearchUrl]]"
 								enrollments-url="[[enrollmentsUrl]]"
+								presentation-url="[[presentationUrl]]"
 								enrollments-search-action="[[item.enrollmentsSearchAction]]"
 								image-catalog-location="[[imageCatalogLocation]]"
 								show-course-code="[[showCourseCode]]"
@@ -59,6 +60,7 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 			</template>
 			<template is="dom-if" if="[[!useSavedSearches]]">
 				<d2l-my-courses-content
+					presentation-url="[[presentationUrl]]"
 					advanced-search-url="[[advancedSearchUrl]]"
 					enrollments-url="[[enrollmentsUrl]]"
 					enrollments-search-action="[[_enrollmentsSearchAction]]"

--- a/d2l-my-courses.html
+++ b/d2l-my-courses.html
@@ -39,16 +39,13 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 						<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
 							<d2l-my-courses-content
 								advanced-search-url="[[advancedSearchUrl]]"
+								course-image-upload-cb="[[courseImageUploadCb]]"
 								enrollments-url="[[enrollmentsUrl]]"
-								presentation-url="[[presentationUrl]]"
 								enrollments-search-action="[[item.enrollmentsSearchAction]]"
 								image-catalog-location="[[imageCatalogLocation]]"
-								show-course-code="[[showCourseCode]]"
-								show-semester="[[showSemester]]"
+								presentation-url="[[presentationUrl]]"
 								standard-department-name="[[standardDepartmentName]]"
 								standard-semester-name="[[standardSemesterName]]"
-								course-updates-config="[[courseUpdatesConfig]]"
-								course-image-upload-cb="[[courseImageUploadCb]]"
 								use-saved-searches="[[useSavedSearches]]"
 								user-settings-url="[[userSettingsUrl]]"
 								tab-search-actions="[[_tabSearchActions]]"
@@ -60,18 +57,16 @@ If it is off and the attribute is not added, the `d2l-my-courses-content-animate
 			</template>
 			<template is="dom-if" if="[[!useSavedSearches]]">
 				<d2l-my-courses-content
-					presentation-url="[[presentationUrl]]"
 					advanced-search-url="[[advancedSearchUrl]]"
+					course-image-upload-cb="[[courseImageUploadCb]]"
 					enrollments-url="[[enrollmentsUrl]]"
 					enrollments-search-action="[[_enrollmentsSearchAction]]"
 					image-catalog-location="[[imageCatalogLocation]]"
-					show-course-code="[[showCourseCode]]"
-					show-semester="[[showSemester]]"
+					presentation-url="[[presentationUrl]]"
 					standard-department-name="[[standardDepartmentName]]"
 					standard-semester-name="[[standardSemesterName]]"
-					course-updates-config="[[courseUpdatesConfig]]"
-					course-image-upload-cb="[[courseImageUploadCb]]"
-					use-saved-searches="[[useSavedSearches]]">
+					use-saved-searches="[[useSavedSearches]]"
+					user-settings-url="[[userSettingsUrl]]">
 				</d2l-my-courses-content>
 			</template>
 		</template>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -39,11 +39,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			<template is="dom-repeat" items="[[filteredEnrollments]]">
 				<div>
 					<d2l-enrollment-card
-						enrollment="[[item]]"
-						tile-sizes="[[_tileSizes]]"
-						show-course-code="[[showCourseCode]]"
-						show-semester="[[showSemester]]"
-						course-updates-config="[[courseUpdatesConfig]]">
+						href="[[_getEntityIdentifier(item)]]",
+						presentation-href=[[presentationUrl]]>
 					</d2l-enrollment-card>
 				</div>
 			</template>
@@ -60,6 +57,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				filterCounts: Object,
 				isSearched: Boolean,
 				filteredEnrollments: Array,
+				presentationUrl: String,
 
 				_noCoursesInSearch: Boolean,
 				_noCoursesInSelection: Boolean,
@@ -115,6 +113,11 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 						this._itemCount = enrollmentLength;
 					}
 				}
+			},
+			_getEntityIdentifier: function(entity) {
+				// An entity's self href should be unique, so use it as an identifier
+				var selfLink = entity.getLinkByRel('self');
+				return selfLink.href;
 			}
 		});
 	</script>

--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -39,7 +39,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			<template is="dom-repeat" items="[[filteredEnrollments]]">
 				<div>
 					<d2l-enrollment-card
-						href="[[_getEntityIdentifier(item)]]",
+						href="[[item]]",
 						presentation-href=[[presentationUrl]]>
 					</d2l-enrollment-card>
 				</div>
@@ -50,9 +50,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 		Polymer({
 			is: 'd2l-all-courses-unified-content',
 			properties: {
-				showCourseCode: Boolean,
-				showSemester: Boolean,
-				courseUpdatesConfig: Object,
 				totalFilterCount: Number,
 				filterCounts: Object,
 				isSearched: Boolean,
@@ -113,11 +110,6 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 						this._itemCount = enrollmentLength;
 					}
 				}
-			},
-			_getEntityIdentifier: function(entity) {
-				// An entity's self href should be unique, so use it as an identifier
-				var selfLink = entity.getLinkByRel('self');
-				return selfLink.href;
 			}
 		});
 	</script>

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -119,9 +119,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 								<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected=[[item.selected]]>
 									<div hidden$="[[!_showTabContent]]">
 										<d2l-all-courses-unified-content
-											show-course-code="[[showCourseCode]]"
-											show-semester="[[showSemester]]"
-											course-updates-config="[[courseUpdatesConfig]]"
+											presentation-url="[[presentationUrl]]"
 											total-filter-count="[[_totalFilterCount]]"
 											filter-counts="[[_filterCounts]]"
 											is-searched="[[_isSearched]]">
@@ -137,9 +135,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					</template>
 					<template is="dom-if" if="[[!useSavedSearches]]">
 						<d2l-all-courses-unified-content
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]"
+							presentation-url="[[presentationUrl]]"
 							total-filter-count="[[_totalFilterCount]]"
 							filter-counts="[[_filterCounts]]"
 							is-searched="[[_isSearched]]"
@@ -178,7 +174,8 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				/*
 				* Public Polymer properties
 				*/
-
+				// presentation url
+				presentationUrl: String,
 				// URL that directs to the advanced search page
 				advancedSearchUrl: String,
 				// Types of notifications to include in update count in course tile

--- a/src/d2l-all-courses.html
+++ b/src/d2l-all-courses.html
@@ -508,7 +508,7 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				var params = {
 					search: search,
 					autoPinCourses: false,
-					embedDepth: 1,
+					embedDepth: 0,
 					sort: this._sortParameter || (this.updatedSortLogic ? 'Current' : '-PinDate,OrgUnitName,OrgUnitId')
 				};
 				if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
@@ -637,6 +637,9 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 				var enrollmentEntities = enrollments.getSubEntitiesByClass(this.HypermediaClasses.enrollments.enrollment);
 
 				if (this.updatedSortLogic) {
+					enrollmentEntities = enrollmentEntities.map(function(value) {
+						return value.href;
+					});
 					var unifiedContent = this.useSavedSearches
 						? this.$$('#' + this._selectedTabId + ' d2l-all-courses-unified-content')
 						: this.$$('d2l-all-courses-unified-content');
@@ -649,16 +652,16 @@ If it is off and the attribute is not added, the `d2l-all-courses-segregated-con
 					var newPinnedEnrollments = [];
 					var newUnpinnedEnrollments = [];
 					enrollmentEntities.forEach(function(enrollment) {
-						var enrollmentId = this.getEntityIdentifier(enrollment);
+						var enrollmentId = enrollment.href;
 
 						if (enrollment.hasClass(this.HypermediaClasses.enrollments.pinned)) {
 							if (!this._pinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newPinnedEnrollments.push(enrollment);
+								newPinnedEnrollments.push(enrollmentId);
 								this._pinnedCoursesMap[enrollmentId] = true;
 							}
 						} else {
 							if (!this._unpinnedCoursesMap.hasOwnProperty(enrollmentId)) {
-								newUnpinnedEnrollments.push(enrollment);
+								newUnpinnedEnrollments.push(enrollmentId);
 								this._unpinnedCoursesMap[enrollmentId] = true;
 							}
 						}

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -17,15 +17,15 @@
 			enrollmentsUrl: String,
 			// URL that is called by the widget to fetch results from the course image catalog
 			imageCatalogLocation: String,
-			// Configuration value passed in to toggle course code
+			// Configuration value passed in to toggle course code -- passed to animation tile
 			showCourseCode: Boolean,
-			// Configuration value passed in to toggle semester on course tile
+			// Configuration value passed in to toggle semester on course tile -- passed to animation tile
 			showSemester: Boolean,
 			// Standard Semester OU Type name to be displayed in the all-courses filter dropdown
 			standardDepartmentName: String,
 			// Standard Department OU Type name to be displayed in the all-courses filter dropdown
 			standardSemesterName: String,
-			// Types of notifications to include in update count in course tile
+			// Types of notifications to include in update count in course tile -- passed to animation tile
 			courseUpdatesConfig: Object,
 			// Callback for upload in image-selector
 			courseImageUploadCb: Function,

--- a/src/d2l-my-courses-content/d2l-my-courses-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-behavior.html
@@ -33,6 +33,11 @@
 			promotedSearches: String,
 			// URL to fetch a user's settings (e.g. default tab to select)
 			userSettingsUrl: String,
+			// URL to fetch widget settings
+			presentationUrl: {
+				type: String,
+				value: null
+			},
 			// Feature flag for using promoted searches tabbed view
 			useSavedSearches: {
 				type: Boolean,
@@ -55,13 +60,6 @@
 			if (!this.enrollmentsUrl) {
 				return;
 			}
-
-			this.fetchSirenEntity(this.enrollmentsUrl)
-				.then(function(enrollmentsRootEntity) {
-					if (enrollmentsRootEntity.hasActionByName(this.HypermediaActions.enrollments.searchMyEnrollments)) {
-						this._enrollmentsSearchAction = enrollmentsRootEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
-					}
-				}.bind(this));
 
 			this._fetchTabSearchActions();
 		},
@@ -104,6 +102,10 @@
 
 				if (!promotedSearchesEntity.actions) {
 					return;
+				}
+
+				if (userSettingsEntity && userSettingsEntity.hasLinkByRel('https://api.brightspace.com/rels/widget-settings')) {
+					this.presentationUrl = userSettingsEntity.getLinkByRel('https://api.brightspace.com/rels/widget-settings').href;
 				}
 
 				this._tabSearchActions = this._tabSearchActions.concat(promotedSearchesEntity.actions.map(function(action) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -30,6 +30,12 @@
 				type: Boolean,
 				value: false
 			},
+			presentationUrl: {
+				type: String,
+				value: null,
+				reflectToAttribute: true,
+				observer: '_resetPresentationUrlCache'
+			},
 
 			// Alerts to display in widget, above course tiles
 			_alerts: {
@@ -420,6 +426,17 @@
 			}
 			!this.cssGridView && this.$$('d2l-course-tile-grid').setCourseImage(e);
 		},
+		_resetPresentationUrlCache: function(newValue) {
+			if (newValue) {
+				window.d2lfetch
+					.fetch(new Request(newValue, {
+						headers: {
+							Accept: 'application/vnd.siren+json',
+							'Cache-Control': 'no-cache'
+						}
+					}));
+			}
+		},
 
 		/*
 		* Utility/helper functions
@@ -533,6 +550,7 @@
 			allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
 			allCourses.updatedSortLogic = this.updatedSortLogic;
 			allCourses.cssGridView = this.cssGridView;
+			allCourses.presentationUrl = this.presentationUrl;
 
 			allCourses.open();
 
@@ -609,7 +627,12 @@
 					method: 'PUT',
 					body: formData
 				}));
-		}
+		},
+		_getEntityIdentifier: function(entity) {
+			// An entity's self href should be unique, so use it as an identifier
+			var selfLink = entity.getLinkByRel('self');
+			return selfLink.href;
+		},
 	};
 
 	/*

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -81,6 +81,10 @@
 				type: Object,
 				value: function() { return {}; }
 			},
+			_lastPinnedIndex: {
+				type: Number,
+				value: 0
+			},
 			// The organization which the user is selecting the image of
 			_setImageOrg: {
 				type: Object,
@@ -121,6 +125,7 @@
 			document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
 			document.body.addEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 			this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
+			this.addEventListener('d2l-enrollment-card-fetched', this._onEnrollmentCardAdded.bind(this));
 
 			Polymer.RenderStatus.afterNextRender(this, function() {
 				if (!this.cssGridView) {
@@ -132,6 +137,7 @@
 			document.body.removeEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
 			document.body.removeEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
+			this.removeEventListener('course-tile-organization', this._onEnrollmentCardAdded.bind(this));
 		},
 		observers: [
 			'_enrollmentsChanged(_enrollments)',
@@ -213,7 +219,13 @@
 		/*
 		* Listeners
 		*/
+		_onEnrollmentCardAdded: function(e) {
+			if (Polymer.dom(e).rootTarget === this) return;
 
+			var orgUnitId = this._getOrgUnitIdFromHref(e.detail.href);
+
+			this._orgUnitIdMap[orgUnitId] = e.detail.enrollment;
+		},
 		_onChangeImageLowerThreshold: function() {
 			this.$$('d2l-basic-image-selector').loadMore(this.$['image-selector-threshold']);
 		},
@@ -292,67 +304,39 @@
 		_onEnrollmentPinnedMessage: function(e) {
 			if (Polymer.dom(e).rootTarget === this) return;
 
+			var isPinned = e.detail.isPinned;
 			var orgUnitId;
 			if (e.detail.orgUnitId) {
 				orgUnitId = e.detail.orgUnitId;
+			} else if (e.detail.organization) {
+				orgUnitId = this._getOrgUnitIdFromHref(this.getEntityIdentifier(this.parseEntity(e.detail.organization)));
 			} else if (e.detail.enrollment && e.detail.enrollment.hasLinkByRel(this.HypermediaRels.organization)) {
 				orgUnitId = this._getOrgUnitIdFromHref(e.detail.enrollment.getLinkByRel(this.HypermediaRels.organization).href);
 			}
 
 			// Only want to move pinned/unpinned enrollment if it exists in the panel
-			var enrollment = orgUnitId && this._orgUnitIdMap[orgUnitId];
-			if (!enrollment) {
+			var changedEnrollmentId = orgUnitId && this._orgUnitIdMap[orgUnitId];
+			if (!changedEnrollmentId) {
 				return this._refetchEnrollments();
 			}
-			var changedEnrollmentId = this.getEntityIdentifier(enrollment);
-			var removalIndex = -1;
-			var lastPinnedIndex = 0;
-			for (var i = 0; i < this._enrollments.length; i++) {
-				if (this._enrollments[lastPinnedIndex].hasClass('pinned')) {
-					lastPinnedIndex = i;
-				}
 
-				var enrollmentId = this.getEntityIdentifier(this._enrollments[i]);
-				if (enrollmentId === changedEnrollmentId) {
-					removalIndex = i;
-				}
+			var lastPinnedIndex = isPinned ? this._lastPinnedIndex++ : --this._lastPinnedIndex;
+			var removalIndex = this._enrollments.indexOf(changedEnrollmentId);
+
+			if (removalIndex === -1) {
+				// Course was not already in list, insert it as last pinned item
+				this.splice('_enrollments', lastPinnedIndex, 0, changedEnrollmentId);
+
+			} else if (removalIndex === lastPinnedIndex) {
+				// Course is already in the correct position, just update it
+				// (avoids removal animation + insertion animation in exact same position)
+			} else {
+				// Remove the enrollment from its current location
+				this.splice('_enrollments', removalIndex, 1);
+
+				// Re-add the (updated) enrollment at the end of the pinned list
+				this.splice('_enrollments', lastPinnedIndex, 0, changedEnrollmentId);
 			}
-
-			// Find the last pinned enrollment
-			while (
-				lastPinnedIndex < this._enrollments.length
-				&& this._enrollments[lastPinnedIndex].hasClass('pinned')
-			) {
-				lastPinnedIndex++;
-			}
-
-			var url = enrollment.getLinkByRel('self').href;
-			url += (url.indexOf('?') === -1 ? '?' : '&') + 'bustCache=' + Math.random();
-
-			return this.fetchSirenEntity(url)
-				.then(function(updatedEnrollment) {
-					var orgUnitId = this._getOrgUnitIdFromHref(this.getEntityIdentifier(updatedEnrollment));
-					this._orgUnitIdMap[orgUnitId] = updatedEnrollment;
-
-					if (removalIndex === -1) {
-						// Course was not already in list, insert it as last pinned item
-						this.splice('_enrollments', lastPinnedIndex, 0, updatedEnrollment);
-					} else if (removalIndex === lastPinnedIndex) {
-						// Course is already in the correct position, just update it
-						// (avoids removal animation + insertion animation in exact same position)
-						this.splice('_enrollments', removalIndex, 1, updatedEnrollment);
-					} else {
-						// Remove the enrollment from its current location
-						this.splice('_enrollments', removalIndex, 1);
-
-						if (removalIndex < lastPinnedIndex) {
-							// Need to account for us removing the enrollment
-							lastPinnedIndex--;
-						}
-						// Re-add the (updated) enrollment at the end of the pinned list
-						this.splice('_enrollments', lastPinnedIndex, 0, updatedEnrollment);
-					}
-				}.bind(this));
 		},
 		_onStartedInactiveAlert: function(e) {
 			this._removeAlert('startedInactiveCourses');
@@ -445,7 +429,7 @@
 		_createFetchEnrollmentsUrl: function(bustCache) {
 			var query = {
 				pageSize: 20,
-				embedDepth: 1,
+				embedDepth: 0,
 				sort: 'current',
 				autoPinCourses: false,
 				promotePins: true
@@ -542,12 +526,9 @@
 			allCourses.tabSearchType = this.tabSearchType;
 			allCourses.useSavedSearches = this.useSavedSearches;
 			allCourses.locale = this.locale;
-			allCourses.showCourseCode = this.showCourseCode;
-			allCourses.showSemester = this.showSemester;
 			allCourses.advancedSearchUrl = this.advancedSearchUrl;
 			allCourses.filterStandardSemesterName = this.standardSemesterName;
 			allCourses.filterStandardDepartmentName = this.standardDepartmentName;
-			allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
 			allCourses.updatedSortLogic = this.updatedSortLogic;
 			allCourses.cssGridView = this.cssGridView;
 			allCourses.presentationUrl = this.presentationUrl;
@@ -578,16 +559,11 @@
 			}
 
 			enrollmentEntities.forEach(function(enrollment) {
-				var enrollmentId = this.getEntityIdentifier(enrollment);
+				var enrollmentId = enrollment.href;
 				if (!this._existingEnrollmentsMap.hasOwnProperty(enrollmentId)) {
-					newEnrollments.push(enrollment);
+					newEnrollments.push(enrollmentId);
 					this._existingEnrollmentsMap[enrollmentId] = true;
-				}
-
-				var orgHref = (enrollment.getLinkByRel(this.HypermediaRels.organization) || {}).href;
-				var orgUnitId = this._getOrgUnitIdFromHref(orgHref);
-				if (!this._orgUnitIdMap.hasOwnProperty(orgUnitId)) {
-					this._orgUnitIdMap[orgUnitId] = enrollment;
+					if (enrollment.hasClass('pinned')) this._lastPinnedIndex++;
 				}
 			}, this);
 
@@ -598,11 +574,6 @@
 				// but this user has no enrollments, so we won't hit that case.
 				this._showContent = true;
 			}
-
-			var colNum = this._calcNumColumns(this._getAvailableWidth(Polymer.dom(this.root).node.host), this._enrollments.length);
-			this._tileSizes = (colNum === 2) ?
-				{ mobile: { maxwidth: 767, size: 50 }, tablet: { maxwidth: 1243, size: 33 }, desktop: { size: 20 } } :
-				{ mobile: { maxwidth: 767, size: 100 }, tablet: { maxwidth: 1243, size: 67 }, desktop: { size: 25 } };
 
 			this.fire('recalculate-columns');
 

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -78,11 +78,8 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				<template is="dom-repeat" items="[[_enrollments]]">
 					<div>
 						<d2l-enrollment-card
-							enrollment="[[item]]"
-							tile-sizes="[[_tileSizes]]"
-							show-course-code="[[showCourseCode]]"
-							show-semester="[[showSemester]]"
-							course-updates-config="[[courseUpdatesConfig]]">
+							href="[[_getEntityIdentifier(item)]]"
+							presentation-href="[[presentationUrl]]">
 						</d2l-enrollment-card>
 					</div>
 				</template>

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -78,7 +78,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				<template is="dom-repeat" items="[[_enrollments]]">
 					<div>
 						<d2l-enrollment-card
-							href="[[_getEntityIdentifier(item)]]"
+							href="[[item]]"
 							presentation-href="[[presentationUrl]]">
 						</d2l-enrollment-card>
 					</div>

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -316,7 +316,7 @@ describe('d2l-all-courses', function() {
 				stopPropagation: function() {}
 			});
 
-			expect(widget._searchUrl).to.equal('/example/foo?autoPinCourses=false&embedDepth=1&sort=SortOrder&search=');
+			expect(widget._searchUrl).to.equal('/example/foo?autoPinCourses=false&embedDepth=0&sort=SortOrder&search=');
 		});
 	});
 

--- a/test/d2l-course-tile-sliding-grid-behavior/d2l-course-tile-sliding-grid-behavior-utility.js
+++ b/test/d2l-course-tile-sliding-grid-behavior/d2l-course-tile-sliding-grid-behavior-utility.js
@@ -1,5 +1,6 @@
-describe('d2l-course-tile-sliding-grid-behavior-utility', function() {
-	var utility = D2L.MyCourses.CourseTileSlidingGridBehaviorUtility;
+var utility = D2L.MyCourses.CourseTileSlidingGridBehaviorUtility;
+
+describe('d2l-course-tile-sliding-grid-behavior-utility', () => {
 
 	describe('calculatePositionChange', function() {
 		[

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -78,6 +78,7 @@ describe('d2l-my-courses-content', () => {
 			entities: [{
 				rel: ['https://api.brightspace.com/rels/user-enrollment'],
 				class: ['enrollment', 'pinned'],
+				href: '/enrollments/users/169/organizations/1',
 				links: [{
 					rel: ['self'],
 					href: '/enrollments/users/169/organizations/1'
@@ -99,6 +100,7 @@ describe('d2l-my-courses-content', () => {
 			entities: [{
 				rel: ['https://api.brightspace.com/rels/user-enrollment'],
 				class: ['enrollment', 'pinned'],
+				href: '/enrollments/users/169/organizations/2',
 				links: [{
 					rel: ['self'],
 					href: '/enrollments/users/169/organizations/2'
@@ -768,7 +770,7 @@ describe('d2l-my-courses-content', () => {
 			return component._fetchRoot().then(() => {
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('autoPinCourses=false')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('pageSize=20')));
-				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('embedDepth=1')));
+				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('embedDepth=0')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('sort=current')));
 				expect(fetchStub).to.have.been.calledWith(sinon.match.has('url', sinon.match('promotePins=true')));
 			});
@@ -835,7 +837,7 @@ describe('d2l-my-courses-content', () => {
 					alertType: 'call-to-action',
 					alertMessage: 'You don\'t have any courses to display. If you believe this is an error, please contact your administrator.'
 				});
-				component._enrollments = [enrollmentEntity];
+				component._enrollments = ['/enrollments/users/169/organizations/1'];
 				expect(component._alerts).to.be.empty;
 			});
 		});


### PR DESCRIPTION
Takes away my-courses-widget knowledge of the enrollment card. It now gets the href for widget presentation settings and enrollment entity href and passes that to the enrollment card.