### PR TITLE
US115271 - Rename all-courses-content to d2l-my-courses-card-grid

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -17,8 +17,8 @@ import 'd2l-alert/d2l-alert.js';
 import 'd2l-organization-hm-behavior/d2l-organization-hm-behavior.js';
 import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import 'd2l-tabs/d2l-tabs.js';
-import './card-grid/d2l-all-courses-content.js';
 import './d2l-alert-behavior.js';
+import './d2l-my-courses-card-grid.js';
 import './d2l-utility-behavior.js';
 import './search-filter/d2l-filter-menu.js';
 import './search-filter/d2l-search-widget-custom.js';
@@ -347,7 +347,7 @@ class AllCourses extends mixinBehaviors([
 							<template items="[[tabSearchActions]]" is="dom-repeat">
 								<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
 									<div hidden$="[[!_showTabContent]]">
-										<d2l-all-courses-content
+										<d2l-my-courses-card-grid
 											token="[[token]]"
 											org-unit-type-ids="[[orgUnitTypeIds]]"
 											show-organization-code="[[showOrganizationCode]]"
@@ -362,7 +362,7 @@ class AllCourses extends mixinBehaviors([
 											<span id="infoMessage" hidden$="[[!_infoMessageText]]">
 												[[_infoMessageText]]
 											</span>
-										</d2l-all-courses-content>
+										</d2l-my-courses-card-grid>
 									</div>
 									<d2l-loading-spinner hidden$="[[_showTabContent]]" size="100">
 									</d2l-loading-spinner>
@@ -371,7 +371,7 @@ class AllCourses extends mixinBehaviors([
 						</d2l-tabs>
 					</template>
 					<template is="dom-if" if="[[!_showGroupByTabs]]">
-						<d2l-all-courses-content
+						<d2l-my-courses-card-grid
 							token="[[token]]"
 							org-unit-type-ids="[[orgUnitTypeIds]]"
 							show-organization-code="[[showOrganizationCode]]"
@@ -386,7 +386,7 @@ class AllCourses extends mixinBehaviors([
 							<span id="infoMessage" hidden$="[[!_infoMessageText]]">
 								[[_infoMessageText]]
 							</span>
-						</d2l-all-courses-content>
+						</d2l-my-courses-card-grid>
 					</template>
 					<d2l-loading-spinner id="lazyLoadSpinner" hidden$="[[!_hasMoreEnrollments]]" size="100">
 					</d2l-loading-spinner>
@@ -805,16 +805,16 @@ class AllCourses extends mixinBehaviors([
 			gridEntities = enrollments.enrollmentsHref();
 		}
 
-		const content = this._showGroupByTabs
-			? this.$$(`#${this._selectedTabId} d2l-all-courses-content`)
-			: this.$$('d2l-all-courses-content');
+		const cardGrid = this._showGroupByTabs
+			? this.$$(`#${this._selectedTabId} d2l-my-courses-card-grid`)
+			: this.$$('d2l-my-courses-card-grid');
 		if (append) {
-			content.filteredEnrollments = content.filteredEnrollments.concat(gridEntities);
+			cardGrid.filteredEnrollments = cardGrid.filteredEnrollments.concat(gridEntities);
 		} else {
-			content.filteredEnrollments = gridEntities;
+			cardGrid.filteredEnrollments = gridEntities;
 		}
 
-		this._updateInfoMessage(content.filteredEnrollments.length);
+		this._updateInfoMessage(cardGrid.filteredEnrollments.length);
 
 		this._lastEnrollmentsSearchResponse = enrollments;
 		requestAnimationFrame(() => {

--- a/src/d2l-my-courses-card-grid.js
+++ b/src/d2l-my-courses-card-grid.js
@@ -1,20 +1,20 @@
 /*
-`d2l-all-courses-content`
+`d2l-my-courses-card-grid`
 Polymer-based web component for the all courses content.
 */
 
 import 'd2l-enrollments/components/d2l-enrollment-card/d2l-enrollment-card.js';
-import './d2l-card-grid-behavior.js';
-import './d2l-card-grid-styles.js';
+import './card-grid/d2l-card-grid-behavior.js';
+import './card-grid/d2l-card-grid-styles.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
-class AllCoursesContent extends mixinBehaviors([
+class MyCoursesCardGrid extends mixinBehaviors([
 	D2L.MyCourses.CardGridBehavior
 ], PolymerElement) {
 
-	static get is() { return 'd2l-all-courses-content'; }
+	static get is() { return 'd2l-my-courses-card-grid'; }
 
 	static get properties() {
 		return {
@@ -94,4 +94,4 @@ class AllCoursesContent extends mixinBehaviors([
 
 }
 
-window.customElements.define(AllCoursesContent.is, AllCoursesContent);
+window.customElements.define(MyCoursesCardGrid.is, MyCoursesCardGrid);

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -886,6 +886,8 @@ class MyCoursesContent extends mixinBehaviors([
 
 		const searchAction = enrollmentCollectionEntity.getSearchEnrollmentsActions();
 
+		// When using Current sort (for users with lower enrollment numbers) and
+		// when not on a specific semester tab (DE30485), hide past courses in the widget view
 		if (searchAction
 			&& searchAction.hasFieldByName('sort')
 			&& searchAction.getFieldByName('sort').value.toLowerCase() === 'current'
@@ -895,8 +897,9 @@ class MyCoursesContent extends mixinBehaviors([
 				&& this.tabSearchType.toLowerCase() === 'bysemester'
 			)
 		) {
-			// When using Current sort, hide past courses in the widget view
+			// This is needed for hiding a closed course that was just unpinned
 			this._getTileGrid().setAttribute('hide-past-courses', '');
+			// This is needed for removing closed courses initially
 			this._hidePastCourses = true;
 		}
 

--- a/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.html
+++ b/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.html
@@ -7,29 +7,17 @@
 		<script src="../../../wct-browser-legacy/browser.js"></script>
 		<script src="https://s.brightspace.com/lib/d2lfetch/1.2.0/d2lfetch.js"></script>
 
-		<script type="module" src="../../src/card-grid/d2l-all-courses-content.js"></script>
+		<script type="module" src="../../src/d2l-my-courses-card-grid.js"></script>
 	</head>
 	<body>
-		<test-fixture id="d2l-all-courses-content-fixture">
+		<test-fixture id="d2l-my-courses-card-grid-fixture">
 			<template>
-				<d2l-all-courses-content
+				<d2l-my-courses-card-grid
 					filtered-enrollments='[]'>
-				</d2l-all-courses-content>
+				</d2l-my-courses-card-grid>
 			</template>
 		</test-fixture>
 
-		<test-fixture id="event-test-fixture">
-			<template>
-				<div id="foo">
-					<div>
-						<d2l-all-courses-content
-							filtered-enrollments='[]'>
-						</d2l-all-courses-content>
-					</div>
-				</div>
-			</template>
-		</test-fixture>
-
-		<script type="module" src="./d2l-all-courses-content.js"></script>
+		<script type="module" src="./d2l-my-courses-card-grid.js"></script>
 	</body>
 </html>

--- a/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
+++ b/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
@@ -1,10 +1,10 @@
 import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 
-describe('d2l-all-courses-content', function() {
+describe('d2l-my-courses-card-grid', function() {
 	let widget;
 
 	beforeEach(function(done) {
-		widget = fixture('d2l-all-courses-content-fixture');
+		widget = fixture('d2l-my-courses-card-grid-fixture');
 
 		setTimeout(function() {
 			done();

--- a/test/index.all.html
+++ b/test/index.all.html
@@ -10,11 +10,11 @@
 		<script>
 			WCT.loadSuites([
 				'./d2l-all-courses/d2l-all-courses.html',
-				'./d2l-all-courses-content/d2l-all-courses-content.html',
 				'./d2l-filter-menu/d2l-filter-menu.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab-roles.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab.html',
 				'./d2l-filter-menu/d2l-filter-list-item.html',
+				'./d2l-my-courses-card-grid/d2l-my-courses-card-grid.html',
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',

--- a/test/index.high-priority.html
+++ b/test/index.high-priority.html
@@ -10,11 +10,11 @@
 		<script>
 			WCT.loadSuites([
 				'./d2l-all-courses/d2l-all-courses.html',
-				'./d2l-all-courses-content/d2l-all-courses-content.html',
 				'./d2l-filter-menu/d2l-filter-menu.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab-roles.html',
 				'./d2l-filter-menu/d2l-filter-menu-tab.html',
 				'./d2l-filter-menu/d2l-filter-list-item.html',
+				'./d2l-my-courses-card-grid/d2l-my-courses-card-grid.html',
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',


### PR DESCRIPTION
This is just a rename and move.  Easier to review on its own, and next PRs will be pulling things back into the component, getting content to use it as well, etc.