### PR TITLE
DE31778-add box-sizing: border-box to enrollment card

### DIFF
--- a/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
+++ b/src/d2l-css-grid-view/d2l-css-grid-view-styles.html
@@ -33,6 +33,7 @@
 			}
 
 			.course-tile-grid d2l-enrollment-card {
+				box-sizing: border-box;
 				height: 100%;
 				padding-bottom: 0.75rem;
 				--course-image-height: var(--course-image-tile-height);


### PR DESCRIPTION
Enrollment card relies on homepage to set box-sizing, hence breaks in shadow dom. This change fixes it.