### PR TITLE
US116105 - Move image selector to container

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -387,7 +387,6 @@ class AllCourses extends mixinBehaviors([
 		this._onFilterDropdownClose = this._onFilterDropdownClose.bind(this);
 		this._onFilterChanged = this._onFilterChanged.bind(this);
 		this._onSearchResultsChanged = this._onSearchResultsChanged.bind(this);
-		this._onSetCourseImage = this._onSetCourseImage.bind(this);
 	}
 
 	connectedCallback() {
@@ -402,14 +401,7 @@ class AllCourses extends mixinBehaviors([
 			this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-close', this._onFilterDropdownClose);
 			this.shadowRoot.querySelector('#filterMenu').addEventListener('d2l-filter-menu-change', this._onFilterChanged);
 			this.shadowRoot.querySelector('#search-widget').addEventListener('d2l-search-widget-results-changed', this._onSearchResultsChanged);
-
-			document.body.addEventListener('set-course-image', this._onSetCourseImage);
 		});
-	}
-
-	disconnectedCallback() {
-		super.disconnectedCallback();
-		document.body.removeEventListener('set-course-image', this._onSetCourseImage);
 	}
 
 	/*
@@ -450,22 +442,14 @@ class AllCourses extends mixinBehaviors([
 		this.load();
 	}
 
+	refreshCardGridImages(organization) {
+		this._getCardGrid().refreshCardGridImages(organization);
+	}
+
 	_getCardGrid() {
 		return this._showGroupByTabs
 			? this.shadowRoot.querySelector(`#${this._selectedTabId} d2l-my-courses-card-grid`)
 			: this.shadowRoot.querySelector('d2l-my-courses-card-grid');
-	}
-
-	_onSetCourseImage(details) {
-		this.showImageError = false;
-
-		if (details && details.detail) {
-			if (details.detail.status === 'failure') {
-				setTimeout(() => {
-					this.showImageError = true;
-				}, 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
-			}
-		}
 	}
 
 	/*
@@ -565,7 +549,6 @@ class AllCourses extends mixinBehaviors([
 			}
 		}
 
-		this.showImageError = false;
 		this._clearSearchWidget();
 		this.$.filterMenu.clearFilters();
 		this._filterText = this.localize('filtering.filter');

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -87,7 +87,7 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('Alerts', function() {
-		it('should remove the course image failure alert when the overlay is opened', function() {
+		it('should show and hide the course image failure alert depending on the value of showImageError', function() {
 			const alertMessage = 'Sorry, we\'re unable to change your image right now. Please try again later.';
 			widget.showImageError = true;
 
@@ -95,39 +95,8 @@ describe('d2l-all-courses', function() {
 			expect(alert.hidden).to.be.false;
 			expect(alert.type).to.equal('warning');
 			expect(alert.innerText).to.include(alertMessage);
-			widget.shadowRoot.querySelector('d2l-simple-overlay')._renderOpened();
+			widget.showImageError = false;
 			expect(alert.hidden).to.be.true;
-		});
-
-		it('should remove the course image failure alert before determining if it needs to add it back', function() {
-			widget.showImageError = true;
-			widget._onSetCourseImage();
-			expect(widget.showImageError).to.be.false;
-		});
-
-		it('should add the course image alert after receiving a failure result (after a timeout)', function() {
-			clock = sinon.useFakeTimers();
-			const setCourseImageEvent = { detail: { status: 'failure'} };
-			widget._onSetCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(widget.showImageError).to.be.true;
-		});
-
-		it('should not add a course image failure alert when a request to set the image succeeds', function() {
-			const setCourseImageEvent = { detail: { status: 'success'} };
-			widget._onSetCourseImage(setCourseImageEvent);
-			expect(widget.showImageError).to.be.false;
-		});
-
-		it('should remove a course image failure alert when a request to set the image is made', function() {
-			clock = sinon.useFakeTimers();
-			let setCourseImageEvent = { detail: { status: 'failure'} };
-			widget._onSetCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(widget.showImageError).to.be.true;
-			setCourseImageEvent = { detail: { status: 'set'} };
-			widget._onSetCourseImage(setCourseImageEvent);
-			expect(widget.showImageError).to.be.false;
 		});
 	});
 

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -361,7 +361,9 @@ describe('d2l-my-courses', () => {
 					});
 				});
 
-				component.dispatchEvent(event);
+				requestAnimationFrame(() => {
+					component.dispatchEvent(event);
+				});
 			});
 
 			it('should return correct org unit id from various href', () => {

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -370,15 +370,18 @@ describe('d2l-my-courses', () => {
 		describe('clear-image-scroll-threshold', () => {
 
 			it('should clear triggers on the image-selector-threshold', (done) => {
-				const threshold = component.shadowRoot.querySelector('#image-selector-threshold');
-				const spy = sandbox.spy(threshold, 'clearTriggers');
+				flush(() => {
+					const threshold = component.shadowRoot.querySelector('#image-selector-threshold');
+					const spy = sandbox.spy(threshold, 'clearTriggers');
 
-				const event = new CustomEvent('clear-image-scroll-threshold');
-				component.dispatchEvent(event);
-				requestAnimationFrame(() => {
-					expect(spy).to.have.been.called;
-					done();
+					const event = new CustomEvent('clear-image-scroll-threshold');
+					component.dispatchEvent(event);
+					requestAnimationFrame(() => {
+						expect(spy).to.have.been.calledOnce;
+						done();
+					});
 				});
+
 			});
 
 		});

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -17,7 +17,7 @@ describe('d2l-my-courses', () => {
 		promotedSearchHref = '/promoted-search-url',
 		lastSearchHref = 'homepages/components/1/user-settings/169';
 
-	beforeEach(done => {
+	beforeEach(() => {
 		sandbox = sinon.sandbox.create();
 
 		searchAction = {
@@ -119,10 +119,6 @@ describe('d2l-my-courses', () => {
 		component._userSettingsEntity = new UserSettingsEntity(lastSearchResponse);
 		component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchResponse);
 		component._enrollmentCollectionEntity = new EnrollmentCollectionEntity(enrollmentsSearchResponse);
-
-		setTimeout(() => {
-			done();
-		});
 	});
 
 	afterEach(function() {
@@ -303,6 +299,11 @@ describe('d2l-my-courses', () => {
 	});
 
 	describe('Events', function() {
+		beforeEach(done => {
+			setTimeout(() => {
+				done();
+			});
+		});
 		describe('open-change-image-view', () => {
 			let event,
 				fetchStub;

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -201,62 +201,66 @@ describe('d2l-my-courses', () => {
 	});
 
 	describe('Public API', () => {
-		it('If image setting was not a success, do nothing in courseImageUploadCompleted', done => {
-			component._showGroupByTabs = false;
-			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
-				component.courseImageUploadCompleted(false);
-				expect(stub).to.not.have.been.called;
-				done();
+
+		describe('courseImageUploadCompleted', () => {
+			it('should do nothing if image setting was not a success', done => {
+				component._showGroupByTabs = false;
+				flush(() => {
+					const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+					component.courseImageUploadCompleted(false);
+					expect(stub).to.not.have.been.called;
+					done();
+				});
 			});
-		});
-		it('In courseImageUploadCompleted when not grouped by tab, should call refreshCardGridImages on card grid', done => {
-			component._showGroupByTabs = false;
-			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
-				component.courseImageUploadCompleted(true);
-				expect(stub).to.have.been.called;
-				done();
+			it('should call refreshCardGridImages on the content (not grouped by tab), ', done => {
+				component._showGroupByTabs = false;
+				flush(() => {
+					const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+					component.courseImageUploadCompleted(true);
+					expect(stub).to.have.been.called;
+					done();
+				});
+			});
+			it('should call refreshCardGridImages on the content (grouped by tab)', done => {
+				component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
+				component._onPromotedSearchEntityChange();
+				component._currentTabId = '6607';
+				flush(() => {
+					const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+					component.courseImageUploadCompleted(true);
+					expect(stub).to.have.been.called;
+					done();
+				});
 			});
 		});
 
-		it('In getLastOrgUnitId when not grouped by tab, should call getOrgUnitIdFromHref', done => {
-			component._showGroupByTabs = false;
-			component._setImageOrg.links = [];
-			flush(() => {
-				const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
-				const stub2 = sandbox.stub(component, 'getEntityIdentifier');
-				component.getLastOrgUnitId();
-				expect(stub1).to.have.been.called;
-				expect(stub2).to.have.been.called;
-				done();
+		describe('getLastOrgUnitId', () => {
+			it('should call getOrgUnitIdFromHref (not grouped by tab)', done => {
+				component._showGroupByTabs = false;
+				component._setImageOrg.links = [];
+				flush(() => {
+					const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
+					const stub2 = sandbox.stub(component, 'getEntityIdentifier');
+					component.getLastOrgUnitId();
+					expect(stub1).to.have.been.called;
+					expect(stub2).to.have.been.called;
+					done();
+				});
 			});
-		});
 
-		it('In getLastOrgUnitId when grouped by tab, should call getOrgUnitIdFromHref', done => {
-			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
-			component._onPromotedSearchEntityChange();
-			component._currentTabId = '6607';
-			component._setImageOrg.links = [];
-			flush(() => {
-				const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
-				const stub2 = sandbox.stub(component, 'getEntityIdentifier');
-				component.getLastOrgUnitId();
-				expect(stub1).to.have.been.called;
-				expect(stub2).to.have.been.called;
-				done();
-			});
-		});
-
-		it('In courseImageUploadCompleted when grouped by tab, should call refreshCardGridImages on card grid', done => {
-			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
-			component._onPromotedSearchEntityChange();
-			component._currentTabId = '6607';
-			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
-				component.courseImageUploadCompleted(true);
-				expect(stub).to.have.been.called;
-				done();
+			it('should call getOrgUnitIdFromHref (grouped by tab)', done => {
+				component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
+				component._onPromotedSearchEntityChange();
+				component._currentTabId = '6607';
+				component._setImageOrg.links = [];
+				flush(() => {
+					const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
+					const stub2 = sandbox.stub(component, 'getEntityIdentifier');
+					component.getLastOrgUnitId();
+					expect(stub1).to.have.been.called;
+					expect(stub2).to.have.been.called;
+					done();
+				});
 			});
 		});
 	});

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -17,7 +17,7 @@ describe('d2l-my-courses', () => {
 		promotedSearchHref = '/promoted-search-url',
 		lastSearchHref = 'homepages/components/1/user-settings/169';
 
-	beforeEach(() => {
+	beforeEach(done => {
 		sandbox = sinon.sandbox.create();
 
 		searchAction = {
@@ -119,6 +119,10 @@ describe('d2l-my-courses', () => {
 		component._userSettingsEntity = new UserSettingsEntity(lastSearchResponse);
 		component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchResponse);
 		component._enrollmentCollectionEntity = new EnrollmentCollectionEntity(enrollmentsSearchResponse);
+
+		setTimeout(() => {
+			done();
+		});
 	});
 
 	afterEach(function() {

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -4,6 +4,7 @@ import { UserSettingsEntity } from 'siren-sdk/src/userSettings/UserSettingsEntit
 
 describe('d2l-my-courses', () => {
 	let component,
+		clock,
 		sandbox,
 		searchAction,
 		searchPinnedEnrollmentsAction,
@@ -120,7 +121,10 @@ describe('d2l-my-courses', () => {
 		component._enrollmentCollectionEntity = new EnrollmentCollectionEntity(enrollmentsSearchResponse);
 	});
 
-	afterEach(() => {
+	afterEach(function() {
+		if (clock) {
+			clock.restore();
+		}
 		sandbox.restore();
 	});
 
@@ -197,51 +201,200 @@ describe('d2l-my-courses', () => {
 	});
 
 	describe('Public API', () => {
-		it('should call d2l-my-courses-content.courseImageUploadCompleted when not grouped by tab', done => {
-			component.updatedSortLogic = true;
+		it('If image setting was not a success, do nothing in courseImageUploadCompleted', done => {
 			component._showGroupByTabs = false;
 			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'courseImageUploadCompleted');
-				component.courseImageUploadCompleted();
-				expect(stub).to.have.been.called;
+				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+				component.courseImageUploadCompleted(false);
+				expect(stub).to.not.have.been.called;
 				done();
 			});
 		});
-
-		it('should call d2l-my-courses-content.getLastOrgUnitId when not grouped by tab', done => {
-			component.updatedSortLogic = true;
+		it('In courseImageUploadCompleted when not grouped by tab, should call refreshCardGridImages on card grid', done => {
 			component._showGroupByTabs = false;
 			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'getLastOrgUnitId');
-				component.getLastOrgUnitId();
+				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+				component.courseImageUploadCompleted(true);
 				expect(stub).to.have.been.called;
 				done();
 			});
 		});
 
-		it('should call d2l-my-courses-content.getLastOrgUnitId when grouped by tab', done => {
-			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
-			component._onPromotedSearchEntityChange();
-			component.updatedSortLogic = true;
-			component._currentTabId = '6607';
+		it('In getLastOrgUnitId when not grouped by tab, should call getOrgUnitIdFromHref', done => {
+			component._showGroupByTabs = false;
+			component._setImageOrg.links = [];
 			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'getLastOrgUnitId');
+				const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
+				const stub2 = sandbox.stub(component, 'getEntityIdentifier');
 				component.getLastOrgUnitId();
-				expect(stub).to.have.been.called;
+				expect(stub1).to.have.been.called;
+				expect(stub2).to.have.been.called;
 				done();
 			});
 		});
 
-		it('should call d2l-my-courses-content.courseImageUploadCompleted when grouped by tab', done => {
+		it('In getLastOrgUnitId when grouped by tab, should call getOrgUnitIdFromHref', done => {
 			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 			component._onPromotedSearchEntityChange();
-			component.updatedSortLogic = true;
+			component._currentTabId = '6607';
+			component._setImageOrg.links = [];
+			flush(() => {
+				const stub1 = sandbox.stub(component, 'getOrgUnitIdFromHref');
+				const stub2 = sandbox.stub(component, 'getEntityIdentifier');
+				component.getLastOrgUnitId();
+				expect(stub1).to.have.been.called;
+				expect(stub2).to.have.been.called;
+				done();
+			});
+		});
+
+		it('In courseImageUploadCompleted when grouped by tab, should call refreshCardGridImages on card grid', done => {
+			component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
+			component._onPromotedSearchEntityChange();
 			component._currentTabId = '6607';
 			flush(() => {
-				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'courseImageUploadCompleted');
-				component.courseImageUploadCompleted();
+				const stub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'refreshCardGridImages');
+				component.courseImageUploadCompleted(true);
 				expect(stub).to.have.been.called;
 				done();
+			});
+		});
+	});
+
+	describe('Alerts', function() {
+		it('should remove the course image failure alert before determining if it needs to add it back', function() {
+			component._showImageError = true;
+			component._onSetCourseImage();
+			expect(component._showImageError).to.be.false;
+		});
+
+		it('should add the course image alert after receiving a failure result (after a timeout)', function() {
+			clock = sinon.useFakeTimers();
+			const setCourseImageEvent = { detail: { status: 'failure'} };
+			component._onSetCourseImage(setCourseImageEvent);
+			clock.tick(1001);
+			expect(component._showImageError).to.be.true;
+		});
+
+		it('should not add a course image failure alert when a request to set the image succeeds', function() {
+			const setCourseImageEvent = { detail: { status: 'success'} };
+			component._onSetCourseImage(setCourseImageEvent);
+			expect(component._showImageError).to.be.false;
+		});
+
+		it('should remove a course image failure alert when a request to set the image is made', function() {
+			clock = sinon.useFakeTimers();
+			let setCourseImageEvent = { detail: { status: 'failure'} };
+			component._onSetCourseImage(setCourseImageEvent);
+			clock.tick(1001);
+			expect(component._showImageError).to.be.true;
+			setCourseImageEvent = { detail: { status: 'set'} };
+			component._onSetCourseImage(setCourseImageEvent);
+			expect(component._showImageError).to.be.false;
+		});
+	});
+
+	describe('Events', function() {
+		describe('open-change-image-view', () => {
+			let event,
+				fetchStub;
+
+			beforeEach(() => {
+				// Prevents the _searchPath of the image selector from being null
+				component.imageCatalogLocation = '/foo';
+				fetchStub = sandbox.stub(window.D2L.Siren.EntityStore, 'fetch');
+				fetchStub.withArgs('/foo', sinon.match.string).returns(Promise.resolve({entity: {}}));
+				event = new CustomEvent('open-change-image-view', {
+					detail: {
+						organization: window.D2L.Hypermedia.Siren.Parse({
+							properties: {
+								name: 'Course One'
+							},
+							links: [{
+								rel: ['self'],
+								href: '/organizations/1'
+							}]
+						})
+					}
+				});
+			});
+
+			it('should update _setImageOrg', done => {
+
+				component.addEventListener('open-change-image-view', function() {
+					expect(component._setImageOrg.properties.name).to.equal('Course One');
+					done();
+				});
+
+				component.dispatchEvent(event);
+
+			});
+
+			it('should open the course image overlay', done => {
+				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'open');
+
+				component.addEventListener('open-change-image-view', function() {
+					requestAnimationFrame(() => {
+						expect(spy).to.have.been.called;
+						done();
+					});
+				});
+
+				component.dispatchEvent(event);
+
+			});
+
+			it('should return undefined for org unit id initally', () => {
+				expect(component.getLastOrgUnitId()).to.equal(undefined);
+			});
+
+			it('should return correct org unit id if course tile used', done => {
+
+				component.addEventListener('open-change-image-view', function() {
+					requestAnimationFrame(() => {
+						expect(component.getLastOrgUnitId()).to.equal('1');
+						done();
+					});
+				});
+
+				component.dispatchEvent(event);
+			});
+
+			it('should return correct org unit id from various href', () => {
+				expect(component.getOrgUnitIdFromHref('/organizations/671')).to.equal('671');
+				expect(component.getOrgUnitIdFromHref('/some/other/route/8798734534')).to.equal('8798734534');
+			});
+
+		});
+
+		describe('clear-image-scroll-threshold', () => {
+
+			it('should clear triggers on the image-selector-threshold', (done) => {
+				const threshold = component.shadowRoot.querySelector('#image-selector-threshold');
+				const spy = sandbox.spy(threshold, 'clearTriggers');
+
+				const event = new CustomEvent('clear-image-scroll-threshold');
+				component.dispatchEvent(event);
+				requestAnimationFrame(() => {
+					expect(spy).to.have.been.called;
+					done();
+				});
+			});
+
+		});
+
+		describe('set-course-image', () => {
+
+			it('should close the image-selector overlay', done => {
+				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'close');
+
+				const event = new CustomEvent('set-course-image');
+				component.dispatchEvent(event);
+
+				setTimeout(() => {
+					expect(spy).to.have.been.called;
+					done();
+				});
 			});
 		});
 	});

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -319,7 +319,7 @@ describe('d2l-my-courses-content', () => {
 			expect(alert.hidden).to.be.true;
 		});
 
-		it('should hide the course image failure alert when the all courses overlay is opened', function() {
+		it('should hide the course image failure alert when the all courses overlay is opened', function(done) {
 			const alertMessage = 'Sorry, we\'re unable to change your image right now. Please try again later.';
 			component.showImageError = true;
 
@@ -327,9 +327,13 @@ describe('d2l-my-courses-content', () => {
 			expect(alert.hidden).to.be.false;
 			expect(alert.type).to.equal('warning');
 			expect(alert.innerText).to.include(alertMessage);
-			component._openAllCoursesView(new CustomEvent('event'));
-			expect(alert.hidden).to.be.true;
-			expect(component.showImageError).to.be.false;
+			component._createAllCourses();
+			flush(() => {
+				component._openAllCoursesView(new CustomEvent('event'));
+				expect(alert.hidden).to.be.true;
+				expect(component.showImageError).to.be.false;
+				done();
+			});
 		});
 
 		it('should hide the course image failure alert when the all courses overlay is closed', function() {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -280,30 +280,32 @@ describe('d2l-my-courses-content', () => {
 
 	describe('Public API', () => {
 
-		it('refreshCardGridImages should refresh cards in both card grids if all courses intialized', done => {
-			component._createAllCourses();
-			flush(() => {
-				const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
-				const stub2 = sandbox.stub(component.shadowRoot.querySelector('d2l-all-courses'), 'refreshCardGridImages');
+		describe('refreshCardGridImages', () => {
 
-				component.refreshCardGridImages();
-				expect(stub1).to.have.been.called;
-				expect(stub2).to.have.been.called;
-				done();
+			it('should refresh cards in both card grids if all courses intialized', done => {
+				component._createAllCourses();
+				flush(() => {
+					const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
+					const stub2 = sandbox.stub(component.shadowRoot.querySelector('d2l-all-courses'), 'refreshCardGridImages');
+
+					component.refreshCardGridImages();
+					expect(stub1).to.have.been.called;
+					expect(stub2).to.have.been.called;
+					done();
+				});
+			});
+
+			it('should refresh cards in just the widget view if all courses not intialized', done => {
+				flush(() => {
+					const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
+
+					component.refreshCardGridImages();
+					expect(component.shadowRoot.querySelector('d2l-all-courses')).to.be.null;
+					expect(stub1).to.have.been.called;
+					done();
+				});
 			});
 		});
-
-		it('refreshCardGridImages should refresh cards in just the widget view if all courses not intialized', done => {
-			flush(() => {
-				const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
-
-				component.refreshCardGridImages();
-				expect(component.shadowRoot.querySelector('d2l-all-courses')).to.be.null;
-				expect(stub1).to.have.been.called;
-				done();
-			});
-		});
-
 	});
 
 	describe('Alerts', function() {

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -189,15 +189,13 @@ describe('d2l-my-courses-content', () => {
 		sandbox.restore();
 	});
 
-	it('should properly implement d2l-my-courses-content-behavior', () => {
+	it('should properly implement a random assortment of properties', () => {
 		expect(component).to.exist;
 		expect(component._alertsView).to.be.an.instanceof(Array);
 		expect(component._existingEnrollmentsMap).to.be.an('object');
 		expect(component._nextEnrollmentEntityUrl).to.be.null;
 		expect(component._orgUnitIdMap).to.be.an('object');
-		expect(component._setImageOrg).to.be.an('object');
 		expect(component._showContent).to.exist;
-		expect(component.getLastOrgUnitId).to.be.a('function');
 	});
 
 	it('should reset enrollments related properties', () => {
@@ -273,16 +271,6 @@ describe('d2l-my-courses-content', () => {
 			setTimeout(done, 300);
 		});
 
-		it('should call refreshCardGridImages on the card gird in courseImageUploadCompleted', () => {
-			const courseGrid = component.shadowRoot.querySelector('d2l-my-courses-card-grid');
-
-			const stub = sandbox.stub(courseGrid, 'refreshCardGridImages');
-
-			component.courseImageUploadCompleted(true);
-
-			expect(stub).to.have.been.called;
-		});
-
 		it('should add the hide-past-courses attribute to the card grid in _populateEnrollments', () => {
 			component._enrollmentsRootResponse(new EnrollmentCollectionEntity(enrollmentsSearchPageTwoEntity));
 			expect(component.shadowRoot.querySelector('d2l-my-courses-card-grid').hidePastCourses).to.be.true;
@@ -292,14 +280,75 @@ describe('d2l-my-courses-content', () => {
 
 	describe('Public API', () => {
 
-		it('should implement courseImageUploadCompleted', () => {
-			expect(component.courseImageUploadCompleted).to.be.a('function');
+		it('refreshCardGridImages should refresh cards in both card grids if all courses intialized', done => {
+			component._createAllCourses();
+			flush(() => {
+				const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
+				const stub2 = sandbox.stub(component.shadowRoot.querySelector('d2l-all-courses'), 'refreshCardGridImages');
+
+				component.refreshCardGridImages();
+				expect(stub1).to.have.been.called;
+				expect(stub2).to.have.been.called;
+				done();
+			});
 		});
 
-		it('should implement getLastOrgUnitId', () => {
-			expect(component.getLastOrgUnitId).to.be.a('function');
+		it('refreshCardGridImages should refresh cards in just the widget view if all courses not intialized', done => {
+			flush(() => {
+				const stub1 = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-card-grid'), 'refreshCardGridImages');
+
+				component.refreshCardGridImages();
+				expect(component.shadowRoot.querySelector('d2l-all-courses')).to.be.null;
+				expect(stub1).to.have.been.called;
+				done();
+			});
 		});
 
+	});
+
+	describe('Alerts', function() {
+		it('should show and hide the course image failure alert depending on the value of showImageError', function() {
+			const alertMessage = 'Sorry, we\'re unable to change your image right now. Please try again later.';
+			component.showImageError = true;
+
+			const alert = component.shadowRoot.querySelector('#imageErrorAlert');
+			expect(alert.hidden).to.be.false;
+			expect(alert.type).to.equal('warning');
+			expect(alert.innerText).to.include(alertMessage);
+			component.showImageError = false;
+			expect(alert.hidden).to.be.true;
+		});
+
+		it('should hide the course image failure alert when the all courses overlay is opened', function() {
+			const alertMessage = 'Sorry, we\'re unable to change your image right now. Please try again later.';
+			component.showImageError = true;
+
+			const alert = component.shadowRoot.querySelector('#imageErrorAlert');
+			expect(alert.hidden).to.be.false;
+			expect(alert.type).to.equal('warning');
+			expect(alert.innerText).to.include(alertMessage);
+			component._openAllCoursesView(new CustomEvent('event'));
+			expect(alert.hidden).to.be.true;
+			expect(component.showImageError).to.be.false;
+		});
+
+		it('should hide the course image failure alert when the all courses overlay is closed', function() {
+			const alertMessage = 'Sorry, we\'re unable to change your image right now. Please try again later.';
+			component.showImageError = true;
+
+			const alert = component.shadowRoot.querySelector('#imageErrorAlert');
+			expect(alert.hidden).to.be.false;
+			expect(alert.type).to.equal('warning');
+			expect(alert.innerText).to.include(alertMessage);
+
+			const event = {
+				type: 'd2l-simple-overlay-closed',
+				composedPath: function() { return [{ id: 'all-courses' }]; }
+			};
+			component._onSimpleOverlayClosed(event);
+			expect(alert.hidden).to.be.true;
+			expect(component.showImageError).to.be.false;
+		});
 	});
 
 	describe('Events', () => {
@@ -370,84 +419,6 @@ describe('d2l-my-courses-content', () => {
 					expect(component._isRefetchNeeded).to.be.false;
 				});
 			});
-		});
-
-		describe('open-change-image-view', () => {
-			let event;
-
-			beforeEach(() => {
-				// Prevents the _searchPath of the image selector from being null
-				component.imageCatalogLocation = '/foo';
-				SetupFetchStub('/foo', {});
-				event = new CustomEvent('open-change-image-view', {
-					detail: {
-						organization: organizationEntity
-					}
-				});
-			});
-
-			it('should update _setImageOrg', done => {
-
-				component.addEventListener('open-change-image-view', function() {
-					expect(component._setImageOrg.properties.name).to.equal('Course One');
-					done();
-				});
-
-				component.dispatchEvent(event);
-
-			});
-
-			it('should open the course image overlay', done => {
-				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'open');
-
-				component.addEventListener('open-change-image-view', function() {
-					requestAnimationFrame(() => {
-						expect(spy).to.have.been.called;
-						done();
-					});
-				});
-
-				component.dispatchEvent(event);
-
-			});
-
-			it('should return undefined for org unit id initally', () => {
-				expect(component.getLastOrgUnitId()).to.equal(undefined);
-			});
-
-			it('should return correct org unit id if course tile used', done => {
-
-				component.addEventListener('open-change-image-view', function() {
-					requestAnimationFrame(() => {
-						expect(component.getLastOrgUnitId()).to.equal('1');
-						done();
-					});
-				});
-
-				component.dispatchEvent(event);
-			});
-
-			it('should return correct org unit id from various href', () => {
-				expect(component.getOrgUnitIdFromHref('/organizations/671')).to.equal('671');
-				expect(component.getOrgUnitIdFromHref('/some/other/route/8798734534')).to.equal('8798734534');
-			});
-
-		});
-
-		describe('clear-image-scroll-threshold', () => {
-
-			it('should clear triggers on the image-selector-threshold', (done) => {
-				const threshold = component.shadowRoot.querySelector('#image-selector-threshold');
-				const spy = sandbox.spy(threshold, 'clearTriggers');
-
-				const event = new CustomEvent('clear-image-scroll-threshold');
-				component.dispatchEvent(event);
-				requestAnimationFrame(() => {
-					expect(spy).to.have.been.calledOnce;
-					done();
-				});
-			});
-
 		});
 
 		describe('d2l-course-pinned-change', () => {
@@ -547,20 +518,6 @@ describe('d2l-my-courses-content', () => {
 
 		});
 
-		describe('set-course-image', () => {
-
-			it('should close the image-selector overlay', done => {
-				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'close');
-
-				const event = new CustomEvent('set-course-image');
-				document.body.dispatchEvent(event);
-
-				setTimeout(() => {
-					expect(spy).to.have.been.called;
-					done();
-				});
-			});
-		});
 	});
 
 	describe('Performance measures', () => {
@@ -724,32 +681,6 @@ describe('d2l-my-courses-content', () => {
 
 			component._populateEnrollments(new EnrollmentCollectionEntity(oneEnrollmentSearchEntity));
 			expect(component._numberOfEnrollments).not.to.equal(0);
-		});
-
-		it('should add the course image failure warning alert when a request to set the image fails', () => {
-			clock = sinon.useFakeTimers();
-			const setCourseImageEvent = { detail: { status: 'failure'} };
-			component._onSetCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(component.showImageError).to.be.true;
-		});
-
-		it('should not add the course image failure warning alert when a request to set the image succeeds', () => {
-			component.showImageError = true;
-			const setCourseImageEvent = { detail: { status: 'success'} };
-			component._onSetCourseImage(setCourseImageEvent);
-			expect(component.showImageError).to.be.false;
-		});
-
-		it('should remove the course image failure warning alert when a request to set the image is made', () => {
-			clock = sinon.useFakeTimers();
-			let setCourseImageEvent = { detail: { status: 'failure'} };
-			component._onSetCourseImage(setCourseImageEvent);
-			clock.tick(1001);
-			expect(component.showImageError).to.be.true;
-			setCourseImageEvent = { detail: { status: 'set'} };
-			component._onSetCourseImage(setCourseImageEvent);
-			expect(component.showImageError).to.be.false;
 		});
 
 		it('should show the number of enrollments when there are no new pages of enrollments with the View All Courses link', () => {


### PR DESCRIPTION
Ok, here's the main PR for this story.  Mostly a lot of re-arranging, moving the `d2l-basic-image-selector` to `d2l-my-courses-container` so that only one exists, instead of one per tab.