### PR TITLE
US116105 - Simplify focus logic

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -284,8 +284,8 @@ class AllCourses extends mixinBehaviors([
 				id="all-courses"
 				title-name="[[localize('allCourses')]]"
 				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
-				with-backdrop
-				restore-focus-on-close>
+				restore-focus-on-close
+				with-backdrop>
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">
@@ -448,10 +448,6 @@ class AllCourses extends mixinBehaviors([
 
 		this.shadowRoot.querySelector('#all-courses').open();
 		this.load();
-	}
-
-	focusCardDropdown(organization) {
-		return this._getCardGrid().focusCardDropdown(organization);
 	}
 
 	_getCardGrid() {

--- a/src/d2l-my-courses-card-grid.js
+++ b/src/d2l-my-courses-card-grid.js
@@ -234,16 +234,6 @@ class MyCoursesCardGrid extends PolymerElement {
 		}
 	}
 
-	focusCardDropdown(organization) {
-		const courseCards = this.shadowRoot.querySelectorAll('d2l-enrollment-card');
-		for (let i = 0; i < courseCards.length; i++) {
-			if (courseCards[i].focusDropdownOpener(organization)) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	_onPresentationEntityChange(url) {
 		entityFactory(PresentationEntity, url, this.token, entity => {
 			this._hideCourseStartDate = entity.hideCourseStartDate();

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -18,7 +18,6 @@ import './d2l-utility-behavior.js';
 import { entityFactory, updateEntity } from 'siren-sdk/src/es6/EntityFactory.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { Actions } from 'd2l-hypermedia-constants';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { MyCoursesLocalizeBehavior } from './localize-behavior.js';

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -164,10 +164,6 @@ class MyCoursesContent extends mixinBehaviors([
 			_hidePastCourses: {
 				type: Boolean,
 				value: false
-			},
-			_isAllCoursesOverlayOpen: {
-				type: Boolean,
-				value: false
 			}
 		};
 	}
@@ -253,6 +249,7 @@ class MyCoursesContent extends mixinBehaviors([
 		<d2l-simple-overlay id="basic-image-selector-overlay"
 			title-name="[[localize('changeImage')]]"
 			close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
+			restore-focus-on-close
 			with-backdrop>
 			<iron-scroll-threshold
 				id="image-selector-threshold"
@@ -311,21 +308,6 @@ class MyCoursesContent extends mixinBehaviors([
 	* Public API functions
 	*/
 
-	// After the image selector is closed, this is called to set focus back to the correct card
-	focusCardDropdown(imageOrg) {
-		const allCourses = this.shadowRoot.querySelector('d2l-all-courses');
-
-		if (allCourses && this._isAllCoursesOverlayOpen) {
-			if (allCourses.focusCardDropdown(imageOrg)) {
-				return;
-			}
-		} else {
-			if (this._getCardGrid().focusCardDropdown(imageOrg)) {
-				return;
-			}
-		}
-		this.$.viewAllCourses.focus();
-	}
 	// This is called by the LE, but only when it's a user-uploaded image
 	// If it's a catalog image this is handled by the enrollment card
 	courseImageUploadCompleted(success) {
@@ -632,7 +614,6 @@ class MyCoursesContent extends mixinBehaviors([
 
 		if (e.composedPath()[0].id === 'all-courses') {
 			this.showImageError = false;
-			this._isAllCoursesOverlayOpen = false;
 
 			if (this._isRefetchNeeded) {
 				this._handleEnrollmentsRefetch();
@@ -640,11 +621,6 @@ class MyCoursesContent extends mixinBehaviors([
 
 			document.body.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinnedMessage, true);
 			this._hasEnrollmentsChanged = false;
-
-		} else if (e.composedPath()[0].id === 'basic-image-selector-overlay') {
-			afterNextRender(this, () => {
-				this.focusCardDropdown(this._setImageOrg);
-			});
 		}
 	}
 
@@ -763,7 +739,6 @@ class MyCoursesContent extends mixinBehaviors([
 		allCourses.presentationUrl = this.presentationUrl;
 
 		allCourses.open();
-		this._isAllCoursesOverlayOpen = true;
 
 		e.preventDefault();
 		e.stopPropagation();

--- a/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
+++ b/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
@@ -79,39 +79,5 @@ describe('d2l-my-courses-card-grid', function() {
 			expect(stub3).to.have.been.calledOnce;
 		});
 
-		it('focusCardDropdown should call focusDropdownOpener until the correct card is focused and return true', () => {
-			const courseCards = widget.shadowRoot.querySelectorAll('d2l-enrollment-card');
-
-			const stub1 = sandbox.stub(courseCards[0], 'focusDropdownOpener');
-			stub1.withArgs('org2').returns(false);
-			const stub2 = sandbox.stub(courseCards[1], 'focusDropdownOpener');
-			stub2.withArgs('org2').returns(true);
-			const stub3 = sandbox.stub(courseCards[2], 'focusDropdownOpener');
-
-			const response = widget.focusCardDropdown('org2');
-
-			expect(response).to.be.true;
-			expect(stub1).to.have.been.calledOnce;
-			expect(stub2).to.have.been.calledOnce;
-			expect(stub3).to.have.not.been.called;
-		});
-
-		it('focusCardDropdown should return false if the org does not match any cards', () => {
-			const courseCards = widget.shadowRoot.querySelectorAll('d2l-enrollment-card');
-
-			const stub1 = sandbox.stub(courseCards[0], 'focusDropdownOpener');
-			stub1.withArgs('org4').returns(false);
-			const stub2 = sandbox.stub(courseCards[1], 'focusDropdownOpener');
-			stub2.withArgs('org4').returns(false);
-			const stub3 = sandbox.stub(courseCards[2], 'focusDropdownOpener');
-			stub3.withArgs('org4').returns(false);
-
-			const response = widget.focusCardDropdown('org4');
-
-			expect(response).to.be.false;
-			expect(stub1).to.have.been.calledOnce;
-			expect(stub2).to.have.been.calledOnce;
-			expect(stub3).to.have.been.calledOnce;
-		});
 	});
 });

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -501,22 +501,6 @@ describe('d2l-my-courses-content', () => {
 					done();
 				});
 			});
-
-			it('should focus on correct card if image selector is closed', done => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'focusCardDropdown');
-
-				const event = {
-					type: 'd2l-simple-overlay-closed',
-					composedPath: function() { return [{ id: 'basic-image-selector-overlay' }]; }
-				};
-
-				component._onSimpleOverlayClosed(event);
-
-				setTimeout(() => {
-					expect(stub).to.have.been.calledOnce;
-					done();
-				}, 200);
-			});
 		});
 
 		describe('course-tile-organization', () => {


### PR DESCRIPTION
I fixed up our own card-focusing logic because it was there before, but in a broken state.  Turns out `iron-overlay-behavior` actually does what we need, and so will its replacement (it makes sense for the overlay to manage focus), so we'll just use that instead.