### PR TITLE
DE31016 Add convertUrlToRelative

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -622,7 +622,6 @@
 			formData.append('mostRecentEnrollmentsSearchType', '0');
 			formData.append('mostRecentEnrollmentsSearchName', id);
 
-			var url = this.userSettingsUrl;
 			var url = this.convertUrlToRelative(this.userSettingsUrl);
 
 			return window.d2lfetch

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -425,8 +425,10 @@
 		},
 		_onPresentationUrlChange: function(newValue) {
 			if (newValue) {
+				var url = this.convertUrlToRelative(newValue);
+
 				window.d2lfetch
-					.fetch(new Request(newValue, {
+					.fetch(new Request(url, {
 						headers: {
 							Accept: 'application/vnd.siren+json',
 							'Cache-Control': 'no-cache'
@@ -619,8 +621,12 @@
 			var formData = new FormData();
 			formData.append('mostRecentEnrollmentsSearchType', '0');
 			formData.append('mostRecentEnrollmentsSearchName', id);
+
+			var url = this.userSettingsUrl;
+			var url = this.convertUrlToRelative(this.userSettingsUrl);
+
 			return window.d2lfetch
-				.fetch(new Request(this.userSettingsUrl, {
+				.fetch(new Request(url, {
 					method: 'PUT',
 					body: formData
 				}));

--- a/src/d2l-utility-behavior.html
+++ b/src/d2l-utility-behavior.html
@@ -50,17 +50,20 @@
 			return window.D2L.Hypermedia.Siren.Parse(entity);
 		},
 		convertUrlToRelative: function(url) {
-			var anchor = document.createElement('a');
-			anchor.href = window.location;
+			if (!url) {
+				return url;
+			}
 
 			var isRelative = url.indexOf('/') === 0;
 			var isCanonical = url.indexOf('.api.') > -1;
-			var isSameOrigin = url.indexOf(anchor.host) > -1;
-			if (!isRelative && !isCanonical && !isSameOrigin) {
-				anchor.href = url;
-				url = anchor.pathname + anchor.search;
+			var isSameOrigin = url.indexOf(window.location.host) > -1;
+			if (isRelative || isCanonical || isSameOrigin) {
+				return url;
 			}
 
+			var anchor = document.createElement('a');
+			anchor.href = url;
+			url = anchor.pathname + anchor.search;
 			return url;
 		},
 		fetchSirenEntity: function(url) {

--- a/src/d2l-utility-behavior.html
+++ b/src/d2l-utility-behavior.html
@@ -49,10 +49,27 @@
 		parseEntity: function(entity) {
 			return window.D2L.Hypermedia.Siren.Parse(entity);
 		},
+		convertUrlToRelative: function(url) {
+			var anchor = document.createElement('a');
+			anchor.href = window.location;
+
+			var isRelative = url.indexOf('/') === 0;
+			var isCanonical = url.indexOf('.api.') > -1;
+			var isSameOrigin = url.indexOf(anchor.host) > -1;
+			if (!isRelative && !isCanonical && !isSameOrigin) {
+				anchor.href = url;
+				url = anchor.pathname + anchor.search;
+			}
+
+			return url;
+		},
 		fetchSirenEntity: function(url) {
 			if (!url) {
 				return;
 			}
+
+			url = this.convertUrlToRelative(url);
+
 			return window.d2lfetch
 				.fetch(new Request(url, {
 					headers: { Accept: 'application/vnd.siren+json' }


### PR DESCRIPTION
Let's get this right out of the way: this is awful and nasty, but it's somehow the least-awful-and-nasty. The crux of this issue is that it's possible for the LMS to return URLs that are neither relative, nor canonical, nor on the same origin that we're logged into. Fortunately, the so-far-always-correct case is that when this does happen, we are able to just convert the URL into a relative one, and that will always work.

This is fragile and finicky and not a great practise and _really_ shouldn't be necessary client-side, but it turns out the LMS is bad at knowing what it's own hostname is. So instead, every time we use window.d2lfetch, we can just run the URL through this helper and it'll change it if needed.

I really hope this only exists for a short while, until we can think of a better solution - preferably, the LMS should only be returning URLs that exist on the same origin as the page we're logged into!