### PR TITLE
DE31508 - Handle hiding completed / closed courses

### DIFF
--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -65,9 +65,9 @@
 				value: false
 			},
 			// True when user has >1 page of enrollments
-			_hasMoreEnrollments: {
-				type: Boolean,
-				value: false
+			_nextEnrollmentEntityUrl: {
+				type: String,
+				value: null
 			},
 			_hasOnlyPastCourses: {
 				type: Boolean,
@@ -105,7 +105,7 @@
 			// Text to render for "View All Courses" link (includes enrollment count approximation)
 			_viewAllCoursesText: {
 				type: String,
-				computed: '_getViewAllCoursesText(_hasMoreEnrollments, _numberOfEnrollments)'
+				computed: '_getViewAllCoursesText(_nextEnrollmentEntityUrl, _numberOfEnrollments)'
 			}
 		},
 		listeners: {
@@ -190,7 +190,6 @@
 		_initiallyVisibleCourseTileCount: 0,
 		_enrollmentsSearchUrl: null,
 		_widgetMaxCardVisible: 12,
-		_nextEnrollmentEntityUrl: false,
 		_hidePastCourses: false,
 
 		_enrollmentsChanged: function(viewAbleLength, totalLength) {
@@ -627,8 +626,8 @@
 		},
 		_populateEnrollments: function(enrollmentsEntity) {
 			var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
-			this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
-			this._nextEnrollmentEntityUrl = this._hasMoreEnrollments && enrollmentsEntity.getLinkByRel('next').href;
+			var hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
+			this._nextEnrollmentEntityUrl = hasMoreEnrollments ? enrollmentsEntity.getLinkByRel('next').href : null;
 			var newEnrollments = [];
 
 			var searchAction = enrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
@@ -677,7 +676,7 @@
 			this.fire('recalculate-columns');
 
 			var lastEnrollment = enrollmentEntities[enrollmentEntities.length - 1];
-			if (lastEnrollment && lastEnrollment.hasClass('pinned') && this._hasMoreEnrollments) {
+			if (lastEnrollment && lastEnrollment.hasClass('pinned') && this._nextEnrollmentEntityUrl) {
 				return this.fetchSirenEntity(this._nextEnrollmentEntityUrl)
 					.then(this._populateEnrollments.bind(this));
 			}

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -191,6 +191,7 @@
 		_enrollmentsSearchUrl: null,
 		_widgetMaxCardVisible: 12,
 		_nextEnrollmentEntityUrl: false,
+		_hidePastCourses: false,
 
 		_enrollmentsChanged: function(viewAbleLength, totalLength) {
 			totalLength = this.useEnrollmentCards ? totalLength : viewAbleLength;
@@ -253,13 +254,17 @@
 			this._orgUnitIdMap[orgUnitId] = e.detail.enrollmentUrl;
 		},
 		_onD2lEnrollmentCardStatus: function(e) {
+			// When we need to hide closed, the backend puts it at the back of the list. So nothing to do.
 			if (!e.detail
 				|| !e.detail.status
 				|| !e.detail.enrollmentUrl
+				|| !this._hidePastCourses
+				|| e.detail.status.closed
 			) {
 				return;
 			}
-			var hide = (e.detail.status.completed || e.detail.status.closed);
+
+			var hide = e.detail.status.completed;
 
 			if (hide) {
 				var index = this._enrollments.indexOf(e.detail.enrollmentUrl);
@@ -271,6 +276,7 @@
 					this.push('_enrollments', e.detail.enrollmentUrl);
 				}
 			}
+
 			if (this._enrollments.length < this._widgetMaxCardVisible && this._nextEnrollmentEntityUrl) {
 				this.fetchSirenEntity(this._nextEnrollmentEntityUrl)
 					.then(this._populateEnrollments.bind(this));
@@ -638,6 +644,7 @@
 				// When using Current sort, hide past courses in the widget view
 				var tileGrid = this.cssGridView ? this.$$('.course-tile-grid') : this.$$('d2l-course-tile-grid');
 				tileGrid.setAttribute('hide-past-courses', '');
+				this._hidePastCourses = true;
 			}
 
 			enrollmentEntities.forEach(function(enrollment) {

--- a/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content-behavior.html
@@ -189,6 +189,8 @@
 		_courseImagesLoadedEventCount: 0,
 		_initiallyVisibleCourseTileCount: 0,
 		_enrollmentsSearchUrl: null,
+		_widgetMaxCardVisible: 12,
+		_nextEnrollmentEntityUrl: false,
 
 		_enrollmentsChanged: function(viewAbleLength, totalLength) {
 			totalLength = this.useEnrollmentCards ? totalLength : viewAbleLength;
@@ -269,6 +271,11 @@
 					this.push('_enrollments', e.detail.enrollmentUrl);
 				}
 			}
+			if (this._enrollments.length < this._widgetMaxCardVisible && this._nextEnrollmentEntityUrl) {
+				this.fetchSirenEntity(this._nextEnrollmentEntityUrl)
+					.then(this._populateEnrollments.bind(this));
+			}
+
 			this._onResize();
 		},
 		_onD2lEnrollmentNew: function() {
@@ -615,6 +622,7 @@
 		_populateEnrollments: function(enrollmentsEntity) {
 			var enrollmentEntities = enrollmentsEntity.getSubEntitiesByClass('enrollment');
 			this._hasMoreEnrollments = enrollmentsEntity.hasLinkByRel('next');
+			this._nextEnrollmentEntityUrl = this._hasMoreEnrollments && enrollmentsEntity.getLinkByRel('next').href;
 			var newEnrollments = [];
 
 			var searchAction = enrollmentsEntity.getActionByName(this.HypermediaActions.enrollments.searchMyEnrollments);
@@ -663,8 +671,7 @@
 
 			var lastEnrollment = enrollmentEntities[enrollmentEntities.length - 1];
 			if (lastEnrollment && lastEnrollment.hasClass('pinned') && this._hasMoreEnrollments) {
-				var url = enrollmentsEntity.getLinkByRel('next').href;
-				return this.fetchSirenEntity(url)
+				return this.fetchSirenEntity(this._nextEnrollmentEntityUrl)
 					.then(this._populateEnrollments.bind(this));
 			}
 		},

--- a/src/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/src/d2l-my-courses-content/d2l-my-courses-content.html
@@ -46,14 +46,14 @@ This is only used if the `US90527-my-courses-updates` LD flag is ON
 				margin-bottom: 20px;
 				clear: both;
 			}
-			.course-tile-grid:not([hide-past-courses]) > d2l-enrollment-card:nth-of-type(n+13):not([pinned]),
+
+			.course-tile-grid[hide-past-courses] > div:nth-of-type(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]),
 			.course-tile-grid:not([hide-past-courses]) > div:nth-of-type(n+13) > d2l-course-image-tile:not([pinned]),
-			.course-tile-grid[hide-past-courses] d2l-enrollment-card[past-course]:not([pinned]),
-			.course-tile-grid > d2l-enrollment-card[completed]:not([pinned]),
-			.course-tile-grid > d2l-enrollment-card[closed]:not([pinned]),
 			.course-tile-grid[hide-past-courses] > div > d2l-course-image-tile[past-course]:not([pinned]),
-			.course-tile-grid[hide-past-courses] > d2l-enrollment-card:nth-of-type(n+13):not([pinned]):not([past-course]):not([completed]),
-			.course-tile-grid[hide-past-courses] > div:nth-of-type(n+13) > d2l-course-image-tile:not([pinned]):not([past-course]):not([completed]) {
+			.course-tile-grid[hide-past-courses] > d2l-enrollment-card:nth-of-type(n+13):not([pinned]),
+			.course-tile-grid:not([hide-past-courses]) > d2l-enrollment-card:nth-of-type(n+13):not([pinned]),
+			.course-tile-grid[hide-past-courses] > d2l-enrollment-card[completed]:not([pinned]),
+			.course-tile-grid[hide-past-courses] > d2l-enrollment-card[closed]:not([pinned]), {
 				display: none;
 			}
 			.d2l-body-standard {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -865,7 +865,7 @@ describe('d2l-my-courses-content', () => {
 			setTimeout(() => {
 				expect(component._hasEnrollments).to.be.true;
 				done();
-			}, 2000);
+			}, 3000);
 		});
 
 		it('should add a setCourseImageFailure warning alert when a request to set the image fails', () => {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -156,7 +156,7 @@ describe('d2l-my-courses-content', () => {
 		expect(component._alertsView).to.be.an.instanceof(Array);
 		expect(component._existingEnrollmentsMap).to.be.an('object');
 		expect(component._hasEnrollments).to.exist;
-		expect(component._hasMoreEnrollments).to.exist;
+		expect(component._nextEnrollmentEntityUrl).to.be.null;
 		expect(component._orgUnitIdMap).to.be.an('object');
 		expect(component._setImageOrg).to.be.an('object');
 		expect(component._showContent).to.exist;
@@ -894,19 +894,19 @@ describe('d2l-my-courses-content', () => {
 		});
 
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', () => {
-			component._hasMoreEnrollments = false;
+			component._nextEnrollmentEntityUrl = null;
 			component._numberOfEnrollments = 6;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6)');
 		});
 
 		it('should show include "+" in the View All Courses link when there are more courses', () => {
-			component._hasMoreEnrollments = true;
+			component._nextEnrollmentEntityUrl = 'enrollments/2';
 			component._numberOfEnrollments = 6;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (6+)');
 		});
 
 		it('should round the number of courses in the View All Courses link when there are many courses', () => {
-			component._hasMoreEnrollments = true;
+			component._nextEnrollmentEntityUrl = 'enrollments/2';
 			component._numberOfEnrollments = 23;
 			expect(component._viewAllCoursesText).to.equal('View All Courses (20+)');
 		});


### PR DESCRIPTION
- Handle the case when the user has > 50 courses and <= 50 courses properly.
- Only using CSS to hide past (closed) courses. The backend puts these at the end of the api calls.
- Using a more complicated method to hide completed courses as the backend doesn't sort these. Completed courses won't hide when there are > 50 courses.