### PR TITLE
Update `d2l-enrollments` version to v2.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "d2l-colors": "^3.1.2",
     "d2l-course-image": "Brightspace/course-image#^2.1.4",
     "d2l-dropdown": "^6.6.1",
-    "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#^0.2.0",
+    "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#^0.2.2",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.16.0",
     "d2l-icons": "^5.0.0",


### PR DESCRIPTION
This adds: 
 - An update to parsing the completion date.
 - Relative past dates.
