### PR TITLE
US114859 - Use d2l-colors from core

### DIFF
--- a/legacy/d2l-all-courses-styles-legacy.js
+++ b/legacy/d2l-all-courses-styles-legacy.js
@@ -1,3 +1,4 @@
+import '@brightspace-ui/core/components/colors/colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 const $_documentContainer = document.createElement('template');
 
@@ -80,7 +81,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-styles-legacy">
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
-				border-bottom: 1px solid var(--d2l-color-titanius);
+				border-bottom: 1px solid var(--d2l-color-mica);
 				width: 100%;
 				padding: 20px;
 			}

--- a/legacy/search-filter/d2l-filter-menu-legacy.js
+++ b/legacy/search-filter/d2l-filter-menu-legacy.js
@@ -10,7 +10,7 @@ Polymer-based web component for the filter menu.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { Actions } from 'd2l-hypermedia-constants';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import '@polymer/iron-pages/iron-pages.js';
@@ -37,7 +37,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-filter-menu-legacy">
 				box-sizing: border-box;
 				display: flex;
 				justify-content: space-between;
-				border-bottom: 1px solid var(--d2l-color-titanius);
+				border-bottom: 1px solid var(--d2l-color-mica);
 				width: 100%;
 				padding: 20px;
 			}

--- a/legacy/search-filter/d2l-search-listbox-legacy.js
+++ b/legacy/search-filter/d2l-search-listbox-legacy.js
@@ -10,6 +10,7 @@ Polymer-based web component for the search listbox.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
+import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import { IronMenuBehavior } from '@polymer/iron-menu-behavior/iron-menu-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -53,7 +54,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-listbox-legacy">
 				padding-bottom: 1rem;
 				margin: 0 !important;
 				cursor: default;
-				border-bottom-color: var(--d2l-color-titanius);
+				border-bottom-color: var(--d2l-color-mica);
 			}
 
 			::slotted([data-list-title]+div) {

--- a/legacy/tile-grid/d2l-course-tile-styles.js
+++ b/legacy/tile-grid/d2l-course-tile-styles.js
@@ -1,4 +1,4 @@
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 const $_documentContainer = document.createElement('template');
 
@@ -58,7 +58,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-course-tile-styles">
 				bottom: 0;
 				border-top-left-radius: 10px;
 				border-top-right-radius: 10px;
-				background: var(--d2l-color-pressicus);
+				background: var(--d2l-color-corundum);
 				overflow: hidden;
 				z-index: 0;
 			}

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
   "dependencies": {
     "@brightspace-ui/core": "^1",
     "d2l-alert": "BrightspaceUI/alert#semver:^4",
-    "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-course-image": "Brightspace/course-image#semver:^3",
     "d2l-dropdown": "BrightspaceUI/dropdown#semver:^7",
     "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#semver:^4",

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -8,6 +8,7 @@ import 'd2l-alert/d2l-alert.js';
 import 'd2l-dropdown/d2l-dropdown.js';
 import 'd2l-dropdown/d2l-dropdown-content.js';
 import 'd2l-dropdown/d2l-dropdown-menu.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { Actions, Classes } from 'd2l-hypermedia-constants';
 import 'd2l-icons/d2l-icons.js';
 import 'd2l-link/d2l-link.js';
@@ -243,7 +244,7 @@ class AllCourses extends mixinBehaviors([
 					display: flex;
 					align-items: center;
 					justify-content: space-between;
-					border-bottom: 1px solid var(--d2l-color-titanius);
+					border-bottom: 1px solid var(--d2l-color-mica);
 					width: 100%;
 					padding: 20px;
 				}

--- a/src/search-filter/d2l-filter-menu.js
+++ b/src/search-filter/d2l-filter-menu.js
@@ -10,7 +10,7 @@ Polymer-based web component for the filter menu.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
-import 'd2l-colors/d2l-colors.js';
+import '@brightspace-ui/core/components/colors/colors.js';
 import { Actions } from 'd2l-hypermedia-constants';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import '@polymer/iron-pages/iron-pages.js';
@@ -37,7 +37,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-filter-menu">
 				box-sizing: border-box;
 				display: flex;
 				justify-content: space-between;
-				border-bottom: 1px solid var(--d2l-color-titanius);
+				border-bottom: 1px solid var(--d2l-color-mica);
 				width: 100%;
 				padding: 20px;
 			}

--- a/src/search-filter/d2l-search-listbox.js
+++ b/src/search-filter/d2l-search-listbox.js
@@ -10,6 +10,7 @@ Polymer-based web component for the search listbox.
 */
 import '@polymer/polymer/polymer-legacy.js';
 
+import '@brightspace-ui/core/components/colors/colors.js';
 import '@polymer/iron-a11y-keys/iron-a11y-keys.js';
 import { IronMenuBehavior } from '@polymer/iron-menu-behavior/iron-menu-behavior.js';
 import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
@@ -53,7 +54,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-search-listbox">
 				padding-bottom: 1rem;
 				margin: 0 !important;
 				cursor: default;
-				border-bottom-color: var(--d2l-color-titanius);
+				border-bottom-color: var(--d2l-color-mica);
 			}
 
 			::slotted([data-list-title]+div) {


### PR DESCRIPTION
- Point to `d2l-colors` in `core`
- Add missing imports
- Removing references to deprecated colour names (https://github.com/BrightspaceUI/colors/blob/master/d2l-colors.js#L10-L32)