### PR TITLE
DE34415 - Fix Widget Refresh After Change in Settings

### DIFF
--- a/src/d2l-my-courses-behavior.js
+++ b/src/d2l-my-courses-behavior.js
@@ -59,7 +59,11 @@ D2L.MyCourses.MyCoursesBehaviorImpl = {
 		},
 		_tabSearchType: String,
 		_changedCourseEnrollment: Object,
-		_updateUserSettingsAction: Object
+		_updateUserSettingsAction: Object,
+		_bustPresentationCache: {
+			type: Boolean,
+			value: true
+		}
 	},
 	_computeShowGroupByTabs: function(groups) {
 		return groups.length >= 2 || (groups.length > 0 && !this._enrollmentsSearchAction);
@@ -68,6 +72,9 @@ D2L.MyCourses.MyCoursesBehaviorImpl = {
 		'd2l-course-enrollment-change': '_onCourseEnrollmentChange',
 		'd2l-tab-changed': '_tabSelectedChanged'
 	},
+	observers: [
+		'_onPresentationUrlChange(presentationUrl)'
+	],
 	attached: function() {
 		if (!this.enrollmentsUrl || !this.userSettingsUrl) {
 			return;
@@ -205,6 +212,12 @@ D2L.MyCourses.MyCoursesBehaviorImpl = {
 
 		}.bind(this));
 	},
+	_onPresentationUrlChange: function(url) {
+		if (url && this._bustPresentationCache) {
+			this._bustPresentationCache = false;
+			this.presentationUrl += '?bustCache=' + Math.random();
+		}
+	}
 };
 
 /*


### PR DESCRIPTION
Now that we're going through the entity store, the presentation url is no longer getting re-fetched if `my-courses` is reattached after the user updates the widget settings.  This will make the url unique each time.  It will result in a duplicate call of the same API, but only the first load (after that, the main url will be cached and not refetched each time, only the new url with the `bustCache` attribute).  We use this technique elsewhere in my-courses (https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-my-courses-content-behavior.js#L578).

Not sure what this means for the SDK... will a similar technique need to be used, or can we tell the SDK entity that we think it has a stale resource?