### PR TITLE
In all courses view, updates, course code and semester name show up.

### DIFF
--- a/src/d2l-course-tile.html
+++ b/src/d2l-course-tile.html
@@ -98,7 +98,7 @@ the user has in that organization - student, teacher, TA, etc.
 						<div>
 							<span class="course-code-text uppercase">
 								[[_organization.properties.code]]
-								<d2l-icon hidden$="[[!_hideSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
+								<d2l-icon hidden$="[[!_showSeparator]]" class="separator-icon" icon="d2l-tier1:bullet"></d2l-icon>
 							</span>
 							<span class="course-semester-text">[[_semesterName]]</span>
 						</div>
@@ -248,10 +248,10 @@ the user has in that organization - student, teacher, TA, etc.
 					value: false
 				},
 				_semesterName: String,
-				_hideSeparator: {
+				_showSeparator: {
 					type: Boolean,
-					value: true,
-					computed: '_computeHideSeparator(_semesterName)'
+					value: false,
+					computed: '_computeShowSeparator(_semesterName)'
 				},
 				// Set by the IntersectionObserver when tile is first visible in viewport
 				_load: Boolean
@@ -776,7 +776,7 @@ the user has in that organization - student, teacher, TA, etc.
 					this._setCourseTileHovered(false);
 				}
 			},
-			_computeHideSeparator: function(semesterName) {
+			_computeShowSeparator: function(semesterName) {
 				return semesterName.length;
 			}
 		});

--- a/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -267,7 +267,31 @@ This is only used if the `US90527-my-courses-updates` LD flag is OFF
 			/*
 			* Utility/helper functions
 			*/
+			// Override for MyCoursesContentBehavior._openAllCoursesView
+			_openAllCoursesView: function(e) {
+				this._createAllCourses();
 
+				var allCourses = this.$$('d2l-all-courses');
+
+				allCourses.enrollmentsSearchAction = this.enrollmentsSearchAction;
+				allCourses.tabSearchActions = this.tabSearchActions;
+				allCourses.tabSearchType = this.tabSearchType;
+				allCourses.locale = this.locale;
+				allCourses.advancedSearchUrl = this.advancedSearchUrl;
+				allCourses.filterStandardSemesterName = this.standardSemesterName;
+				allCourses.filterStandardDepartmentName = this.standardDepartmentName;
+				allCourses.updatedSortLogic = this.updatedSortLogic;
+				allCourses.cssGridView = this.cssGridView;
+				allCourses.presentationUrl = this.presentationUrl;
+				allCourses.showCourseCode = this.showCourseCode;
+				allCourses.showSemester = this.showSemester;
+				allCourses.courseUpdatesConfig = this.courseUpdatesConfig;
+
+				allCourses.open();
+
+				e.preventDefault();
+				e.stopPropagation();
+			},
 			// Override for MyCoursesContentBehavior._createFetchEnrollmentsUrl
 			_createFetchEnrollmentsUrl: function(bustCache) {
 				var query = {


### PR DESCRIPTION
Removed separator when semesterName was empty
Both these changes are for when updatedSortLogic=false.
