### PR TITLE
US104330: Remove unused properties `enrollments-url` (from `-content`…

### DIFF
--- a/d2l-my-courses.js
+++ b/d2l-my-courses.js
@@ -27,7 +27,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses">
 		<template is="dom-if" if="[[!updatedSortLogic]]">
 			<d2l-my-courses-content-animated
 				advanced-search-url="[[advancedSearchUrl]]"
-				enrollments-url="[[enrollmentsUrl]]"
 				enrollments-search-action="[[_enrollmentsSearchAction]]"
 				image-catalog-location="[[imageCatalogLocation]]"
 				show-course-code="[[showCourseCode]]"
@@ -47,7 +46,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses">
 							<d2l-my-courses-content
 								advanced-search-url="[[advancedSearchUrl]]"
 								course-image-upload-cb="[[courseImageUploadCb]]"
-								enrollments-url="[[enrollmentsUrl]]"
 								enrollments-search-action="[[item.enrollmentsSearchAction]]"
 								image-catalog-location="[[imageCatalogLocation]]"
 								presentation-url="[[presentationUrl]]"
@@ -66,7 +64,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses">
 				<d2l-my-courses-content
 					advanced-search-url="[[advancedSearchUrl]]"
 					course-image-upload-cb="[[courseImageUploadCb]]"
-					enrollments-url="[[enrollmentsUrl]]"
 					enrollments-search-action="[[_enrollmentsSearchAction]]"
 					image-catalog-location="[[imageCatalogLocation]]"
 					presentation-url="[[presentationUrl]]"

--- a/src/d2l-all-courses-segregated-content.js
+++ b/src/d2l-all-courses-segregated-content.js
@@ -50,7 +50,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-segregated-cont
 			enrollments="[[filteredPinnedEnrollments]]"
 			enrollments-to-animate="[[_pinnedEnrollmentsToAnimate]]"
 			tile-sizes="[[_tileSizes]]"
-			locale="[[locale]]" show-course-code="[[showCourseCode]]"
+			locale="[[locale]]"
+			show-course-code="[[showCourseCode]]"
 			show-semester="[[showSemester]]"
 			course-updates-config="[[courseUpdatesConfig]]">
 		</d2l-course-tile-grid>

--- a/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
+++ b/test/d2l-all-courses-unified-content/d2l-all-courses-unified-content.html
@@ -13,7 +13,6 @@
 		<test-fixture id="d2l-all-courses-unified-content-fixture">
 			<template>
 				<d2l-all-courses-unified-content
-					use-saved-searches="true"
 					filtered-enrollments='[]'>
 				</d2l-all-courses-unified-content>
 			</template>
@@ -24,7 +23,6 @@
 				<div id="foo">
 					<div>
 						<d2l-all-courses-unified-content
-							use-saved-searches="true"
 							filtered-enrollments='[]'>
 						</d2l-all-courses-unified-content>
 					</div>

--- a/test/d2l-all-courses/d2l-all-courses.html
+++ b/test/d2l-all-courses/d2l-all-courses.html
@@ -14,8 +14,7 @@
 				<d2l-all-courses id="all-courses-tab-12345"
 					pinned-enrollments='[]'
 					unpinned-enrollments='[]'
-					advanced-search-url="/test/url/"
-					use-saved-searches="true">
+					advanced-search-url="/test/url/">
 				</d2l-all-courses>
 			</template>
 		</test-fixture>

--- a/test/d2l-my-courses-content/d2l-my-courses-content-animated.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content-animated.html
@@ -10,7 +10,7 @@
 	<body>
 		<test-fixture id="d2l-my-courses-content-animated-fixture">
 			<template>
-				<d2l-my-courses-content-animated enrollments-url="/enrollments"></d2l-my-courses-content-animated>
+				<d2l-my-courses-content-animated></d2l-my-courses-content-animated>
 			</template>
 		</test-fixture>
 

--- a/test/d2l-my-courses-content/d2l-my-courses-content.html
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.html
@@ -10,14 +10,14 @@
 	<body>
 		<test-fixture id="d2l-my-courses-content-fixture">
 			<template>
-				<d2l-my-courses-content use-saved-searches="true"></d2l-my-courses-content>
+				<d2l-my-courses-content></d2l-my-courses-content>
 			</template>
 		</test-fixture>
 
 		<test-fixture id="tab-event-fixture">
 			<template>
 				<div id="foo">
-					<d2l-my-courses-content use-saved-searches="true"></d2l-my-courses-content>
+					<d2l-my-courses-content></d2l-my-courses-content>
 				</div>
 			</template>
 		</test-fixture>

--- a/test/d2l-my-courses/d2l-my-courses.html
+++ b/test/d2l-my-courses/d2l-my-courses.html
@@ -10,7 +10,7 @@
 	<body>
 		<test-fixture id="d2l-my-courses-fixture">
 			<template>
-				<d2l-my-courses use-saved-searches="true"></d2l-my-courses>
+				<d2l-my-courses></d2l-my-courses>
 			</template>
 		</test-fixture>
 


### PR DESCRIPTION
… components) and `use-saved-searches`.