### PR TITLE
DE38482 - Fix widget settings refresh

### DIFF
--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -162,7 +162,8 @@ class MyCoursesContainer extends mixinBehaviors([
 
 		if (userSettingsEntity.userSettingsHref()) {
 			// We need to bust the cache so the entity store will refetch the presentation details after widget settings are updated
-			this._presentationUrl = `${userSettingsEntity.userSettingsHref()}?bustCache=${Math.random()}`;
+			const url = userSettingsEntity.userSettingsHref();
+			this._presentationUrl = `${url}${(url.indexOf('?') !== -1 ? '&' : '?')}bustCache=${Math.random()}`;
 		}
 
 		this._updateUserSettingsAction = userSettingsEntity.userSettingsAction();

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -161,7 +161,8 @@ class MyCoursesContainer extends mixinBehaviors([
 		}
 
 		if (userSettingsEntity.userSettingsHref()) {
-			this._presentationUrl = userSettingsEntity.userSettingsHref();
+			// We need to bust the cache so the entity store will refetch the presentation details after widget settings are updated
+			this._presentationUrl = `${userSettingsEntity.userSettingsHref()}?bustCache=${Math.random()}`;
 		}
 
 		this._updateUserSettingsAction = userSettingsEntity.userSettingsAction();


### PR DESCRIPTION
This fixes https://rally1.rallydev.com/#/15545167705ud/detail/defect/379581808432?fdp=true, which we fixed once before by adding `disable-entity-cache` to the `d2l-my-courses-content` component (https://github.com/Brightspace/d2l-my-courses-ui/pull/752/files).  Since we know longer use the entity behaviour, we can't use that.  Instead, we manually bust the cache if the presentation url is reassigned, which should only happen if the widget is reloaded after the settings have changed.  This is actually better than the previous solution, which refetches the presentation url for every tab.  This sends the same url into each tab.

We bust the cache like this in other places as well, until we have some type of HM change push functionality.