### PR TITLE
DE34346 - Disable entity cache for the presentation url

### DIFF
--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -26,6 +26,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses-container">
 						<d2l-my-courses-content
 							href="[[presentationUrl]]"
 							token="[[token]]"
+							disable-entity-cache
 							advanced-search-url="[[advancedSearchUrl]]"
 							course-image-upload-cb="[[courseImageUploadCb]]"
 							enrollments-search-action="[[item.enrollmentsSearchAction]]"
@@ -46,6 +47,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses-container">
 			<d2l-my-courses-content
 				href="[[presentationUrl]]"
 				token="[[token]]"
+				disable-entity-cache
 				advanced-search-url="[[advancedSearchUrl]]"
 				org-unit-type-ids="[[orgUnitTypeIds]]"
 				course-image-upload-cb="[[courseImageUploadCb]]"


### PR DESCRIPTION
This will fix the issue where a my-courses refresh caused by changes to the widget settings does not display those new settings