### PR TITLE
The method that checks if there are only past courses needs to update on enrollment length

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -72,7 +72,7 @@
 			_hasOnlyPastCourses: {
 				type: Boolean,
 				value: false,
-				computed: '_computeHasOnlyPastCourses(_courseTileOrganizationEventCount)'
+				computed: '_computeHasOnlyPastCourses(_courseTileOrganizationEventCount, _enrollments.length)'
 			},
 			// Lookup table of org unit ID -> enrollment, to avoid having to re-fetch enrollments
 			_orgUnitIdMap: {


### PR DESCRIPTION
This was thought to be fixed in #616. However, it wasn't. When I tested #616 I got lucky with the order of which the events got called. Anyways, figured it out and now there is no luck involved.