### PR TITLE
US114864 - Move more components to es6 classes

### DIFF
--- a/src/card-grid/d2l-all-courses-content.js
+++ b/src/card-grid/d2l-all-courses-content.js
@@ -3,18 +3,84 @@
 Polymer-based web component for the all courses content.
 */
 
-import '@polymer/polymer/polymer-legacy.js';
-
 import 'd2l-enrollments/components/d2l-enrollment-card/d2l-enrollment-card.js';
 import './d2l-card-grid-behavior.js';
 import './d2l-card-grid-styles.js';
 import '../localize-behavior.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-const $_documentContainer = document.createElement('template');
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-content">
-	<template strip-whitespace="">
+class AllCoursesContent extends mixinBehaviors([
+	D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
+	D2L.MyCourses.CardGridBehavior
+], PolymerElement) {
+
+	static get is() { return 'd2l-all-courses-content'; }
+
+	static get properties() {
+		return {
+			totalFilterCount: Number,
+			filterCounts: Object,
+			isSearched: Boolean,
+			filteredEnrollments: Array,
+			showOrganizationCode: {
+				type: Boolean,
+				value: false
+			},
+			showSemesterName: {
+				type: Boolean,
+				value: false
+			},
+			hideCourseStartDate: {
+				type: Boolean,
+				value: false
+			},
+			hideCourseEndDate: {
+				type: Boolean,
+				value: false
+			},
+			showDropboxUnreadFeedback: {
+				type: Boolean,
+				value: false
+			},
+			showUnattemptedQuizzes: {
+				type: Boolean,
+				value: false
+			},
+			showUngradedQuizAttempts: {
+				type: Boolean,
+				value: false
+			},
+			showUnreadDiscussionMessages: {
+				type: Boolean,
+				value: false
+			},
+			showUnreadDropboxSubmissions: {
+				type: Boolean,
+				value: false
+			},
+
+			_noCoursesInSearch: Boolean,
+			_noCoursesInSelection: Boolean,
+			_noCoursesInDepartment: Boolean,
+			_noCoursesInSemester: Boolean,
+			_noCoursesInRole: Boolean,
+			_itemCount: {
+				type: Number,
+				value: 0
+			}
+		};
+	}
+
+	static get observers() {
+		return [
+			'_enrollmentsChanged(filteredEnrollments.length)'
+		];
+	}
+
+	static get template() {
+		return html`
 		<style include="d2l-card-grid-styles">
 			:host {
 				display: block;
@@ -23,7 +89,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-content">
 				padding-bottom: 20px;
 			}
 		</style>
-
 		<span class="bottom-pad" hidden$="[[!_noCoursesInSearch]]">
 			[[localize('noCoursesInSearch')]]
 		</span>
@@ -56,81 +121,17 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-all-courses-content">
 					hide-course-end-date="[[hideCourseEndDate]]">
 				</d2l-enrollment-card>
 			</template>
-		</div>
-	</template>
+		</div>`;
+	}
 
-</dom-module>`;
-
-document.head.appendChild($_documentContainer.content);
-Polymer({
-	is: 'd2l-all-courses-content',
-	properties: {
-		totalFilterCount: Number,
-		filterCounts: Object,
-		isSearched: Boolean,
-		filteredEnrollments: Array,
-		showOrganizationCode: {
-			type: Boolean,
-			value: false
-		},
-		showSemesterName: {
-			type: Boolean,
-			value: false
-		},
-		hideCourseStartDate: {
-			type: Boolean,
-			value: false
-		},
-		hideCourseEndDate: {
-			type: Boolean,
-			value: false
-		},
-		showDropboxUnreadFeedback: {
-			type: Boolean,
-			value: false
-		},
-		showUnattemptedQuizzes: {
-			type: Boolean,
-			value: false
-		},
-		showUngradedQuizAttempts: {
-			type: Boolean,
-			value: false
-		},
-		showUnreadDiscussionMessages: {
-			type: Boolean,
-			value: false
-		},
-		showUnreadDropboxSubmissions: {
-			type: Boolean,
-			value: false
-		},
-
-		_noCoursesInSearch: Boolean,
-		_noCoursesInSelection: Boolean,
-		_noCoursesInDepartment: Boolean,
-		_noCoursesInSemester: Boolean,
-		_noCoursesInRole: Boolean,
-		_itemCount: {
-			type: Number,
-			value: 0
-		}
-	},
-	behaviors: [
-		D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
-		D2L.MyCourses.CardGridBehavior
-	],
-	observers: [
-		'_enrollmentsChanged(filteredEnrollments.length)'
-	],
-
-	attached: function() {
+	connectedCallback() {
+		super.connectedCallback();
 		afterNextRender(this, () => {
 			this._onResize();
 		});
-	},
+	}
 
-	_enrollmentsChanged: function(enrollmentLength) {
+	_enrollmentsChanged(enrollmentLength) {
 		this._noCoursesInSearch = false;
 		this._noCoursesInSelection = false;
 		this._noCoursesInDepartment = false;
@@ -156,4 +157,6 @@ Polymer({
 			}
 		}
 	}
-});
+}
+
+window.customElements.define(AllCoursesContent.is, AllCoursesContent);

--- a/src/search-filter/d2l-filter-menu.js
+++ b/src/search-filter/d2l-filter-menu.js
@@ -1,14 +1,8 @@
 /*
 `d2l-filter-menu`
 Polymer-based web component for the filter menu.
+*/
 
-*/
-/*
-  FIXME(polymer-modulizer): the above comments were extracted
-  from HTML and may be out of place here. Review them and
-  then delete this comment!
-*/
-import '@polymer/polymer/polymer-legacy.js';
 import '@polymer/iron-pages/iron-pages.js';
 
 import '@brightspace-ui/core/components/colors/colors.js';
@@ -17,12 +11,99 @@ import './d2l-filter-menu-tab.js';
 import './d2l-filter-menu-tab-roles.js';
 import '../d2l-utility-behavior.js';
 import '../localize-behavior.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { Actions } from 'd2l-hypermedia-constants';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-const $_documentContainer = document.createElement('template');
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
-$_documentContainer.innerHTML = `<dom-module id="d2l-filter-menu">
-	<template strip-whitespace="">
+class FilterMenu extends mixinBehaviors([
+	D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
+	D2L.MyCourses.UtilityBehavior
+], PolymerElement) {
+
+	static get is() { return 'd2l-filter-menu'; }
+
+	static get properties() {
+		return {
+			filterStandardDepartmentName: String,
+			filterStandardSemesterName: String,
+			filterRolesName: String,
+			myEnrollmentsEntity: {
+				type: Object,
+				observer: '_myEnrollmentsEntityChanged'
+			},
+			tabSearchType: {
+				type: String,
+				observer: '_tabSearchTypeChanged'
+			},
+			_departmentFilters: {
+				type: Array,
+				value: function() { return []; }
+			},
+			_semesterFilters: {
+				type: Array,
+				value: function() { return []; }
+			},
+			_roleFiltersCount: {
+				type: Number,
+				value: 0
+			},
+			_searchDepartmentsAction: Object,
+			_searchSemestersAction: Object,
+			_searchMyEnrollmentsAction: Object,
+			_semestersTabSelected: {
+				type: Boolean,
+				value: false
+			},
+			_departmentsTabSelected: {
+				type: Boolean,
+				value: false
+			},
+			_rolesTabSelected: {
+				type: Boolean,
+				value: false
+			},
+			_hasFilters: {
+				type: Boolean,
+				value: false,
+				computed: '_computeHasFilters(_departmentFilters.length, _semesterFilters.length, _roleFiltersCount)'
+			},
+			_semestersTabText: {
+				type: String,
+				computed: '_computeTabText(filterStandardSemesterName, _semesterFilters.length)'
+			},
+			_departmentsTabText: {
+				type: String,
+				computed: '_computeTabText(filterStandardDepartmentName, _departmentFilters.length)'
+			},
+			_rolesTabText: {
+				type: String,
+				computed: '_computeTabText(filterRolesName, _roleFiltersCount)'
+			},
+			_semestersSearchPlaceholderText: {
+				type: String,
+				computed: '_computeSearchPlaceholderText(filterStandardSemesterName)'
+			},
+			_departmentsSearchPlaceholderText: {
+				type: String,
+				computed: '_computeSearchPlaceholderText(filterStandardDepartmentName)'
+			},
+			_rolesTabHidden: {
+				type: Boolean,
+				value: false
+			},
+			_semestersTabHidden: {
+				type: Boolean,
+				value: false
+			},
+			_departmentsTabHidden: {
+				type: Boolean,
+				value: false
+			}
+		};
+	}
+
+	static get template() {
+		return html`
 		<style>
 			:host {
 				display: flex;
@@ -111,105 +192,18 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-filter-menu">
 
 			<d2l-filter-menu-tab-roles id="rolesTab" data-tab-name="roles" aria-labelledby="rolesTabButton" no-filters-text="[[localize('filtering.noRoles')]]" my-enrollments-entity="[[myEnrollmentsEntity]]" hidden$="[[_rolesTabHidden]]">
 			</d2l-filter-menu-tab-roles>
-		</iron-pages>
-	</template>
-	
-</dom-module>`;
+		</iron-pages>`;
+	}
 
-document.head.appendChild($_documentContainer.content);
-Polymer({
-	is: 'd2l-filter-menu',
-	properties: {
-		filterStandardDepartmentName: String,
-		filterStandardSemesterName: String,
-		filterRolesName: String,
-		myEnrollmentsEntity: {
-			type: Object,
-			observer: '_myEnrollmentsEntityChanged'
-		},
-		tabSearchType: {
-			type: String,
-			observer: '_tabSearchTypeChanged'
-		},
-		_departmentFilters: {
-			type: Array,
-			value: function() { return []; }
-		},
-		_semesterFilters: {
-			type: Array,
-			value: function() { return []; }
-		},
-		_roleFiltersCount: {
-			type: Number,
-			value: 0
-		},
-		_searchDepartmentsAction: Object,
-		_searchSemestersAction: Object,
-		_searchMyEnrollmentsAction: Object,
-		_semestersTabSelected: {
-			type: Boolean,
-			value: false
-		},
-		_departmentsTabSelected: {
-			type: Boolean,
-			value: false
-		},
-		_rolesTabSelected: {
-			type: Boolean,
-			value: false
-		},
-		_hasFilters: {
-			type: Boolean,
-			value: false,
-			computed: '_computeHasFilters(_departmentFilters.length, _semesterFilters.length, _roleFiltersCount)'
-		},
-		_semestersTabText: {
-			type: String,
-			computed: '_computeTabText(filterStandardSemesterName, _semesterFilters.length)'
-		},
-		_departmentsTabText: {
-			type: String,
-			computed: '_computeTabText(filterStandardDepartmentName, _departmentFilters.length)'
-		},
-		_rolesTabText: {
-			type: String,
-			computed: '_computeTabText(filterRolesName, _roleFiltersCount)'
-		},
-		_semestersSearchPlaceholderText: {
-			type: String,
-			computed: '_computeSearchPlaceholderText(filterStandardSemesterName)'
-		},
-		_departmentsSearchPlaceholderText: {
-			type: String,
-			computed: '_computeSearchPlaceholderText(filterStandardDepartmentName)'
-		},
-		_rolesTabHidden: {
-			type: Boolean,
-			value: false
-		},
-		_semestersTabHidden: {
-			type: Boolean,
-			value: false
-		},
-		_departmentsTabHidden: {
-			type: Boolean,
-			value: false
-		}
-	},
-	behaviors: [
-		D2L.PolymerBehaviors.MyCourses.LocalizeBehavior,
-		D2L.MyCourses.UtilityBehavior
-	],
-	listeners: {
-		'role-filters-changed': '_onRoleFiltersChanged',
-		'selected-filters-changed': '_onDepartmentOrSemesterFiltersChanged'
-	},
-	attached: function() {
+	connectedCallback() {
+		super.connectedCallback();
+		this.addEventListener('role-filters-changed', this._onRoleFiltersChanged);
+		this.addEventListener('selected-filters-changed', this._onDepartmentOrSemesterFiltersChanged);
+
 		this.filterRolesName = this.localize('filtering.roles');
-	},
+	}
 
-	open: function() {
-
+	open() {
 		const defaultTab = !this._semestersTabHidden
 			? 'semesters'
 			: !this._departmentsTabHidden ? 'departments' : 'roles';
@@ -220,8 +214,8 @@ Polymer({
 			this.$.semestersTab.load(),
 			this.$.departmentsTab.load()
 		]);
-	},
-	clearFilters: function() {
+	}
+	clearFilters() {
 		this.$.semestersTab.clear();
 		this.$.departmentsTab.clear();
 		this.$.rolesTab.clear();
@@ -262,9 +256,8 @@ Polymer({
 				roles: 0
 			}
 		});
-	},
-
-	_onRoleFiltersChanged: function(e) {
+	}
+	_onRoleFiltersChanged(e) {
 		this._roleFiltersCount = e.detail.filterCount;
 
 		this.fire('d2l-filter-menu-change', {
@@ -275,8 +268,8 @@ Polymer({
 				roles: this._roleFiltersCount
 			}
 		});
-	},
-	_onDepartmentOrSemesterFiltersChanged: function() {
+	}
+	_onDepartmentOrSemesterFiltersChanged() {
 		if (!this._semesterFilters || !this._departmentFilters || !this._searchMyEnrollmentsAction) {
 			return;
 		}
@@ -296,8 +289,8 @@ Polymer({
 				roles: this._roleFiltersCount
 			}
 		});
-	},
-	_myEnrollmentsEntityChanged: function(myEnrollmentsEntity) {
+	}
+	_myEnrollmentsEntityChanged(myEnrollmentsEntity) {
 		myEnrollmentsEntity = this.parseEntity(myEnrollmentsEntity);
 
 		if (myEnrollmentsEntity.hasActionByName(Actions.enrollments.searchMySemesters)) {
@@ -313,8 +306,8 @@ Polymer({
 		}
 
 		this._hideInvalidSearchTabs();
-	},
-	_selectTab: function(e) {
+	}
+	_selectTab(e) {
 		const tabName = e.target.dataset.tabName;
 
 		this.$$('iron-pages').select(tabName);
@@ -330,25 +323,27 @@ Polymer({
 		this.$.semestersTabButton.setAttribute('aria-pressed', this._semestersTabSelected);
 		this.$.departmentsTabButton.setAttribute('aria-pressed', this._departmentsTabSelected);
 		this.$.rolesTabButton.setAttribute('aria-pressed', this._rolesTabSelected);
-	},
-	_tabSearchTypeChanged: function() {
+	}
+	_tabSearchTypeChanged() {
 		this._hideInvalidSearchTabs();
-	},
-	_hideInvalidSearchTabs: function() {
+	}
+	_hideInvalidSearchTabs() {
 		// If My Courses is grouped by semesters/departments, don't show either of these tabs
 		const semesterOrDepartmentGrouping = this.tabSearchType === 'BySemester' || this.tabSearchType === 'ByDepartment';
 		this._semestersTabHidden = semesterOrDepartmentGrouping || !this._searchSemestersAction;
 		this._departmentsTabHidden = semesterOrDepartmentGrouping || !this._searchDepartmentsAction;
 		// If My Courses is grouped by role alias, don't show the Role tab
 		this._rolesTabHidden = this.tabSearchType === 'ByRoleAlias';
-	},
-	_computeHasFilters: function(departmentFiltersLength, semesterFiltersLength, roleFiltersCount) {
+	}
+	_computeHasFilters(departmentFiltersLength, semesterFiltersLength, roleFiltersCount) {
 		return departmentFiltersLength + semesterFiltersLength + roleFiltersCount > 0;
-	},
-	_computeTabText: function(filterLabel, num) {
+	}
+	_computeTabText(filterLabel, num) {
 		return this.localize('filtering.filterLabel', 'filterLabel', filterLabel, 'num', num);
-	},
-	_computeSearchPlaceholderText: function(name) {
+	}
+	_computeSearchPlaceholderText(name) {
 		return this.localize('filtering.searchBy', 'filter', name);
 	}
-});
+}
+
+window.customElements.define(FilterMenu.is, FilterMenu);

--- a/test/localize-behavior/consumer-element.js
+++ b/test/localize-behavior/consumer-element.js
@@ -1,8 +1,12 @@
 import '../../src/localize-behavior.js';
-import { Polymer } from '@polymer/polymer/lib/legacy/polymer-fn.js';
-Polymer({
-	is: 'consumer-element',
-	behaviors: [
-		D2L.PolymerBehaviors.MyCourses.LocalizeBehavior
-	]
-});
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+class ConsumerElement extends mixinBehaviors([
+	D2L.PolymerBehaviors.MyCourses.LocalizeBehavior
+], PolymerElement) {
+	static get is() { return 'consumer-element'; }
+}
+
+window.customElements.define(ConsumerElement.is, ConsumerElement);
+


### PR DESCRIPTION
I wasn't going to bother moving these components to es6 class syntax because they were going to be disappearing eventually (I want to refactor `d2l-all-courses-content` into a card grid component to be used by both `all-courses` and `my-courses-content`, and the filter will eventually be replaced with the shared component).  However, I want to refactor the localize behavior into a mixin, so I needed to update the components that were pulling in that old behavior.

The next PRs will move to a mixin, translation cleanup, and move to the new serge format to just use `js` files directly.