### PR TITLE
Khuff/us113521

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -489,7 +489,8 @@ class AllCourses extends mixinBehaviors([
 				autoPinCourses: false,
 				orgUnitTypeId: this.orgUnitTypeIds,
 				embedDepth: 0,
-				sort: 'Current'
+				sort: this._sortMap[0].action,
+				promotePins: this._sortMap[0].promotePins
 			})
 		);
 	}
@@ -583,9 +584,6 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_onSortOrderChanged(e) {
-		let sortParameter, langterm;
-		let promotePins = false;
-
 		var sortData = this._mapSortOption(e.detail.value, 'name');
 
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
@@ -620,7 +618,10 @@ class AllCourses extends mixinBehaviors([
 				this._enrollmentsSearchAction.getFieldByName('search').value = '';
 			}
 			if (this._enrollmentsSearchAction.hasFieldByName('sort')) {
-				this._enrollmentsSearchAction.getFieldByName('sort').value = 'Current';
+				this._enrollmentsSearchAction.getFieldByName('sort').value = this._sortMap[0].action;
+			}
+			if (this._enrollmentsSearchAction.hasFieldByName('promotePins')) {
+				this._enrollmentsSearchAction.getFieldByName('promotePins').value = this._sortMap[0].promotePins;
 			}
 		}
 
@@ -654,7 +655,10 @@ class AllCourses extends mixinBehaviors([
 			this._enrollmentsSearchAction.getFieldByName('search').value : '';
 
 		const sort = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('sort') ?
-			this._enrollmentsSearchAction.getFieldByName('sort').value : 'Current';
+			this._enrollmentsSearchAction.getFieldByName('sort').value : this._sortMap[0].action;
+
+		const promotePins = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('promotePins') ?
+			this._enrollmentsSearchAction.getFieldByName('promotePins').value : this._sortMap[0].promotePins;
 
 		this._showTabContent = false;
 		const params = {
@@ -662,7 +666,8 @@ class AllCourses extends mixinBehaviors([
 			orgUnitTypeId: this.orgUnitTypeIds,
 			autoPinCourses: false,
 			sort: sort,
-			embedDepth: 0
+			embedDepth: 0,
+			promotePins: promotePins
 		};
 		if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
 			params.parentOrganizations =  this._enrollmentsSearchAction.getFieldByName('parentOrganizations').value;

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -211,7 +211,7 @@ class AllCourses extends mixinBehaviors([
 							promotePins: false
 						}
 					];
-				} 
+				}
 			}
 		};
 	}
@@ -584,7 +584,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_onSortOrderChanged(e) {
-		var sortData = this._mapSortOption(e.detail.value, 'name');
+		const sortData = this._mapSortOption(e.detail.value, 'name');
 
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
 			this.createActionUrl(this._enrollmentsSearchAction, {
@@ -728,7 +728,7 @@ class AllCourses extends mixinBehaviors([
 				return;
 			}
 
-			var sortData = this._mapSortOption(sortParameter, 'action');
+			const sortData = this._mapSortOption(sortParameter, 'action');
 
 			this.$.sortText.textContent = this.localize(sortData.langterm || '');
 			this._selectSortOption(sortData.name);
@@ -778,10 +778,10 @@ class AllCourses extends mixinBehaviors([
 	_computeShowGroupByTabs(groups) {
 		return groups.length > 2 || (groups.length > 0 && !this._enrollmentsSearchAction);
 	}
-	
+
 	_mapSortOption(identifier, identifierName) {
-		var i = 0;
-		for (i = 0; i < this._sortMap.length; i+= 1) {
+		let i = 0;
+		for (i = 0; i < this._sortMap.length; i += 1) {
 			if (this._sortMap[i][identifierName] === identifier) {
 				return this._sortMap[i];
 			}

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -82,11 +82,6 @@ class AllCourses extends mixinBehaviors([
 			},
 			// URL that directs to the advanced search page
 			advancedSearchUrl: String,
-			// Default option in Sort menu
-			_defaultSortValue: {
-				type: String,
-				value: 'Default'
-			},
 			// Standard Department OU Type name to be displayed in the filter dropdown
 			filterStandardDepartmentName: String,
 			// Standard Semester OU Type name to be displayed in the filter dropdown
@@ -484,13 +479,16 @@ class AllCourses extends mixinBehaviors([
 		if (!this.enrollmentsSearchAction) {
 			return;
 		}
+
+		const sortData = this._mapSortOption('Default', 'name');
+
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
 			this.createActionUrl(this.enrollmentsSearchAction, {
 				autoPinCourses: false,
 				orgUnitTypeId: this.orgUnitTypeIds,
 				embedDepth: 0,
-				sort: this._sortMap[0].action,
-				promotePins: this._sortMap[0].promotePins
+				sort: sortData.action,
+				promotePins: sortData.promotePins
 			})
 		);
 	}
@@ -655,19 +653,18 @@ class AllCourses extends mixinBehaviors([
 			this._enrollmentsSearchAction.getFieldByName('search').value : '';
 
 		const sort = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('sort') ?
-			this._enrollmentsSearchAction.getFieldByName('sort').value : this._sortMap[0].action;
+			this._enrollmentsSearchAction.getFieldByName('sort').value : '';
 
-		const promotePins = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('promotePins') ?
-			this._enrollmentsSearchAction.getFieldByName('promotePins').value : this._sortMap[0].promotePins;
+		const sortData = this._mapSortOption(sort, 'action');
 
 		this._showTabContent = false;
 		const params = {
 			search: search,
 			orgUnitTypeId: this.orgUnitTypeIds,
 			autoPinCourses: false,
-			sort: sort,
+			sort: sortData.action,
 			embedDepth: 0,
-			promotePins: promotePins
+			promotePins: sortData.promotePins
 		};
 		if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
 			params.parentOrganizations =  this._enrollmentsSearchAction.getFieldByName('parentOrganizations').value;
@@ -791,7 +788,8 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_resetSortDropdown() {
-		this._selectSortOption(this._defaultSortValue);
+		const sortData = this._mapSortOption('Default', 'name');
+		this._selectSortOption(sortData.name);
 
 		const content = this.$.sortDropdown.__getContentElement();
 		if (content) {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -480,7 +480,7 @@ class AllCourses extends mixinBehaviors([
 			return;
 		}
 
-		const sortData = this._mapSortOption('Default', 'name');
+		const sortData = this._mapSortOption(this._sortMap[0].name, 'name');
 
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
 			this.createActionUrl(this.enrollmentsSearchAction, {
@@ -653,7 +653,7 @@ class AllCourses extends mixinBehaviors([
 			this._enrollmentsSearchAction.getFieldByName('search').value : '';
 
 		const sort = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('sort') ?
-			this._enrollmentsSearchAction.getFieldByName('sort').value : '';
+			this._enrollmentsSearchAction.getFieldByName('sort').value : this._sortMap[0].action;
 
 		const sortData = this._mapSortOption(sort, 'action');
 
@@ -788,7 +788,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_resetSortDropdown() {
-		const sortData = this._mapSortOption('Default', 'name');
+		const sortData = this._mapSortOption(this._sortMap[0].name, 'name');
 		this._selectSortOption(sortData.name);
 
 		const content = this.$.sortDropdown.__getContentElement();

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -585,7 +585,6 @@ class AllCourses extends mixinBehaviors([
 			})
 		);
 
-		this._sortParameter = sortParameter;
 		this.$.sortText.textContent = this.localize(langterm || '');
 		this.$.sortDropdown.toggleOpen();
 	}
@@ -612,7 +611,6 @@ class AllCourses extends mixinBehaviors([
 			if (this._enrollmentsSearchAction.hasFieldByName('sort')) {
 				this._enrollmentsSearchAction.getFieldByName('sort').value = 'Current';
 			}
-			this._sortParameter = 'Current';
 		}
 
 		this._removeAlert('setCourseImageFailure');
@@ -636,18 +634,23 @@ class AllCourses extends mixinBehaviors([
 				break;
 			}
 		}
-		const search = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('search') ?
-			this._enrollmentsSearchAction.getFieldByName('search').value : '';
+
 		if (!tabAction) {
 			return;
 		}
+
+		const search = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('search') ?
+			this._enrollmentsSearchAction.getFieldByName('search').value : '';
+
+		const sort = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('sort') ?
+			this._enrollmentsSearchAction.getFieldByName('sort').value : 'Current';
 
 		this._showTabContent = false;
 		const params = {
 			search: search,
 			orgUnitTypeId: this.orgUnitTypeIds,
 			autoPinCourses: false,
-			sort: this._sortParameter || 'Current',
+			sort: sort,
 			embedDepth: 0
 		};
 		if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
@@ -740,7 +743,6 @@ class AllCourses extends mixinBehaviors([
 			if (sort) {
 				this.$.sortText.textContent = this.localize(sort.langterm || '');
 				this._selectSortOption(sort.name);
-				this._sortParameter = sortParameter;
 			} else {
 				this.$.sortText.textContent = this.localize('sorting.sortDefault');
 				this._selectSortOption(this._defaultSortValue);

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -480,15 +480,13 @@ class AllCourses extends mixinBehaviors([
 			return;
 		}
 
-		const sortData = this._mapSortOption(this._sortMap[0].name, 'name');
-
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
 			this.createActionUrl(this.enrollmentsSearchAction, {
 				autoPinCourses: false,
 				orgUnitTypeId: this.orgUnitTypeIds,
 				embedDepth: 0,
-				sort: sortData.action,
-				promotePins: sortData.promotePins
+				sort: this._sortMap[0].action,
+				promotePins: this._sortMap[0].promotePins
 			})
 		);
 	}
@@ -788,8 +786,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_resetSortDropdown() {
-		const sortData = this._mapSortOption(this._sortMap[0].name, 'name');
-		this._selectSortOption(sortData.name);
+		this._selectSortOption(this._sortMap[0].name);
 
 		const content = this.$.sortDropdown.__getContentElement();
 		if (content) {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -365,13 +365,11 @@ describe('d2l-all-courses', function() {
 		});
 
 		it('should set the _searchUrl based on the selected tab\'s action', function() {
-			widget._sortParameter = 'SortOrder';
 
 			widget.dispatchEvent(new CustomEvent(
 				'd2l-tab-panel-selected', { bubbles: true, composed: true }
 			));
-
-			expect(widget._searchUrl.indexOf('/example/foo?autoPinCourses=false&embedDepth=0&sort=SortOrder&search=&bustCache=') !== -1).to.be.true;
+			expect(widget._searchUrl.indexOf('/example/foo?autoPinCourses=false&embedDepth=0&sort=Current&search=&bustCache=') !== -1).to.be.true;
 		});
 	});
 


### PR DESCRIPTION
This pull request does a few things:
1) Remove tracking of the sort from a member variable (ie. remove _sortParameter). Instead, let the action be the source of truth in all cases.
2) Refactor the sort code such that there is only one method for mapping all of the sort properties (langterm, sort action, promotepins).

3) (This is the functional change): set promotePins == true for the default sort, so that it is consistent with the widget itself.