### PR TITLE
DE38903 - Fix closed course hiding behavior

### DIFF
--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -440,9 +440,8 @@ class MyCoursesContent extends mixinBehaviors([
 			});
 
 			enrollmentEntity.onOrganizationChange((org) => {
-				const enrollmentDate = org.processedDate(this._hideCourseStartDate, this._hideCourseEndDate);
 				const enrollmentCardStatusDetails = {
-					status: {closed: enrollmentDate && enrollmentDate.afterEndDate},
+					status: {closed: org && org.isAfterEndDate()},
 					enrollmentUrl: url
 				};
 				this._setEnrollmentCardStatus(enrollmentCardStatusDetails);

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -848,7 +848,7 @@ describe('d2l-my-courses-content', () => {
 			const onUserActivityUsageChangeStub = sinon.stub();
 			const onEnrollmentEntityChangeStub = sinon.stub();
 			const onOrganizationChangeStub = sinon.stub();
-			const processedDateStub = sinon.stub();
+			const isAfterEndDateStub = sinon.stub();
 			_enrollmentCollectionEntity = {
 				_entity: oneEnrollmentSearchEntity,
 				getEnrollmentEntities: function() { return [
@@ -875,15 +875,13 @@ describe('d2l-my-courses-content', () => {
 
 			const organizationEntity = {
 				_entity: {},
-				processedDate: processedDateStub
+				isAfterEndDate: isAfterEndDateStub
 			};
 
 			onEnrollmentEntityChangeStub.callsArgWith(1, _enrollmentEntity);
 			onUserActivityUsageChangeStub.callsArgWith(0, userActivityUsageEntity);
 			onOrganizationChangeStub.callsArgWith(0, organizationEntity);
-			processedDateStub.returns({
-				afterEndDate: false
-			});
+			isAfterEndDateStub.returns(false);
 
 			component = fixture('d2l-my-courses-content-fixture');
 			component.token = 'fake';


### PR DESCRIPTION
Related to BrightspaceHypermediaComponents/siren-sdk#184, I'm migrating usages of the `processedDate` function from `OrganizationEntity` to no longer access `beforeStartDate` and `afterEndDate` directly, and to instead use the new functions.

In this case, when the widget settings have "Show End Date" OFF (ie `_hideCourseEndDate = true`), it meant we weren't properly hiding closed courses on the main widget view for users with less than 50 enrollments.  We also weren't displaying the closed badge in the main courses view or the all courses view, which is fixed by https://github.com/BrightspaceHypermediaComponents/enrollments/pull/215.