### PR TITLE
Setup all courses view the same as the widget.

### DIFF
--- a/src/d2l-all-courses-unified-content.html
+++ b/src/d2l-all-courses-unified-content.html
@@ -39,12 +39,10 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 		<div class="course-tile-grid">
 			<template is="dom-if" if="[[useEnrollmentCards]]">
 				<template is="dom-repeat" items="[[filteredEnrollments]]">
-					<div>
-						<d2l-enrollment-card
-							href="[[item]]"
-							presentation-href=[[presentationUrl]]>
-						</d2l-enrollment-card>
-					</div>
+					<d2l-enrollment-card
+						href="[[item]]"
+						presentation-href=[[presentationUrl]]>
+					</d2l-enrollment-card>
 				</template>
 			</template>
 			<template is="dom-if" if="[[!useEnrollmentCards]]">

--- a/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-behavior.html
@@ -78,7 +78,7 @@
 
 			for (var i = 0, position = 0; i < courseTileDivs.length; i++, position++) {
 				var div = courseTileDivs[i];
-				if ((div.hasAttribute('completed') || div.hasAttribute('closed')) && !div.hasAttribute('pinned')) {
+				if (this.__hideElement(div)) {
 					position--;
 					continue;
 				}
@@ -89,6 +89,12 @@
 				div.style['-ms-grid-column'] = column;
 				div.style['-ms-grid-row'] = row;
 			}
+		},
+
+		__hideElement: function(div) {
+			return this.is !== 'd2l-all-courses-unified-content'
+				&& (div.hasAttribute('completed') || div.hasAttribute('closed'))
+				&& !div.hasAttribute('pinned');
 		}
 	};
 </script>

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -177,7 +177,7 @@ describe('d2l-my-courses-content', () => {
 					var courseTileGrid = component.$$('.course-tile-grid');
 					expect(courseTileGrid.classList.toString()).to.contain('columns-');
 					done();
-				}, 100);
+				}, 500);
 			};
 
 			window.addEventListener('resize', listener);


### PR DESCRIPTION
While enrolled in multiple, open/active courses, going to View All Courses shows only one card.

Steps to reproduce:
Use IE11
Login as a user that is enrolled in more than one course
Click on View All Courses
Observe
Actual:
Only one course card is rendered

Expected:
All enrolled courses should be rendered