### PR TITLE
Compatibility fix for the Polymer to Lit dropdown conversion

### DIFF
--- a/legacy/d2l-all-courses-legacy.js
+++ b/legacy/d2l-all-courses-legacy.js
@@ -738,7 +738,7 @@ Polymer({
 	_resetSortDropdown: function() {
 		this._selectSortOption(this.defaultSortValue);
 
-		var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');
+		var content = this.$.sortDropdown.__getContentElement();
 		if (content) {
 			content.close();
 		}

--- a/legacy/tile-grid/d2l-course-tile.js
+++ b/legacy/tile-grid/d2l-course-tile.js
@@ -25,6 +25,7 @@ import 'd2l-loading-spinner/d2l-loading-spinner.js';
 import 'd2l-icons/d2l-icons.js';
 import 'd2l-organization-hm-behavior/d2l-organization-hm-behavior.js';
 import 'd2l-menu/d2l-menu-item-link.js';
+import 'd2l-menu/d2l-menu-item.js';
 import 'd2l-offscreen/d2l-offscreen.js';
 import 'd2l-polymer-behaviors/d2l-dom.js';
 import { IronA11yAnnouncer } from '@polymer/iron-a11y-announcer/iron-a11y-announcer.js';

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -690,7 +690,7 @@ class AllCourses extends mixinBehaviors([
 	_resetSortDropdown() {
 		this._selectSortOption(this.defaultSortValue);
 
-		var content = this.$.sortDropdown.queryEffectiveChildren('[d2l-dropdown-content]');
+		var content = this.$.sortDropdown.__getContentElement();
 		if (content) {
 			content.close();
 		}


### PR DESCRIPTION
Replace `queryEffectiveChildren` with the internal opener mixin's function to get
the content element since `queryEffectiveChildren` doesn't exist in Lit.

`__getContentElement()` should not be used since its an internal dropdown implementation detail but an exception is being made because My Courses is already accessing the internal `d2l-dropdown-content` attribute.

[The Polymer dropdown was updated to facilitate this change in this PR.](https://github.com/BrightspaceUI/dropdown/pull/178/files)