### PR TITLE
DE32768-fix issue where _selectedTabId is not defined when no tabs

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -261,7 +261,8 @@ Polymer({
 			value: false
 		},
 		_isSearched: Boolean,
-		_bustCacheToken: Number
+		_bustCacheToken: Number,
+		_selectedTabId: String
 	},
 	behaviors: [
 		D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior,
@@ -511,10 +512,12 @@ Polymer({
 		);
 	},
 	_onEnrollmentPinned: function(e) {
-		this._bustCacheToken = Math.random();
-		var actionName = this._selectedTabId.replace('all-courses-tab-', '');
-		if (!e.detail.isPinned &&  actionName === Actions.enrollments.searchMyPinnedEnrollments) {
-			this._searchUrl = this._appendOrUpdateBustCacheQueryString(this._searchUrl);
+		if (this._showGroupByTabs) {
+			this._bustCacheToken = Math.random();
+			var actionName = this._selectedTabId.replace('all-courses-tab-', '');
+			if (!e.detail.isPinned &&  actionName === Actions.enrollments.searchMyPinnedEnrollments) {
+				this._searchUrl = this._appendOrUpdateBustCacheQueryString(this._searchUrl);
+			}
 		}
 
 		var orgUnitId;


### PR DESCRIPTION
Thanks @njostonehouse for finding this issue and suggested the fix.  You are totally right that `_selectedTabId` should be only used when `_showGroupByTabs` is true, and it fixed the undefined issue when no tabs. I have it tested with both feature off and `UpdatedSortLogic` off.