### PR TITLE
US114859 - More cleanup of d2l-all-courses and d2l-my-courses-container

### DIFF
--- a/d2l-my-courses.js
+++ b/d2l-my-courses.js
@@ -6,96 +6,97 @@ If the `d2l.Tools.MyCoursesWidget.UpdatedSortLogic` config variable is on, the `
 If it is off and the attribute is not added, the `legacy/d2l-my-courses-legacy` component is rendered.
 
 */
-import '@polymer/polymer/polymer-legacy.js';
 
 import './src/d2l-my-courses-container.js';
 import './legacy/d2l-my-courses-legacy.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-const $_documentContainer = document.createElement('template');
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-my-courses">
-	<template strip-whitespace="">
-		<template is="dom-if" if="[[!updatedSortLogic]]">
-			<d2l-my-courses-legacy
-				enrollments-url="[[enrollmentsUrl]]"
-				advanced-search-url="[[advancedSearchUrl]]"
-				standard-semester-name="[[standardSemesterName]]"
-				standard-department-name="[[standardDepartmentName]]"
-				show-course-code="[[showCourseCode]]"
-				course-updates-config="[[courseUpdatesConfig]]"
-				image-catalog-location="[[imageCatalogLocation]]"
-				promoted-searches="[[promotedSearches]]"
-				user-settings-url="[[userSettingsUrl]]"
-				show-semester="[[showSemester]]"
-				org-unit-type-ids="[[orgUnitTypeIds]]"
-				updated-sort-logic="[[updatedSortLogic]]"
-				course-image-upload-cb="[[courseImageUploadCb]]"
-				token="[[token]]">
-			</d2l-my-courses-legacy>
-		</template>
-		<template is="dom-if" if="[[updatedSortLogic]]">
-			<d2l-my-courses-container
-				enrollments-url="[[enrollmentsUrl]]"
-				advanced-search-url="[[advancedSearchUrl]]"
-				standard-semester-name="[[standardSemesterName]]"
-				standard-department-name="[[standardDepartmentName]]"
-				image-catalog-location="[[imageCatalogLocation]]"
-				promoted-searches="[[promotedSearches]]"
-				user-settings-url="[[userSettingsUrl]]"
-				org-unit-type-ids="[[orgUnitTypeIds]]"
-				course-image-upload-cb="[[courseImageUploadCb]]"
-				token="[[token]]">
-			</d2l-my-courses-container>
-		</template>
-	</template>
+class MyCourses extends PolymerElement {
 
-</dom-module>`;
+	static get is() { return 'd2l-my-courses'; }
 
-document.head.appendChild($_documentContainer.content);
-Polymer({
-	is: 'd2l-my-courses',
-	properties: {
-		// URL that directs to the advanced search page
-		advancedSearchUrl: String,
-		// URL that is called by the widget to fetch enrollments
-		enrollmentsUrl: String,
-		// URL that is called by the widget to fetch results from the course image catalog
-		imageCatalogLocation: String,
-		// Configuration value passed in to toggle course code -- passed to animation tile
-		showCourseCode: Boolean,
-		// Configuration value passed in to toggle Learning Paths code
-		orgUnitTypeIds: String,
-		// Configuration value passed in to toggle semester on course tile -- passed to animation tile
-		showSemester: Boolean,
-		// Standard Semester OU Type name to be displayed in the all-courses filter dropdown
-		standardDepartmentName: String,
-		// Standard Department OU Type name to be displayed in the all-courses filter dropdown
-		standardSemesterName: String,
-		// Types of notifications to include in update count in course tile -- passed to animation tile
-		courseUpdatesConfig: Object,
-		// Callback for upload in image-selector
-		courseImageUploadCb: Function,
-		// URL to fetch promoted searches for tabs
-		promotedSearches: String,
-		// URL to fetch a user's settings (e.g. default tab to select)
-		userSettingsUrl: String,
-		// Feature flag (switch) for using the updated sort logic and related fetaures
-		updatedSortLogic: {
-			type: Boolean,
-			value: false
-		},
-		token: String
-	},
+	static get properties() {
+		return {
+			// URL that directs to the advanced search page
+			advancedSearchUrl: String,
+			// URL that is called by the widget to fetch enrollments
+			enrollmentsUrl: String,
+			// URL that is called by the widget to fetch results from the course image catalog
+			imageCatalogLocation: String,
+			// Configuration value passed in to toggle course code -- passed to animation tile
+			showCourseCode: Boolean,
+			// Configuration value passed in to toggle Learning Paths code
+			orgUnitTypeIds: String,
+			// Configuration value passed in to toggle semester on course tile -- passed to animation tile
+			showSemester: Boolean,
+			// Standard Semester OU Type name to be displayed in the all-courses filter dropdown
+			standardDepartmentName: String,
+			// Standard Department OU Type name to be displayed in the all-courses filter dropdown
+			standardSemesterName: String,
+			// Types of notifications to include in update count in course tile -- passed to animation tile
+			courseUpdatesConfig: Object,
+			// Callback for upload in image-selector
+			courseImageUploadCb: Function,
+			// URL to fetch promoted searches for tabs
+			promotedSearches: String,
+			// URL to fetch a user's settings (e.g. default tab to select)
+			userSettingsUrl: String,
+			// Feature flag (switch) for using the updated sort logic and related fetaures
+			updatedSortLogic: {
+				type: Boolean,
+				value: false
+			},
+			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
+			token: String
+		};
+	}
 
-	courseImageUploadCompleted: function(success) {
+	static get template() {
+		return html`
+			<template is="dom-if" if="[[!updatedSortLogic]]">
+				<d2l-my-courses-legacy
+					enrollments-url="[[enrollmentsUrl]]"
+					advanced-search-url="[[advancedSearchUrl]]"
+					standard-semester-name="[[standardSemesterName]]"
+					standard-department-name="[[standardDepartmentName]]"
+					show-course-code="[[showCourseCode]]"
+					course-updates-config="[[courseUpdatesConfig]]"
+					image-catalog-location="[[imageCatalogLocation]]"
+					promoted-searches="[[promotedSearches]]"
+					user-settings-url="[[userSettingsUrl]]"
+					show-semester="[[showSemester]]"
+					org-unit-type-ids="[[orgUnitTypeIds]]"
+					updated-sort-logic="[[updatedSortLogic]]"
+					course-image-upload-cb="[[courseImageUploadCb]]"
+					token="[[token]]">
+				</d2l-my-courses-legacy>
+			</template>
+			<template is="dom-if" if="[[updatedSortLogic]]">
+				<d2l-my-courses-container
+					enrollments-url="[[enrollmentsUrl]]"
+					advanced-search-url="[[advancedSearchUrl]]"
+					standard-semester-name="[[standardSemesterName]]"
+					standard-department-name="[[standardDepartmentName]]"
+					image-catalog-location="[[imageCatalogLocation]]"
+					promoted-searches="[[promotedSearches]]"
+					user-settings-url="[[userSettingsUrl]]"
+					org-unit-type-ids="[[orgUnitTypeIds]]"
+					course-image-upload-cb="[[courseImageUploadCb]]"
+					token="[[token]]">
+				</d2l-my-courses-container>
+			</template>`;
+	}
+
+	courseImageUploadCompleted(success) {
 		return this.updatedSortLogic
 			? this.$$('d2l-my-courses-container').courseImageUploadCompleted(success)
 			: this.$$('d2l-my-courses-legacy').courseImageUploadCompleted(success);
-	},
-	getLastOrgUnitId: function() {
+	}
+	getLastOrgUnitId() {
 		return this.updatedSortLogic
 			? this.$$('d2l-my-courses-container').getLastOrgUnitId()
 			: this.$$('d2l-my-courses-legacy').getLastOrgUnitId();
 	}
+}
 
-});
+window.customElements.define(MyCourses.is, MyCourses);

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -1,8 +1,8 @@
 /*
 `d2l-all-courses`
 Polymer-based web component for the all courses overlay.
-
 */
+
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import 'd2l-alert/d2l-alert.js';
 import 'd2l-dropdown/d2l-dropdown.js';
@@ -27,11 +27,6 @@ import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/Enrollment
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
-
-/**
- * @customElement
- * @polymer
- */
 
 class AllCourses extends mixinBehaviors([
 	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior,
@@ -86,7 +81,7 @@ class AllCourses extends mixinBehaviors([
 			// URL that directs to the advanced search page
 			advancedSearchUrl: String,
 			// Default option in Sort menu
-			defaultSortValue: {
+			_defaultSortValue: {
 				type: String,
 				value: 'Default'
 			},
@@ -95,9 +90,9 @@ class AllCourses extends mixinBehaviors([
 			// Standard Semester OU Type name to be displayed in the filter dropdown
 			filterStandardSemesterName: String,
 			// Object containing the last response from an enrollments search request
-			lastEnrollmentsSearchResponse: Object,
+			_lastEnrollmentsSearchResponse: Object,
 			// Entity returned from my-enrollments Link from the enrollments root
-			myEnrollmentsEntity: {
+			_myEnrollmentsEntity: {
 				type: Object,
 				value: function() { return {}; },
 				observer: '_myEnrollmentsEntityChanged'
@@ -123,12 +118,10 @@ class AllCourses extends mixinBehaviors([
 			_enrollmentsSearchAction: Object,
 			// Filter dropdown opener text
 			_filterText: String,
-			// True when there are any filtered enrollments (pinned or unpinned)
-			_hasFilteredEnrollments: Boolean,
 			// True when there are more enrollments to fetch (i.e. current page of enrollments has a `next` link)
 			_hasMoreEnrollments: {
 				type: Boolean,
-				computed: '_computeHasMoreEnrollments(lastEnrollmentsSearchResponse, _showTabContent)'
+				computed: '_computeHasMoreEnrollments(_lastEnrollmentsSearchResponse, _showTabContent)'
 			},
 			// URL passed to search widget, called for searching
 			_searchUrl: String,
@@ -296,7 +289,7 @@ class AllCourses extends mixinBehaviors([
 											id="filterMenu"
 											tab-search-type="[[tabSearchType]]"
 											org-unit-type-ids="[[orgUnitTypeIds]]"
-											my-enrollments-entity="[[myEnrollmentsEntity]]"
+											my-enrollments-entity="[[_myEnrollmentsEntity]]"
 											filter-standard-semester-name="[[filterStandardSemesterName]]"
 											filter-standard-department-name="[[filterStandardDepartmentName]]">
 										</d2l-filter-menu>
@@ -462,8 +455,8 @@ class AllCourses extends mixinBehaviors([
 	*/
 
 	_onAllCoursesLowerThreshold() {
-		if (this.$['all-courses'].opened && this.lastEnrollmentsSearchResponse) {
-			var lastResponseEntity = this.lastEnrollmentsSearchResponse;
+		if (this.$['all-courses'].opened && this._lastEnrollmentsSearchResponse) {
+			var lastResponseEntity = this._lastEnrollmentsSearchResponse;
 			if (!lastResponseEntity._entity) {
 				if (lastResponseEntity && lastResponseEntity.hasLinkByRel('next')) {
 					const url = lastResponseEntity.getLinkByRel('next').href;
@@ -566,7 +559,7 @@ class AllCourses extends mixinBehaviors([
 	_onSearchResultsChanged(e) {
 		this._isSearched = !!e.detail.searchValue;
 		this._updateFilteredEnrollments(e.detail.searchResponse, false);
-		this.myEnrollmentsEntity = e.detail.searchResponse;
+		this._myEnrollmentsEntity = e.detail.searchResponse;
 		this.fire('recalculate-columns');
 
 		this._showContent = true;
@@ -707,7 +700,7 @@ class AllCourses extends mixinBehaviors([
 				this._sortParameter = sortParameter;
 			} else {
 				this.$.sortText.textContent = this.localize('sorting.sortDefault');
-				this._selectSortOption(this.defaultSortValue);
+				this._selectSortOption(this._defaultSortValue);
 			}
 		}
 	}
@@ -757,7 +750,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_resetSortDropdown() {
-		this._selectSortOption(this.defaultSortValue);
+		this._selectSortOption(this._defaultSortValue);
 
 		var content = this.$.sortDropdown.__getContentElement();
 		if (content) {
@@ -802,7 +795,7 @@ class AllCourses extends mixinBehaviors([
 			}
 		}
 
-		this.lastEnrollmentsSearchResponse = enrollments;
+		this._lastEnrollmentsSearchResponse = enrollments;
 		requestAnimationFrame(function() {
 			window.dispatchEvent(new Event('resize')); // doing this so ie11 and older edge browser will get ms-grid style assigned
 			this.$['all-courses-scroll-threshold'].clearTriggers();

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -27,6 +27,7 @@ import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/Enrollment
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 class AllCourses extends mixinBehaviors([
 	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior,
@@ -386,26 +387,37 @@ class AllCourses extends mixinBehaviors([
 			</d2l-simple-overlay>`;
 	}
 
-	attached() {
-		this.addEventListener('d2l-simple-overlay-opening', this._onSimpleOverlayOpening);
-		this.addEventListener('d2l-tab-panel-selected', this._onTabSelected);
-		this.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinned);
-		this.listen(this.$.sortDropdown, 'd2l-menu-item-change', '_onSortOrderChanged');
-		this.listen(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
-		this.listen(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-		this.listen(this.$.filterMenu, 'd2l-filter-menu-change', '_onFilterChanged');
-		this.listen(this.$['search-widget'], 'd2l-search-widget-results-changed', '_onSearchResultsChanged');
-		document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
+	ready() {
+		super.ready();
+		this._onSortOrderChanged = this._onSortOrderChanged.bind(this);
+		this._onFilterDropdownOpen = this._onFilterDropdownOpen.bind(this);
+		this._onFilterDropdownClose = this._onFilterDropdownClose.bind(this);
+		this._onFilterChanged = this._onFilterChanged.bind(this);
+		this._onSearchResultsChanged = this._onSearchResultsChanged.bind(this);
 	}
 
-	detached() {
-		this.unlisten(this.$.sortDropdown, 'd2l-menu-item-change', '_onSortOrderChanged');
-		this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-open', '_onFilterDropdownOpen');
-		this.unlisten(this.$.filterDropdownContent, 'd2l-dropdown-close', '_onFilterDropdownClose');
-		this.unlisten(this.$.filterMenu, 'd2l-filter-menu-change', '_onFilterChanged');
-		this.unlisten(this.$['search-widget'], 'd2l-search-widget-results-changed', '_onSearchResultsChanged');
+	connectedCallback() {
+		super.connectedCallback();
+		afterNextRender(this, () => {
+			this.addEventListener('d2l-simple-overlay-opening', this._onSimpleOverlayOpening);
+			this.addEventListener('d2l-tab-panel-selected', this._onTabSelected);
+			this.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinned);
+
+			this.shadowRoot.querySelector('#sortDropdown').addEventListener('d2l-menu-item-change', this._onSortOrderChanged);
+			this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-open', this._onFilterDropdownOpen);
+			this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-close', this._onFilterDropdownClose);
+			this.shadowRoot.querySelector('#filterMenu').addEventListener('d2l-filter-menu-change', this._onFilterChanged);
+			this.shadowRoot.querySelector('#search-widget').addEventListener('d2l-search-widget-results-changed', this._onSearchResultsChanged);
+
+			document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
+		});
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
 		document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
 	}
+
 	/*
 	* Public API methods
 	*/

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -109,6 +109,10 @@ class AllCourses extends mixinBehaviors([
 				type: Boolean,
 				value: false
 			},
+			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
+			token: String,
+			// Initial search action, should combine with _enrollmentsSearchAction
+			enrollmentsSearchAction: Object,
 
 			/*
 			* Private Polymer properties

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -394,6 +394,7 @@ class AllCourses extends mixinBehaviors([
 		this._onFilterDropdownClose = this._onFilterDropdownClose.bind(this);
 		this._onFilterChanged = this._onFilterChanged.bind(this);
 		this._onSearchResultsChanged = this._onSearchResultsChanged.bind(this);
+		this._onSetCourseImage = this._onSetCourseImage.bind(this);
 	}
 
 	connectedCallback() {
@@ -409,13 +410,13 @@ class AllCourses extends mixinBehaviors([
 			this.shadowRoot.querySelector('#filterMenu').addEventListener('d2l-filter-menu-change', this._onFilterChanged);
 			this.shadowRoot.querySelector('#search-widget').addEventListener('d2l-search-widget-results-changed', this._onSearchResultsChanged);
 
-			document.body.addEventListener('set-course-image', this._onSetCourseImage.bind(this));
+			document.body.addEventListener('set-course-image', this._onSetCourseImage);
 		});
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
-		document.body.removeEventListener('set-course-image', this._onSetCourseImage.bind(this));
+		document.body.removeEventListener('set-course-image', this._onSetCourseImage);
 	}
 
 	/*

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -66,7 +66,7 @@ class MyCoursesContainer extends mixinBehaviors([
 			_updateUserSettingsAction: Object,
 			_enrollmentCollectionEntity: Object,
 			_userSettingsEntity: Object,
-			_promotedSearch: Object,
+			_promotedSearchEntity: Object,
 			// Hides loading spinner and shows tabs when true
 			_showContent: {
 				type: Boolean,

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -131,7 +131,8 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>`;
 	}
 
-	attached() {
+	connectedCallback() {
+		super.connectedCallback();
 		afterNextRender(this, () => {
 			this.addEventListener('d2l-course-enrollment-change', this._onCourseEnrollmentChange);
 			this.addEventListener('d2l-tab-changed', this._tabSelectedChanged);

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -6,8 +6,6 @@ Component for when the `d2l.Tools.MyCoursesWidget.UpdatedSortLogic` config varia
 
 */
 
-import '@polymer/polymer/polymer-legacy.js';
-
 import 'd2l-tabs/d2l-tabs.js';
 import './card-grid/d2l-my-courses-content.js';
 import './d2l-utility-behavior.js';

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -13,7 +13,6 @@ import './card-grid/d2l-my-courses-content.js';
 import './d2l-utility-behavior.js';
 import './localize-behavior.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { EntityMixin } from 'siren-sdk/src/mixin/entity-mixin.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { UserSettingsEntity } from 'siren-sdk/src/userSettings/UserSettingsEntity';
 import { PromotedSearchEntity } from 'siren-sdk/src/promotedSearch/PromotedSearchEntity.js';
@@ -23,7 +22,7 @@ import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 class MyCoursesContainer extends mixinBehaviors([
 	D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
 	D2L.MyCourses.UtilityBehavior
-], EntityMixin(PolymerElement)) {
+], PolymerElement) {
 
 	static get is() { return 'd2l-my-courses-container'; }
 
@@ -47,9 +46,11 @@ class MyCoursesContainer extends mixinBehaviors([
 			promotedSearches: String,
 			// URL to fetch a user's settings (e.g. default tab to select)
 			userSettingsUrl: String,
+			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
+			token: String,
 			// URL to fetch widget settings
-			presentationUrl: String,
-			currentTabId: String,
+			_presentationUrl: String,
+			_currentTabId: String,
 			_enrollmentsSearchAction: Object,
 			_pinnedTabAction: Object,
 			_showGroupByTabs: {
@@ -96,7 +97,7 @@ class MyCoursesContainer extends mixinBehaviors([
 						<!-- item.name is an OrgUnitId, and querySelector does not work with components with ids that start with a number -->
 						<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
 							<d2l-my-courses-content
-								presentation-url="[[presentationUrl]]"
+								presentation-url="[[_presentationUrl]]"
 								token="[[token]]"
 								disable-entity-cache
 								advanced-search-url="[[advancedSearchUrl]]"
@@ -117,7 +118,7 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>
 			<template is="dom-if" if="[[!_showGroupByTabs]]">
 				<d2l-my-courses-content
-					presentation-url="[[presentationUrl]]"
+					presentation-url="[[_presentationUrl]]"
 					token="[[token]]"
 					disable-entity-cache
 					advanced-search-url="[[advancedSearchUrl]]"
@@ -162,7 +163,7 @@ class MyCoursesContainer extends mixinBehaviors([
 		}
 
 		if (userSettingsEntity.userSettingsHref()) {
-			this.presentationUrl = userSettingsEntity.userSettingsHref();
+			this._presentationUrl = userSettingsEntity.userSettingsHref();
 		}
 
 		this._updateUserSettingsAction = userSettingsEntity.userSettingsAction();
@@ -238,7 +239,7 @@ class MyCoursesContainer extends mixinBehaviors([
 		};
 	}
 	_tabSelectedChanged(e) {
-		this.currentTabId = `panel-${e.detail.tabId}`;
+		this._currentTabId = `panel-${e.detail.tabId}`;
 	}
 	courseImageUploadCompleted(success) {
 		return this._fetchContentComponent().courseImageUploadCompleted(success);
@@ -247,9 +248,9 @@ class MyCoursesContainer extends mixinBehaviors([
 		return this._fetchContentComponent().getLastOrgUnitId();
 	}
 	_fetchContentComponent() {
-		return this._showGroupByTabs === false || !this.currentTabId
+		return this._showGroupByTabs === false || !this._currentTabId
 			? this.$$('d2l-my-courses-content')
-			: this.$$(`#${this.currentTabId} d2l-my-courses-content`);
+			: this.$$(`#${this._currentTabId} d2l-my-courses-content`);
 	}
 	_getPinTabAndAllTabActions(lastEnrollmentsSearchName) {
 		var actions = [];

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -16,6 +16,7 @@ import { UserSettingsEntity } from 'siren-sdk/src/userSettings/UserSettingsEntit
 import { PromotedSearchEntity } from 'siren-sdk/src/promotedSearch/PromotedSearchEntity.js';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
+import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
 class MyCoursesContainer extends mixinBehaviors([
 	D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
@@ -130,13 +131,12 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>`;
 	}
 
-	constructor() {
-		super();
-		this.addEventListener('d2l-course-enrollment-change', this._onCourseEnrollmentChange);
-		this.addEventListener('d2l-tab-changed', this._tabSelectedChanged);
-	}
-
 	attached() {
+		afterNextRender(this, () => {
+			this.addEventListener('d2l-course-enrollment-change', this._onCourseEnrollmentChange);
+			this.addEventListener('d2l-tab-changed', this._tabSelectedChanged);
+		});
+
 		if (!this.enrollmentsUrl || !this.userSettingsUrl) {
 			return;
 		}

--- a/src/d2l-my-courses-content-behavior.js
+++ b/src/d2l-my-courses-content-behavior.js
@@ -660,7 +660,6 @@ D2L.MyCourses.MyCoursesContentBehaviorImpl = {
 		allCourses.enrollmentsSearchAction = this.enrollmentsSearchAction;
 		allCourses.tabSearchActions = this.tabSearchActions;
 		allCourses.tabSearchType = this.tabSearchType;
-		allCourses.locale = this.locale;
 		allCourses.advancedSearchUrl = this.advancedSearchUrl;
 		allCourses.filterStandardSemesterName = this.standardSemesterName;
 		allCourses.filterStandardDepartmentName = this.standardDepartmentName;

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -184,15 +184,15 @@ describe('d2l-my-courses', () => {
 		});
 	});
 
-	it('should have updated currentTabId property based on the event', () => {
-		component.currentTabId = null;
+	it('should have updated _currentTabId property based on the event', () => {
+		component._currentTabId = null;
 		var event = {
 			detail: {
 				tabId: 1254
 			}
 		};
 		component._tabSelectedChanged(event);
-		expect(component.currentTabId).to.equal(`panel-${event.detail.tabId}`);
+		expect(component._currentTabId).to.equal(`panel-${event.detail.tabId}`);
 	});
 
 	describe('Public API', () => {
@@ -222,7 +222,7 @@ describe('d2l-my-courses', () => {
 			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 			component._onPromotedSearchEntityChange();
 			component.updatedSortLogic = true;
-			component.currentTabId = '6607';
+			component._currentTabId = '6607';
 			flush(() => {
 				var stub = sandbox.stub(component.$$('d2l-my-courses-content'), 'getLastOrgUnitId');
 				component.getLastOrgUnitId();
@@ -235,7 +235,7 @@ describe('d2l-my-courses', () => {
 			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 			component._onPromotedSearchEntityChange();
 			component.updatedSortLogic = true;
-			component.currentTabId = '6607';
+			component._currentTabId = '6607';
 			flush(() => {
 				var stub = sandbox.stub(component.$$('d2l-my-courses-content'), 'courseImageUploadCompleted');
 				component.courseImageUploadCompleted();


### PR DESCRIPTION
Lots of random fixes here to try to bring consistency:
- Update the format of `d2l-my-courses` to class based
- Stop using Polymer's `listen`, delay hookup of event listeners with `AfterNextRender`
- `d2l-all-courses` wasn't really using the entity mixin as intended, switched to `entityFactory` to act more like the rest of the components
- Remove unused properties, mark private properties as private, add missing properties

`d2l-my-courses-content` will be tackled next PR, this is just going back over files I've started cleaning.