### PR TITLE
Fix Overlay Loading with Pinned Tab

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -698,7 +698,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_computeShowGroupByTabs(groups) {
-		return groups.length > 2 || (groups.length > 0 && !this._enrollmentsSearchAction);
+		return groups.length > 0;
 	}
 
 	_mapSortOption(identifier, identifierName) {


### PR DESCRIPTION
I want to get this fixed before turning the pinned tab on in Spark and Quad.  The overlay loads fine the first time (because `this._enrollmentsSearchAction` is undefined).  But if I open it again, then this fails as `this._enrollmentsSearchAction` has been set.  I'm not sure if this has always been broken, and I don't _100%_ know why this condition was added.

What I'm doing instead is just using the exact same tabs that the widget uses.  If there's no tabs, `groups` will be an empty array.  If there is tabs, then we will use them, even if there's only 1 or 2, because that's what the widget view has decided to do.