### PR TITLE
US116105 - Prep moving image selector to container component

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -281,7 +281,8 @@ class AllCourses extends mixinBehaviors([
 				id="all-courses"
 				title-name="[[localize('allCourses')]]"
 				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
-				with-backdrop>
+				with-backdrop
+				restore-focus-on-close>
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -449,7 +449,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	focusCardDropdown(organization) {
-		this._getCardGrid().focusCardDropdown(organization);
+		return this._getCardGrid().focusCardDropdown(organization);
 	}
 
 	_getCardGrid() {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -280,7 +280,8 @@ class AllCourses extends mixinBehaviors([
 			<d2l-simple-overlay
 				id="all-courses"
 				title-name="[[localize('allCourses')]]"
-				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]">
+				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
+				with-backdrop>
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -280,9 +280,7 @@ class AllCourses extends mixinBehaviors([
 			<d2l-simple-overlay
 				id="all-courses"
 				title-name="[[localize('allCourses')]]"
-				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
-				with-backdrop=""
-				restore-focus-on-close="">
+				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]">
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -244,8 +244,7 @@ class MyCoursesContent extends mixinBehaviors([
 
 		<d2l-simple-overlay id="basic-image-selector-overlay"
 			title-name="[[localize('changeImage')]]"
-			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
-			with-backdrop="">
+			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]">
 			<iron-scroll-threshold
 				id="image-selector-threshold"
 				on-lower-threshold="_onChangeImageLowerThreshold">

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -333,6 +333,34 @@ class MyCoursesContent extends mixinBehaviors([
 		return this.getOrgUnitIdFromHref(this.getEntityIdentifier(this._setImageOrg));
 	}
 
+	/*
+	* Changing Course Image Functions
+	*/
+	_onChangeImageLowerThreshold() {
+		this.shadowRoot.querySelector('d2l-basic-image-selector').loadMore(this.$['image-selector-threshold']);
+	}
+	_onClearImageScrollThreshold() {
+		this.$['image-selector-threshold'].clearTriggers();
+	}
+	_onOpenChangeImageView(e) {
+		if (e.detail.organization) {
+			this._setImageOrg = this.parseEntity(e.detail.organization);
+		}
+
+		this.$['basic-image-selector-overlay'].open();
+	}
+	_onSetCourseImage(e) {
+		this.$['basic-image-selector-overlay'].close();
+		this._removeAlert('setCourseImageFailure');
+		if (e && e.detail) {
+			if (e.detail.status === 'failure') {
+				setTimeout(() => {
+					this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
+				}, 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
+			}
+		}
+	}
+
 	_getCardGrid() {
 		return this.shadowRoot.querySelector('d2l-my-courses-card-grid');
 	}
@@ -428,12 +456,6 @@ class MyCoursesContent extends mixinBehaviors([
 			message = 'newEnrollmentMultiple';
 		}
 		this._addAlert('call-to-action', message, this.localize(message));
-	}
-	_onChangeImageLowerThreshold() {
-		this.shadowRoot.querySelector('d2l-basic-image-selector').loadMore(this.$['image-selector-threshold']);
-	}
-	_onClearImageScrollThreshold() {
-		this.$['image-selector-threshold'].clearTriggers();
 	}
 	_onCourseImageLoaded() {
 		this._courseImagesLoadedEventCount++;
@@ -614,24 +636,6 @@ class MyCoursesContent extends mixinBehaviors([
 			afterNextRender(this, () => {
 				this.focusCardDropdown(this._setImageOrg);
 			});
-		}
-	}
-	_onOpenChangeImageView(e) {
-		if (e.detail.organization) {
-			this._setImageOrg = this.parseEntity(e.detail.organization);
-		}
-
-		this.$['basic-image-selector-overlay'].open();
-	}
-	_onSetCourseImage(e) {
-		this.$['basic-image-selector-overlay'].close();
-		this._removeAlert('setCourseImageFailure');
-		if (e && e.detail) {
-			if (e.detail.status === 'failure') {
-				setTimeout(() => {
-					this._addAlert('warning', 'setCourseImageFailure', this.localize('error.settingImage'));
-				}, 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
-			}
 		}
 	}
 

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -301,6 +301,22 @@ class MyCoursesContent extends mixinBehaviors([
 	/*
 	* Public API functions
 	*/
+
+	// After the image selector is closed, this is called to set focus back to the correct card
+	focusCardDropdown(imageOrg) {
+		const allCourses = this.shadowRoot.querySelector('d2l-all-courses');
+
+		if (allCourses && this._isAllCoursesOverlayOpen) {
+			if (allCourses.focusCardDropdown(imageOrg)) {
+				return;
+			}
+		} else {
+			if (this._getCardGrid().focusCardDropdown(imageOrg)) {
+				return;
+			}
+		}
+		this.$.viewAllCourses.focus();
+	}
 	// This is called by the LE, but only when it's a user-uploaded image
 	// If it's a catalog image this is handled by the enrollment card
 	courseImageUploadCompleted(success) {
@@ -596,18 +612,7 @@ class MyCoursesContent extends mixinBehaviors([
 
 		} else if (e.composedPath()[0].id === 'basic-image-selector-overlay') {
 			afterNextRender(this, () => {
-				const allCourses = this.shadowRoot.querySelector('d2l-all-courses');
-
-				if (allCourses && this._isAllCoursesOverlayOpen) {
-					if (allCourses.focusCardDropdown(this._setImageOrg)) {
-						return;
-					}
-				} else {
-					if (this._getCardGrid().focusCardDropdown(this._setImageOrg)) {
-						return;
-					}
-				}
-				this.$.viewAllCourses.focus();
+				this.focusCardDropdown(this._setImageOrg);
 			});
 		}
 	}

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -314,7 +314,7 @@ class MyCoursesContent extends mixinBehaviors([
 		if (!this._setImageOrg.links) {
 			return;
 		}
-		return this._getOrgUnitIdFromHref(this.getEntityIdentifier(this._setImageOrg));
+		return this.getOrgUnitIdFromHref(this.getEntityIdentifier(this._setImageOrg));
 	}
 
 	_getCardGrid() {
@@ -349,7 +349,7 @@ class MyCoursesContent extends mixinBehaviors([
 			return;
 		}
 		enrollmentCollectionEntity.onEnrollmentEntityChange(url, (enrollmentEntity) => {
-			const orgUnitId = this._getOrgUnitIdFromHref(enrollmentEntity.organizationHref());
+			const orgUnitId = this.getOrgUnitIdFromHref(enrollmentEntity.organizationHref());
 			this._orgUnitIdMap[orgUnitId] = url;
 		});
 	}
@@ -489,7 +489,7 @@ class MyCoursesContent extends mixinBehaviors([
 				updateEntity(enrollmentHref, this.token);
 			}
 		} else {
-			orgUnitId = this._getOrgUnitIdFromHref(e.detail.enrollment.organizationHref());
+			orgUnitId = this.getOrgUnitIdFromHref(e.detail.enrollment.organizationHref());
 		}
 		// Only want to move pinned/unpinned enrollment if it exists in the panel
 		const changedEnrollmentId = orgUnitId && this._orgUnitIdMap[orgUnitId];
@@ -708,14 +708,6 @@ class MyCoursesContent extends mixinBehaviors([
 		);
 
 		this._enrollmentsRootResponse(enrollmentsEntity);
-	}
-	_getOrgUnitIdFromHref(organizationHref) {
-		const match = /[0-9]+$/.exec(organizationHref);
-
-		if (!match) {
-			return;
-		}
-		return match[0];
 	}
 	_getViewAllCoursesText(hasMoreEnrollments, enrollmentsLength) {
 		const viewAllCourses = this.localize('viewAllCourses');

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -598,9 +598,9 @@ class MyCoursesContent extends mixinBehaviors([
 		});
 	}
 	_onSimpleOverlayClosed(e) {
-		this._removeAlert('setCourseImageFailure');
 
 		if (e.composedPath()[0].id === 'all-courses') {
+			this._removeAlert('setCourseImageFailure');
 			this._isAllCoursesOverlayOpen = false;
 
 			if (this._isRefetchNeeded) {

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -244,7 +244,8 @@ class MyCoursesContent extends mixinBehaviors([
 
 		<d2l-simple-overlay id="basic-image-selector-overlay"
 			title-name="[[localize('changeImage')]]"
-			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]">
+			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
+			with-backdrop>
 			<iron-scroll-threshold
 				id="image-selector-threshold"
 				on-lower-threshold="_onChangeImageLowerThreshold">

--- a/src/d2l-utility-behavior.js
+++ b/src/d2l-utility-behavior.js
@@ -71,6 +71,7 @@ D2L.MyCourses.UtilityBehavior = {
 	parseEntity: function(entity) {
 		return SirenParse(entity);
 	},
+	// This is only used by the filter menu and can hopefully be removed after that is moved to the shared component
 	fetchSirenEntity: function(url, clearCache) {
 		if (!url) {
 			return;
@@ -89,12 +90,6 @@ D2L.MyCourses.UtilityBehavior = {
 				headers: headers
 			}))
 			.then(this.responseToSirenEntity.bind(this));
-	},
-	sirenEntityStoreFetch: function(url, token, clearCache) {
-		if (!url) {
-			return;
-		}
-		return window.D2L.Siren.EntityStore.fetch(url, token, clearCache);
 	},
 	performanceMark: function(name) {
 		if (window.performance && window.performance.mark) {
@@ -116,20 +111,7 @@ D2L.MyCourses.UtilityBehavior = {
 			}
 		}
 	},
-	submitForm: function(url, formParameters) {
-		const formData = new FormData();
-		for (const formKey in formParameters) {
-			if (formParameters.hasOwnProperty(formKey)) {
-				formData.append(formKey, formParameters[formKey]);
-			}
-		}
-
-		return window.d2lfetch
-			.fetch(new Request(url, {
-				method: 'PUT',
-				body: formData
-			}));
-	},
+	// This is only used by fetchSirenEntity above and can be removed once that function is removed
 	responseToSirenEntity: function(response) {
 		if (response.ok) {
 			return response

--- a/src/d2l-utility-behavior.js
+++ b/src/d2l-utility-behavior.js
@@ -60,6 +60,14 @@ D2L.MyCourses.UtilityBehavior = {
 		const selfLink = entity.getLinkByRel('self');
 		return selfLink.href;
 	},
+	getOrgUnitIdFromHref(organizationHref) {
+		const match = /[0-9]+$/.exec(organizationHref);
+
+		if (!match) {
+			return;
+		}
+		return match[0];
+	},
 	parseEntity: function(entity) {
 		return SirenParse(entity);
 	},

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -428,8 +428,8 @@ describe('d2l-my-courses-content', () => {
 			});
 
 			it('should return correct org unit id from various href', () => {
-				expect(component._getOrgUnitIdFromHref('/organizations/671')).to.equal('671');
-				expect(component._getOrgUnitIdFromHref('/some/other/route/8798734534')).to.equal('8798734534');
+				expect(component.getOrgUnitIdFromHref('/organizations/671')).to.equal('671');
+				expect(component.getOrgUnitIdFromHref('/some/other/route/8798734534')).to.equal('8798734534');
 			});
 
 		});
@@ -483,8 +483,11 @@ describe('d2l-my-courses-content', () => {
 			it('should remove any existing set-course-image-failure alerts', done => {
 				const spy = sandbox.spy(component, '_removeAlert');
 
-				const event = new CustomEvent('d2l-simple-overlay-closed');
-				component.dispatchEvent(event);
+				const event = {
+					type: 'd2l-simple-overlay-closed',
+					composedPath: function() { return [{ id: 'all-courses' }]; }
+				};
+				component._onSimpleOverlayClosed(event);
 
 				setTimeout(() => {
 					expect(spy).to.have.been.calledWith('setCourseImageFailure');


### PR DESCRIPTION
This PR includes a collection of changes to make the next PR a little cleaner.  The next PR will be moving the image selector out from the `d2l-my-courses-content` component to the `d2l-my-courses-container` component.  This is to make `d2l-my-courses-content` a bit simpler, stop having one image selector per tab which isn't needed, and facilitate eventually moving to having one all-courses overlay as well (instead of one per tab).