### PR TITLE
No course alert shows when there are no courses.

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -191,6 +191,7 @@
 		_enrollmentsSearchUrl: null,
 
 		_enrollmentsChanged: function(viewAbleLength, totalLength) {
+			totalLength = this.useEnrollmentCards ? totalLength : viewAbleLength;
 			this._hasEnrollments = totalLength > 0;
 
 			this._removeAlert('noCourses');

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -143,7 +143,7 @@
 			document.body.removeEventListener('d2l-tab-panel-selected', this._onTabSelected.bind(this));
 		},
 		observers: [
-			'_enrollmentsChanged(_enrollments)',
+			'_enrollmentsChanged(_enrollments.length, _numberOfEnrollments)',
 			'_enrollmentSearchActionChanged(enrollmentsSearchAction)',
 		],
 
@@ -190,12 +190,14 @@
 		_initiallyVisibleCourseTileCount: 0,
 		_enrollmentsSearchUrl: null,
 
-		_enrollmentsChanged: function(enrollments) {
-			this._hasEnrollments = enrollments.length > 0;
+		_enrollmentsChanged: function(viewAbleLength, totalLength) {
+			this._hasEnrollments = totalLength > 0;
 
 			this._removeAlert('noCourses');
-			if (!this._hasEnrollments) {
+			if (viewAbleLength <= 0) {
 				this._clearAlerts();
+			}
+			if (!this._hasEnrollments) {
 				this._addAlert('call-to-action', 'noCourses', this.localize('noCoursesMessage'));
 			}
 		},

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -75,7 +75,7 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 			</d2l-alert>
 
 			<template is="dom-repeat" items="[[_alertsView]]">
-				<d2l-alert type="[[item.alertType]]" hidden$="[[!_enrollments.length]]">
+				<d2l-alert type="[[item.alertType]]">
 					[[item.alertMessage]]
 				</d2l-alert>
 			</template>

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -117,6 +117,8 @@ describe('d2l-my-courses-content', () => {
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch');
 		SetupFetchStub(/\/enrollments$/, enrollmentsRootEntity);
+		SetupFetchStub(/\/enrollments\/users\/169\/organizations\/1/, enrollmentEntity);
+		SetupFetchStub(/\/enrollments\/users\/169\/organizations\/2/, enrollmentEntity);
 		SetupFetchStub(/\/organizations\/1$/, organizationEntity);
 		SetupFetchStub(/\/organizations\/2$/, organizationEntity);
 		SetupFetchStub(/\/organizations\/3$/, organizationEntity);
@@ -842,6 +844,7 @@ describe('d2l-my-courses-content', () => {
 					alertMessage: 'You don\'t have any courses to display.'
 				});
 				component._enrollments = ['/enrollments/users/169/organizations/1'];
+				component._numberOfEnrollments = 1;
 				expect(component._alertsView).to.be.empty;
 			});
 		});
@@ -856,10 +859,11 @@ describe('d2l-my-courses-content', () => {
 			});
 		});
 
-		it('should correctly evaluate whether it has enrollments', () => {
-			return component._fetchRoot().then(() => {
+		it('should correctly evaluate whether it has enrollments', done => {
+			setTimeout(() => {
 				expect(component._hasEnrollments).to.be.true;
-			});
+				done();
+			}, 2000);
 		});
 
 		it('should add a setCourseImageFailure warning alert when a request to set the image fails', () => {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -800,6 +800,7 @@ describe('d2l-my-courses-content', () => {
 		it('should display the appropriate alert when there are no enrollments', () => {
 			fetchStub.restore();
 			component._enrollments = [];
+			component._numberOfEnrollments = 0;
 
 			SetupFetchStub(/\/enrollments$/, enrollmentsRootEntity);
 			SetupFetchStub(/\/enrollments\/users\/169.*&.*$/, window.D2L.Hypermedia.Siren.Parse({
@@ -825,6 +826,7 @@ describe('d2l-my-courses-content', () => {
 		it('should update enrollment alerts when enrollment information is updated', () => {
 			fetchStub.restore();
 			component._enrollments = [];
+			component._numberOfEnrollments = 0;
 
 			SetupFetchStub(/\/enrollments$/, enrollmentsRootEntity);
 			SetupFetchStub(/\/enrollments\/users\/169.*&.*$/, window.D2L.Hypermedia.Siren.Parse({


### PR DESCRIPTION
The 'You don't have any courses to display...' alert is not being shown in the My Courses Widget when a user logs in and isn't enrolled in any courses.

Steps to reproduce:
1) Create a new user
2) Log in as that user
3) Observe the My Courses Widget