### PR TITLE
[20.20.5] DE39205 - Fix all courses overlay opening in legacy edge with tabs

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -25,7 +25,6 @@ import './search-filter/d2l-filter-menu.js';
 import './search-filter/d2l-search-widget-custom.js';
 import { Actions, Classes } from 'd2l-hypermedia-constants';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
-import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
@@ -401,19 +400,18 @@ class AllCourses extends mixinBehaviors([
 
 	connectedCallback() {
 		super.connectedCallback();
-		afterNextRender(this, () => {
-			this.addEventListener('d2l-simple-overlay-opening', this._onSimpleOverlayOpening);
-			this.addEventListener('d2l-tab-panel-selected', this._onTabSelected);
-			this.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinned);
 
-			this.shadowRoot.querySelector('#sortDropdown').addEventListener('d2l-menu-item-change', this._onSortOrderChanged);
-			this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-open', this._onFilterDropdownOpen);
-			this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-close', this._onFilterDropdownClose);
-			this.shadowRoot.querySelector('#filterMenu').addEventListener('d2l-filter-menu-change', this._onFilterChanged);
-			this.shadowRoot.querySelector('#search-widget').addEventListener('d2l-search-widget-results-changed', this._onSearchResultsChanged);
+		this.addEventListener('d2l-simple-overlay-opening', this._onSimpleOverlayOpening);
+		this.addEventListener('d2l-tab-panel-selected', this._onTabSelected);
+		this.addEventListener('d2l-course-pinned-change', this._onEnrollmentPinned);
 
-			document.body.addEventListener('set-course-image', this._onSetCourseImage);
-		});
+		this.shadowRoot.querySelector('#sortDropdown').addEventListener('d2l-menu-item-change', this._onSortOrderChanged);
+		this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-open', this._onFilterDropdownOpen);
+		this.shadowRoot.querySelector('#filterDropdownContent').addEventListener('d2l-dropdown-close', this._onFilterDropdownClose);
+		this.shadowRoot.querySelector('#filterMenu').addEventListener('d2l-filter-menu-change', this._onFilterChanged);
+		this.shadowRoot.querySelector('#search-widget').addEventListener('d2l-search-widget-results-changed', this._onSearchResultsChanged);
+
+		document.body.addEventListener('set-course-image', this._onSetCourseImage);
 	}
 
 	disconnectedCallback() {


### PR DESCRIPTION
This PR removes the delay of adding event listeners in d2l-all-courses.  The main ones causing the issue are `d2l-tab-panel-selected` and `d2l-search-widget-results-changed`, but I'm also suspicious of `d2l-simple-overlay-opening` and it seems safer to add everything immediately like it used to.