### PR TITLE
DE33973-always show compelted courses

### DIFF
--- a/src/card-grid/d2l-my-courses-content.js
+++ b/src/card-grid/d2l-my-courses-content.js
@@ -50,7 +50,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses-content">
 			}
 
 			.course-card-grid d2l-enrollment-card:nth-of-type(n+13):not([pinned]),
-			.course-card-grid[hide-past-courses] d2l-enrollment-card[completed]:not([pinned]),
 			.course-card-grid[hide-past-courses] d2l-enrollment-card[closed]:not([pinned]) {
 				display: none;
 			}

--- a/src/d2l-my-courses-content-behavior.js
+++ b/src/d2l-my-courses-content-behavior.js
@@ -269,20 +269,16 @@ D2L.MyCourses.MyCoursesContentBehaviorImpl = {
 		this._orgUnitIdMap[orgUnitId] = e.detail.enrollmentUrl;
 	},
 	_onD2lEnrollmentCardStatus: function(e) {
-		if (!e.detail || !e.detail.status || !e.detail.enrollmentUrl) {
+		if (!e.detail || !e.detail.status || !e.detail.enrollmentUrl || e.detail.status.completed) {
 			return;
 		}
 
-		var hide = this._hidePastCourses && (e.detail.status.completed || e.detail.status.closed);
+		var hide = this._hidePastCourses && (e.detail.status.closed);
 		var index = this._enrollments.indexOf(e.detail.enrollmentUrl);
 
 		if (hide && index !== -1 && index > this._lastPinnedIndex) {
 			this.splice('_enrollments', index, 1);
 		}
-		//This is to force updating the urls
-		const temp = this._enrollments;
-		this._enrollments = [];
-		this._enrollments = temp;
 
 		if (this._enrollments.length < this._widgetMaxCardVisible && this._nextEnrollmentEntityUrl) {
 			this._entityStoreFetch(this._nextEnrollmentEntityUrl)


### PR DESCRIPTION
Added the same fix to master, will delete the handler when the API is updated to new search and filter framework or a fix from SDK.