### PR TITLE
DE38876

### DIFF
--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -46,7 +46,10 @@ class MyCoursesContainer extends mixinBehaviors([
 			// URL to fetch a user's settings (e.g. default tab to select)
 			userSettingsUrl: String,
 			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
-			token: String,
+			token: {
+				type: String,
+				observer: '_tokenChanged'
+			},
 			// URL to fetch widget settings
 			_presentationUrl: String,
 			_currentTabId: String,
@@ -135,13 +138,6 @@ class MyCoursesContainer extends mixinBehaviors([
 			this.addEventListener('d2l-course-enrollment-change', this._onCourseEnrollmentChange);
 			this.addEventListener('d2l-tab-changed', this._tabSelectedChanged);
 		});
-
-		if (!this.enrollmentsUrl || !this.userSettingsUrl) {
-			return;
-		}
-
-		this._setEnrollmentCollectionEntity(this.enrollmentsUrl);
-		this._setUserSettingsEntity(this.userSettingsUrl);
 	}
 
 	_onEnrollmentAndUserSettingsEntityChange() {
@@ -241,6 +237,12 @@ class MyCoursesContainer extends mixinBehaviors([
 	}
 	_tabSelectedChanged(e) {
 		this._currentTabId = `panel-${e.detail.tabId}`;
+	}
+	_tokenChanged(token) {
+		if ( token && this.enrollmentsUrl && this.userSettingsUrl ) {
+			this._setEnrollmentCollectionEntity(this.enrollmentsUrl);
+			this._setUserSettingsEntity(this.userSettingsUrl);
+		}
 	}
 	courseImageUploadCompleted(success) {
 		return this._fetchContentComponent().courseImageUploadCompleted(success);

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -132,6 +132,12 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>`;
 	}
 
+	static get observers() {
+		return [
+			'_tokenChanged(token, enrollmentsUrl, userSettingsUrl)'
+		];
+	}
+
 	connectedCallback() {
 		super.connectedCallback();
 		afterNextRender(this, () => {
@@ -238,10 +244,10 @@ class MyCoursesContainer extends mixinBehaviors([
 	_tabSelectedChanged(e) {
 		this._currentTabId = `panel-${e.detail.tabId}`;
 	}
-	_tokenChanged(token) {
-		if (token && this.enrollmentsUrl && this.userSettingsUrl) {
-			this._setEnrollmentCollectionEntity(this.enrollmentsUrl);
-			this._setUserSettingsEntity(this.userSettingsUrl);
+	_tokenChanged(token, enrollmentsUrl, userSettingsUrl) {
+		if (token && enrollmentsUrl && userSettingsUrl) {
+			this._setEnrollmentCollectionEntity(enrollmentsUrl);
+			this._setUserSettingsEntity(userSettingsUrl);
 		}
 	}
 	courseImageUploadCompleted(success) {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -239,7 +239,7 @@ class MyCoursesContainer extends mixinBehaviors([
 		this._currentTabId = `panel-${e.detail.tabId}`;
 	}
 	_tokenChanged(token) {
-		if ( token && this.enrollmentsUrl && this.userSettingsUrl ) {
+		if (token && this.enrollmentsUrl && this.userSettingsUrl) {
 			this._setEnrollmentCollectionEntity(this.enrollmentsUrl);
 			this._setUserSettingsEntity(this.userSettingsUrl);
 		}

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -46,10 +46,7 @@ class MyCoursesContainer extends mixinBehaviors([
 			// URL to fetch a user's settings (e.g. default tab to select)
 			userSettingsUrl: String,
 			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
-			token: {
-				type: String,
-				observer: '_tokenChanged'
-			},
+			token: String,
 			// URL to fetch widget settings
 			_presentationUrl: String,
 			_currentTabId: String,
@@ -75,6 +72,12 @@ class MyCoursesContainer extends mixinBehaviors([
 				value: false
 			}
 		};
+	}
+
+	static get observers() {
+		return [
+			'_tokenChanged(token, enrollmentsUrl, userSettingsUrl)'
+		];
 	}
 
 	static get template() {
@@ -130,12 +133,6 @@ class MyCoursesContainer extends mixinBehaviors([
 					standard-semester-name="[[standardSemesterName]]">
 				</d2l-my-courses-content>
 			</template>`;
-	}
-
-	static get observers() {
-		return [
-			'_tokenChanged(token, enrollmentsUrl, userSettingsUrl)'
-		];
 	}
 
 	connectedCallback() {


### PR DESCRIPTION
Add an observer for `token`, and only send the first enrollments and user settings requests when all three are set of:
-token
-enrollment url
-settings url

Before this change, the initial enrollments call, and user settings call are made without an authorization token.