### PR TITLE
Hide completed and close courses in css

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,7 @@
     "d2l-colors": "^3.1.2",
     "d2l-course-image": "Brightspace/course-image#^2.1.4",
     "d2l-dropdown": "^6.6.1",
-    "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#^0.3.5",
+    "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#^0.3.6",
     "d2l-fetch": "Brightspace/d2l-fetch#^1.8.0",
     "d2l-hm-constants-behavior": "Brightspace/d2l-hm-constants-behavior#^5.16.0",
     "d2l-icons": "^5.0.0",

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -258,7 +258,7 @@
 
 			if (hide) {
 				var index = this._enrollments.indexOf(e.detail.enrollmentUrl);
-				if (index !== -1) {
+				if (index !== -1 && index >= this._lastPinnedIndex) {
 					this.splice('_enrollments', index, 1);
 				}
 			} else if (!hide && (this._enrollments.indexOf(e.detail.enrollmentUrl) === -1)) {
@@ -372,6 +372,9 @@
 				return this._refetchEnrollments();
 			}
 
+			var enrollmentCard = Polymer.dom(e).event && Polymer.dom(e).event.srcElement;
+			var shouldHide = enrollmentCard && (enrollmentCard.hasAttribute('completed') || enrollmentCard.hasAttribute('closed'));
+
 			var lastPinnedIndex = isPinned ? this._lastPinnedIndex++ : --this._lastPinnedIndex;
 			var removalIndex = this._enrollments.indexOf(changedEnrollmentId);
 
@@ -381,12 +384,17 @@
 			} else if (removalIndex === lastPinnedIndex) {
 				// Course is already in the correct position, just update it
 				// (avoids removal animation + insertion animation in exact same position)
+				if (shouldHide && !isPinned) {
+					this.splice('_enrollments', removalIndex, 1);
+				}
 			} else {
 				// Remove the enrollment from its current location
 				this.splice('_enrollments', removalIndex, 1);
 
 				// Re-add the (updated) enrollment at the end of the pinned list
-				this.splice('_enrollments', lastPinnedIndex, 0, changedEnrollmentId);
+				if (!shouldHide || isPinned) {
+					this.splice('_enrollments', lastPinnedIndex, 0, changedEnrollmentId);
+				}
 			}
 		},
 		_onStartedInactiveAlert: function(e) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -79,6 +79,10 @@
 				type: Object,
 				value: function() { return {}; }
 			},
+			_numberOfEnrollment: {
+				type: Number,
+				value: 0
+			},
 			_lastPinnedIndex: {
 				type: Number,
 				value: 0
@@ -101,7 +105,7 @@
 			// Text to render for "View All Courses" link (includes enrollment count approximation)
 			_viewAllCoursesText: {
 				type: String,
-				computed: '_getViewAllCoursesText(_hasMoreEnrollments, _enrollments.length)'
+				computed: '_getViewAllCoursesText(_hasMoreEnrollments, _numberOfEnrollment)'
 			}
 		},
 		listeners: {
@@ -189,8 +193,9 @@
 		_enrollmentsChanged: function(enrollments) {
 			this._hasEnrollments = enrollments.length > 0;
 
-			this._clearAlerts();
+			this._removeAlert('noCourses');
 			if (!this._hasEnrollments) {
+				this._clearAlerts();
 				this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
 			}
 		},
@@ -237,7 +242,9 @@
 			}
 
 			var orgUnitId = this._getOrgUnitIdFromHref(e.detail.organizationUrl);
-
+			if (!this._orgUnitIdMap[orgUnitId]) {
+				this._numberOfEnrollment++;
+			}
 			this._orgUnitIdMap[orgUnitId] = e.detail.enrollmentUrl;
 		},
 		_onD2lEnrollmentCardStatus: function(e) {
@@ -554,10 +561,12 @@
 
 			// With individual fetching of courses as they get pinned, we can end
 			// up with "21+", "22+", etc., so round down to nearest 5 for >20 courses
+			var maxCount = 99;
 			var count = enrollmentsLength < 20
 				? enrollmentsLength
 				: String(enrollmentsLength - (enrollmentsLength % 5));
-			if (hasMoreEnrollments) count += '+';
+			if (count > maxCount) count = maxCount + '+';
+			if (hasMoreEnrollments && count !== maxCount + '+') count += '+';
 
 			return enrollmentsLength > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 		},

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -573,8 +573,12 @@
 			var count = enrollmentsLength < 20
 				? enrollmentsLength
 				: String(enrollmentsLength - (enrollmentsLength % 5));
-			if (count > maxCount) count = maxCount + '+';
-			if (hasMoreEnrollments && count !== maxCount + '+') count += '+';
+			if (count > maxCount) {
+				count = maxCount + '+';
+			}
+			if (hasMoreEnrollments && count !== maxCount + '+') {
+				count += '+';
+			}
 
 			return enrollmentsLength > 0 ? viewAllCourses + ' (' + count + ')' : viewAllCourses;
 		},

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -75,7 +75,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			</d2l-alert>
 
 			<template is="dom-repeat" items="[[_alertsView]]">
-				<d2l-alert type="[[item.alertType]]">
+				<d2l-alert type="[[item.alertType]]" hidden$="[[!_enrollments.length]]">
 					[[item.alertMessage]]
 				</d2l-alert>
 			</template>

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -46,11 +46,13 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				margin-bottom: 20px;
 				clear: both;
 			}
-			.course-tile-grid:not([hide-past-courses]) > div:nth-of-type(n+13) > d2l-enrollment-card:not([pinned]),
+			.course-tile-grid:not([hide-past-courses]) > d2l-enrollment-card:nth-of-type(n+13):not([pinned]),
 			.course-tile-grid:not([hide-past-courses]) > div:nth-of-type(n+13) > d2l-course-image-tile:not([pinned]),
-			.course-tile-grid[hide-past-courses] > div > d2l-enrollment-card[past-course]:not([pinned]),
+			.course-tile-grid[hide-past-courses] d2l-enrollment-card[past-course]:not([pinned]),
+			.course-tile-grid > d2l-enrollment-card[completed]:not([pinned]),
+			.course-tile-grid > d2l-enrollment-card[closed]:not([pinned]),
 			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]),
-			.course-tile-grid[hide-past-courses] > div:nth-of-type(n+13) > d2l-enrollment-card:not([pinned]):not([past-course]):not([completed]),
+			.course-tile-grid[hide-past-courses] > d2l-enrollment-card:nth-of-type(n+13):not([pinned]):not([past-course]):not([completed]),
 			.course-tile-grid[hide-past-courses] > div:nth-of-type(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]):not([completed]) {
 				display: none;
 			}
@@ -80,12 +82,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			<div class="course-tile-grid">
 				<template is="dom-if" if="[[useEnrollmentCards]]">
 					<template is="dom-repeat" items="[[_enrollments]]">
-						<div>
 							<d2l-enrollment-card
 								href="[[item]]"
 								presentation-href="[[presentationUrl]]">
 							</d2l-enrollment-card>
-						</div>
 					</template>
 				</template>
 				<template is="dom-if" if="[[!useEnrollmentCards]]">

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -897,19 +897,19 @@ describe('d2l-my-courses-content', () => {
 
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', () => {
 			component._hasMoreEnrollments = false;
-			component._enrollments = new Array(6);
+			component._numberOfEnrollment = 6;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6)');
 		});
 
 		it('should show include "+" in the View All Courses link when there are more courses', () => {
 			component._hasMoreEnrollments = true;
-			component._enrollments = new Array(6);
+			component._numberOfEnrollment = 6;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6+)');
 		});
 
 		it('should round the number of courses in the View All Courses link when there are many courses', () => {
 			component._hasMoreEnrollments = true;
-			component._enrollments = new Array(23);
+			component._numberOfEnrollment = 23;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (20+)');
 		});
 

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -846,14 +846,6 @@ describe('d2l-my-courses-content', () => {
 			});
 		});
 
-		it('should remove all existing alerts when enrollment alerts are updated', () => {
-			component._addAlert('error', 'testError', 'this is a test');
-			component._addAlert('warning', 'testWarning', 'this is another test');
-			expect(component._alertsView).to.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-			component._enrollmentsChanged([1]);
-			expect(component._alertsView).to.not.include({ alertName: 'testError', alertType: 'error', alertMessage: 'this is a test'});
-		});
-
 	});
 
 	describe('With enrollments', () => {


### PR DESCRIPTION
Use course count from org->enrollment map
Display no open courses alert based enrollments
Enrollment count.
Fixed double count.
Maxed out the course count to 99+
Fixed alerts being cleared
Fixed View All Courses link not showing when there is one hidden course