### PR TITLE
US113258 - Remove two-way binding from everything except the filter menu

### DIFF
--- a/legacy/d2l-all-courses-legacy.js
+++ b/legacy/d2l-all-courses-legacy.js
@@ -42,8 +42,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-legacy">
 
 		<d2l-simple-overlay
 			id="all-courses"
-			title-name="{{localize('allCourses')}}"
-			close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}"
+			title-name="[[localize('allCourses')]]"
+			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
 			with-backdrop=""
 			restore-focus-on-close="">
 
@@ -80,27 +80,27 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-legacy">
 
 							<d2l-dropdown id="sortDropdown">
 								<button class="d2l-dropdown-opener dropdown-button" aria-labelledby="sortText">
-									<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortCourseName')}}</span>
+									<span id="sortText" class="dropdown-opener-text">[[localize('sorting.sortCourseName')]]</span>
 									<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 								</button>
 								<d2l-dropdown-menu no-padding="" min-width="350">
-									<d2l-menu id="sortDropdownMenu" label="{{localize('sorting.sortBy')}}">
+									<d2l-menu id="sortDropdownMenu" label="[[localize('sorting.sortBy')]]">
 										<div class="dropdown-content-header">
-											<span>{{localize('sorting.sortBy')}}</span>
+											<span>[[localize('sorting.sortBy')]]</span>
 										</div>
-										<d2l-menu-item-radio hidden$="[[!updatedSortLogic]]" class="dropdown-content-gradient" value="Default" text="{{localize('sorting.sortDefault')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="OrgUnitName" class$="[[_showDropdownGradient(updatedSortLogic)]]" text="{{localize('sorting.sortCourseName')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="OrgUnitCode" text="{{localize('sorting.sortCourseCode')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="PinDate" text="{{localize('sorting.sortDatePinned')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio value="LastAccessed" text="{{localize('sorting.sortLastAccessed')}}"></d2l-menu-item-radio>
-										<d2l-menu-item-radio hidden$="[[!updatedSortLogic]]" value="EnrollmentDate" text="{{localize('sorting.sortEnrollmentDate')}}"></d2l-menu-item-radio>
+										<d2l-menu-item-radio hidden$="[[!updatedSortLogic]]" class="dropdown-content-gradient" value="Default" text="[[localize('sorting.sortDefault')]]"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="OrgUnitName" class$="[[_showDropdownGradient(updatedSortLogic)]]" text="[[localize('sorting.sortCourseName')]]"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="OrgUnitCode" text="[[localize('sorting.sortCourseCode')]]"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="PinDate" text="[[localize('sorting.sortDatePinned')]]"></d2l-menu-item-radio>
+										<d2l-menu-item-radio value="LastAccessed" text="[[localize('sorting.sortLastAccessed')]]"></d2l-menu-item-radio>
+										<d2l-menu-item-radio hidden$="[[!updatedSortLogic]]" value="EnrollmentDate" text="[[localize('sorting.sortEnrollmentDate')]]"></d2l-menu-item-radio>
 									</d2l-menu>
 								</d2l-dropdown-menu>
 							</d2l-dropdown>
 						</div>
 					</div>
 					<div class="search-and-filter-row advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]">
-						<d2l-link href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</d2l-link>
+						<d2l-link href$="[[advancedSearchUrl]]">[[localize('advancedSearch')]]</d2l-link>
 					</div>
 				</div>
 

--- a/legacy/tile-grid/d2l-course-tile.js
+++ b/legacy/tile-grid/d2l-course-tile.js
@@ -80,9 +80,9 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-course-tile">
 						</div>
 						<div class="notification-overlay">
 							<div class="overlay-date-container">
-								<div class="overlay-text">{{_notificationTitle}}</div>
-								<div class="overlay-date">{{_notificationDate}}</div>
-								<div class="overlay-inactive">{{_notificationInactive}}</div>
+								<div class="overlay-text">[[_notificationTitle]]</div>
+								<div class="overlay-date">[[_notificationDate]]</div>
+								<div class="overlay-inactive">[[_notificationInactive]]</div>
 							</div>
 						</div>
 						<d2l-course-image image="[[_image]]" sizes="[[tileSizes]]" type="tile"></d2l-course-image>
@@ -102,8 +102,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-course-tile">
 						<d2l-offscreen id="courseNotificationLabel" aria-hidden="true">[[_courseNotificationLabel]]</d2l-offscreen>
 					</div>
 					<div id="courseUpdates" hidden$="[[!_hasCourseUpdates]]" aria-hidden="true">
-						<d2l-offscreen>{{localize('courseTile.updates')}}</d2l-offscreen>
-						<span class="update-text-box">{{_courseUpdates}}</span>
+						<d2l-offscreen>[[localize('courseTile.updates')]]</d2l-offscreen>
+						<span class="update-text-box">[[_courseUpdates]]</span>
 					</div>
 				</div>
 			</a>
@@ -117,12 +117,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-course-tile">
 						<template is="dom-if" if="[[_showHoverMenu]]">
 							<d2l-dropdown-menu id="overflow-dropdown">
 								<d2l-menu label$="[[_courseSettingsLabel]]">
-									<template is="dom-if" if="{{_courseInfoUrl}}" restamp="true">
-										<d2l-menu-item-link id="see-course-info-link" text="{{localize('courseOfferingInformation')}}" href="{{_courseInfoUrl}}">
+									<template is="dom-if" if="[[_courseInfoUrl]]" restamp="true">
+										<d2l-menu-item-link id="see-course-info-link" text="[[localize('courseOfferingInformation')]]" href="[[_courseInfoUrl]]">
 										</d2l-menu-item-link>
 									</template>
-									<template is="dom-if" if="{{_canChangeCourseImage}}" restamp="true">
-										<d2l-menu-item id="change-image-button" text="{{localize('changeImage')}}" on-d2l-menu-item-select="_launchCourseTileImageSelector">
+									<template is="dom-if" if="[[_canChangeCourseImage]]" restamp="true">
+										<d2l-menu-item id="change-image-button" text="[[localize('changeImage')]]" on-d2l-menu-item-select="_launchCourseTileImageSelector">
 										</d2l-menu-item>
 									</template>
 									<d2l-menu-item id="pin-button" text$="[[_pinLabel]]" on-d2l-menu-item-select="_pinClickHandler" on-focus="_hoverPinMenuItem" on-blur="_unhoverPinMenuItem" on-mouseover="_hoverPinMenuItem" on-mouseout="_unhoverPinMenuItem">

--- a/legacy/tile-grid/d2l-my-courses-content-animated.js
+++ b/legacy/tile-grid/d2l-my-courses-content-animated.js
@@ -63,7 +63,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses-content-animated
 		<div hidden$="[[!_showContent]]" class="my-courses-content">
 			<template is="dom-repeat" items="[[_alertsView]]">
 				<d2l-alert type="[[item.alertType]]">
-					{{item.alertMessage}}
+					[[item.alertMessage]]
 				</d2l-alert>
 			</template>
 			<d2l-course-tile-grid
@@ -82,7 +82,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-my-courses-content-animated
 		<div id="allCoursesPlaceholder">
 		</div>
 
-		<d2l-simple-overlay id="basic-image-selector-overlay" title-name="{{localize('changeImage')}}" close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}" with-backdrop="">
+		<d2l-simple-overlay id="basic-image-selector-overlay" title-name="[[localize('changeImage')]]" close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]" with-backdrop="">
 			<iron-scroll-threshold id="image-selector-threshold" on-lower-threshold="_onChangeImageLowerThreshold">
 			</iron-scroll-threshold>
 			<d2l-basic-image-selector

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -56,8 +56,8 @@ class AllCourses extends mixinBehaviors([
 
 			<d2l-simple-overlay
 				id="all-courses"
-				title-name="{{localize('allCourses')}}"
-				close-simple-overlay-alt-text="{{localize('closeSimpleOverlayAltText')}}"
+				title-name="[[localize('allCourses')]]"
+				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
 				with-backdrop=""
 				restore-focus-on-close="">
 
@@ -94,27 +94,27 @@ class AllCourses extends mixinBehaviors([
 
 								<d2l-dropdown id="sortDropdown">
 									<button class="d2l-dropdown-opener dropdown-button" aria-labelledby="sortText">
-										<span id="sortText" class="dropdown-opener-text">{{localize('sorting.sortDefault')}}</span>
+										<span id="sortText" class="dropdown-opener-text">[[localize('sorting.sortDefault')]]</span>
 										<d2l-icon icon="d2l-tier1:chevron-down" aria-hidden="true"></d2l-icon>
 									</button>
 									<d2l-dropdown-menu no-padding="" min-width="350">
-										<d2l-menu id="sortDropdownMenu" label="{{localize('sorting.sortBy')}}">
+										<d2l-menu id="sortDropdownMenu" label="[[localize('sorting.sortBy')]]">
 											<div class="dropdown-content-header">
-												<span>{{localize('sorting.sortBy')}}</span>
+												<span>[[localize('sorting.sortBy')]]</span>
 											</div>
-											<d2l-menu-item-radio class="dropdown-content-gradient" value="Default" text="{{localize('sorting.sortDefault')}}"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="OrgUnitName" text="{{localize('sorting.sortCourseName')}}"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="OrgUnitCode" text="{{localize('sorting.sortCourseCode')}}"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="PinDate" text="{{localize('sorting.sortDatePinned')}}"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="LastAccessed" text="{{localize('sorting.sortLastAccessed')}}"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="EnrollmentDate" text="{{localize('sorting.sortEnrollmentDate')}}"></d2l-menu-item-radio>
+											<d2l-menu-item-radio class="dropdown-content-gradient" value="Default" text="[[localize('sorting.sortDefault')]]"></d2l-menu-item-radio>
+											<d2l-menu-item-radio value="OrgUnitName" text="[[localize('sorting.sortCourseName')]]"></d2l-menu-item-radio>
+											<d2l-menu-item-radio value="OrgUnitCode" text="[[localize('sorting.sortCourseCode')]]"></d2l-menu-item-radio>
+											<d2l-menu-item-radio value="PinDate" text="[[localize('sorting.sortDatePinned')]]"></d2l-menu-item-radio>
+											<d2l-menu-item-radio value="LastAccessed" text="[[localize('sorting.sortLastAccessed')]]"></d2l-menu-item-radio>
+											<d2l-menu-item-radio value="EnrollmentDate" text="[[localize('sorting.sortEnrollmentDate')]]"></d2l-menu-item-radio>
 										</d2l-menu>
 									</d2l-dropdown-menu>
 								</d2l-dropdown>
 							</div>
 						</div>
 						<div class="search-and-filter-row advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]">
-							<d2l-link href$="[[advancedSearchUrl]]">{{localize('advancedSearch')}}</d2l-link>
+							<d2l-link href$="[[advancedSearchUrl]]">[[localize('advancedSearch')]]</d2l-link>
 						</div>
 					</div>
 


### PR DESCRIPTION
The usages below weren't actually doing anything with the two-way binding, so changing to one-way to make further Lit conversions easier.

The only usages I left in `my-courses`  are in the `d2l-filter-menu` (https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/search-filter/d2l-filter-menu.js#L106-L110) for both `src` and `legacy`.  Since this component and the one its set on (`d2l-filter-menu-tab`) live in this repo and aren't shared, we won't run into an issue with future Lit conversions.  This _should_ also be short-lived - `src` will be moved to `d2l-filter-dropdown` which doesn't rely on two-way binding and `legacy` will die eventually.