### PR TITLE
DE31831: Make sure animation end clears the class of the departing tile.

### DIFF
--- a/src/d2l-course-tile.js
+++ b/src/d2l-course-tile.js
@@ -560,6 +560,8 @@ Polymer({
 		} else if (e.animationName.indexOf('tile-pre-insertion') > -1) {
 			this.toggleClass('animate-insertion', true, this);
 		}
+
+		this.toggleClass('unpin', false, this);
 	},
 	_onOrganizationResponse: function(organization) {
 


### PR DESCRIPTION
The `unpin` class is added when a tile moves between the "pinned" and "unpinned" lists. This class kept the new location of incoming tiles marked as though the tile wasn't there. This messed up animations by hiding the tiles that slid into the slot of a departing tile.

This problem is only in Polymer 3 for reasons I haven't yet deduced.

