### PR TITLE
US114858 - Hide and Show the Pinned Tab

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -579,8 +579,10 @@ class AllCourses extends mixinBehaviors([
 		let tabAction;
 		for (let i = 0; i < this.tabSearchActions.length; i++) {
 			if (this.tabSearchActions[i].name === actionName) {
+				this.tabSearchActions[i].selected = true;
 				tabAction = this.tabSearchActions[i];
-				break;
+			} else {
+				this.tabSearchActions[i].selected = false;
 			}
 		}
 

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -471,7 +471,7 @@ class MyCoursesContainer extends mixinBehaviors([
 	}
 	_verifyPinnedTab(pinnedTabAction) {
 		let pinnedSearchUrl = this.createActionUrl(pinnedTabAction);
-		if (pinnedSearchUrl.indexOf('?') > -1) {
+		if (pinnedSearchUrl && pinnedSearchUrl.indexOf('?') > -1) {
 			// pinnedSearchUrl already has some query params, append ours
 			pinnedSearchUrl += `&bustCache=${Math.random()}`;
 		} else {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -388,6 +388,16 @@ class MyCoursesContainer extends mixinBehaviors([
 			});
 
 			this._getAllCoursesComponent().courseEnrollmentChanged(this._changedCourseEnrollment);
+
+			if (this._pinnedTabAction) {
+				if (e.detail.isPinned) {
+					// We need to check if we need to add the pinned tab
+					this._addPinnedTab();
+				} else {
+					// We need to check if we've removed the last pinned course and if so, remove the pinned tab
+					this._verifyPinnedTab(this._pinnedTabAction);
+				}
+			}
 		}
 	}
 	_tabSelectedChanged(e) {
@@ -419,16 +429,31 @@ class MyCoursesContainer extends mixinBehaviors([
 			});
 		}
 
-		if (this._pinnedTabAction) {
-			actions.push({
-				name: this._pinnedTabAction.name,
-				title: this.localize('pinnedCourses'),
-				selected: this._pinnedTabAction.name === lastEnrollmentsSearchName,
-				enrollmentsSearchAction: this._pinnedTabAction
-			});
+		if (!this._pinnedTabAction) {
+			return actions;
 		}
 
+		// Check cache to get our best guess about showing/hiding the pinned tab
+		const pinnedTabCache = this._tryGetItemLocalStorage('myCourses.pinnedTab');
+
+		if (pinnedTabCache && pinnedTabCache.previouslyShown) {
+			actions.push(this._getPinnedTabAction(lastEnrollmentsSearchName));
+		} else {
+			// Do not add the pinned action
+		}
+
+		// Check actual value asynchronously
+		this._verifyPinnedTab(this._pinnedTabAction);
+
 		return actions;
+	}
+	_getPinnedTabAction(lastEnrollmentsSearchName) {
+		return {
+			name: this._pinnedTabAction.name,
+			title: this.localize('pinnedCourses'),
+			selected: this._pinnedTabAction.name === lastEnrollmentsSearchName,
+			enrollmentsSearchAction: this._pinnedTabAction
+		};
 	}
 	_fetchTabSearchActions() {
 		if (!this.userSettingsUrl) {
@@ -443,6 +468,73 @@ class MyCoursesContainer extends mixinBehaviors([
 		}
 
 		return this._setPromotedSearchEntity(this.promotedSearches);
+	}
+	_verifyPinnedTab(pinnedTabAction) {
+		let enrollmentsSearchUrl = this.createActionUrl(pinnedTabAction);
+		enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+
+		entityFactory(EnrollmentCollectionEntity, enrollmentsSearchUrl, this.token, entity => {
+			if (!entity) {
+				return;
+			}
+
+			const enrollmentEntities = entity.getEnrollmentEntities();
+			if (enrollmentEntities && enrollmentEntities.length > 0) {
+				this._addPinnedTab();
+			} else {
+				this._removePinnedTab();
+			}
+		});
+	}
+	_addPinnedTab() {
+		const pinnedTabIndex = this._tabSearchActions.findIndex(action => action.name === this._pinnedTabAction.name);
+		if (pinnedTabIndex === -1) {
+			this.splice('_tabSearchActions', 1, 0, this._getPinnedTabAction());
+
+			const allCourses = this._getAllCoursesComponent();
+			if (allCourses.tabSearchActions && allCourses.tabSearchActions.length > 0) {
+				allCourses.splice('tabSearchActions', 1, 0, this._getPinnedTabAction());
+			}
+
+			const contents = this.shadowRoot.querySelectorAll('d2l-my-courses-content');
+			contents.forEach(content => {
+				content.requestRefresh();
+			});
+		}
+		this._trySetItemLocalStorage('myCourses.pinnedTab', {'previouslyShown': true});
+	}
+	_removePinnedTab() {
+		const pinnedTabIndex = this._tabSearchActions.findIndex(action => action.name === this._pinnedTabAction.name);
+		if (pinnedTabIndex !== -1) {
+			this.splice('_tabSearchActions', pinnedTabIndex, 1);
+
+			const allCourses = this._getAllCoursesComponent();
+			if (allCourses.tabSearchActions && allCourses.tabSearchActions.length > 0) {
+				allCourses.splice('tabSearchActions', pinnedTabIndex, 1);
+			}
+
+			const contents = this.shadowRoot.querySelectorAll('d2l-my-courses-content');
+			contents.forEach(content => {
+				content.requestRefresh();
+			});
+		}
+		this._trySetItemLocalStorage('myCourses.pinnedTab', {'previouslyShown': false});
+	}
+	_tryGetItemLocalStorage(itemName) {
+		try {
+			return JSON.parse(localStorage.getItem(itemName));
+		} catch (_) {
+			//noop if session storage isn't available or has bad data
+			return;
+		}
+	}
+	_trySetItemLocalStorage(itemName, value) {
+		try {
+			const itemCopied = JSON.parse(JSON.stringify(value));
+			localStorage.setItem(itemName, JSON.stringify(itemCopied));
+		} catch (_) {
+			//noop we don't want to blow up if we exceed a quota or are in safari private browsing mode
+		}
 	}
 }
 

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -524,7 +524,7 @@ class MyCoursesContainer extends mixinBehaviors([
 		try {
 			return JSON.parse(localStorage.getItem(itemName));
 		} catch (_) {
-			//noop if session storage isn't available or has bad data
+			//noop if local storage isn't available or has bad data
 			return;
 		}
 	}

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -470,15 +470,15 @@ class MyCoursesContainer extends mixinBehaviors([
 		return this._setPromotedSearchEntity(this.promotedSearches);
 	}
 	_verifyPinnedTab(pinnedTabAction) {
-		let enrollmentsSearchUrl = this.createActionUrl(pinnedTabAction);
-		if (enrollmentsSearchUrl.indexOf('?') > -1) {
-			// enrollmentsSearchUrl already has some query params, append ours
-			enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+		let pinnedSearchUrl = this.createActionUrl(pinnedTabAction);
+		if (pinnedSearchUrl.indexOf('?') > -1) {
+			// pinnedSearchUrl already has some query params, append ours
+			pinnedSearchUrl += `&bustCache=${Math.random()}`;
 		} else {
-			enrollmentsSearchUrl += `?bustCache=${Math.random()}`;
+			pinnedSearchUrl += `?bustCache=${Math.random()}`;
 		}
 
-		entityFactory(EnrollmentCollectionEntity, enrollmentsSearchUrl, this.token, entity => {
+		entityFactory(EnrollmentCollectionEntity, pinnedSearchUrl, this.token, entity => {
 			if (!entity) {
 				return;
 			}

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -471,7 +471,12 @@ class MyCoursesContainer extends mixinBehaviors([
 	}
 	_verifyPinnedTab(pinnedTabAction) {
 		let enrollmentsSearchUrl = this.createActionUrl(pinnedTabAction);
-		enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+		if (enrollmentsSearchUrl.indexOf('?') > -1) {
+			// enrollmentsSearchUrl already has some query params, append ours
+			enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+		} else {
+			enrollmentsSearchUrl += `?bustCache=${Math.random()}`;
+		}
 
 		entityFactory(EnrollmentCollectionEntity, enrollmentsSearchUrl, this.token, entity => {
 			if (!entity) {

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -528,7 +528,7 @@ class MyCoursesContent extends mixinBehaviors([
 		let enrollmentsSearchUrl = this.createActionUrl(this.enrollmentsSearchAction, query);
 
 		if (bustCache) {
-			if (enrollmentsSearchUrl.indexOf('?') > -1) {
+			if (enrollmentsSearchUrl && enrollmentsSearchUrl.indexOf('?') > -1) {
 				// enrollmentsSearchUrl already has some query params, append ours
 				enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
 			} else {

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -528,7 +528,12 @@ class MyCoursesContent extends mixinBehaviors([
 		let enrollmentsSearchUrl = this.createActionUrl(this.enrollmentsSearchAction, query);
 
 		if (bustCache) {
-			enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+			if (enrollmentsSearchUrl.indexOf('?') > -1) {
+				// enrollmentsSearchUrl already has some query params, append ours
+				enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
+			} else {
+				enrollmentsSearchUrl += `?bustCache=${Math.random()}`;
+			}
 		}
 
 		return enrollmentsSearchUrl;

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -280,6 +280,12 @@ class MyCoursesContent extends mixinBehaviors([
 		this._getCardGrid().refreshCardGridImages(imageOrg);
 	}
 
+	// Called by d2l-my-courses-container when the pinned tab has been added or removed
+	// Needed because of dom-repeat's re-use of DOM nodes
+	requestRefresh() {
+		this._isRefetchNeeded = true;
+	}
+
 	_getCardGrid() {
 		return this.shadowRoot.querySelector('d2l-my-courses-card-grid');
 	}
@@ -444,7 +450,7 @@ class MyCoursesContent extends mixinBehaviors([
 
 		if (this._isRefetchNeeded) {
 			this._handleEnrollmentsRefetch();
-		} else if (this._numberOfEnrollments === 0) {
+		} else if (this._numberOfEnrollments === 0 && !this._rootTabSelected) {
 			this._rootTabSelected = true;
 			this._fetchRoot();
 		} else {
@@ -521,7 +527,7 @@ class MyCoursesContent extends mixinBehaviors([
 		};
 		let enrollmentsSearchUrl = this.createActionUrl(this.enrollmentsSearchAction, query);
 
-		if (bustCache) {
+		if (bustCache || this._isPinnedTab) {
 			enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
 		}
 

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -527,7 +527,7 @@ class MyCoursesContent extends mixinBehaviors([
 		};
 		let enrollmentsSearchUrl = this.createActionUrl(this.enrollmentsSearchAction, query);
 
-		if (bustCache || this._isPinnedTab) {
+		if (bustCache) {
 			enrollmentsSearchUrl += `&bustCache=${Math.random()}`;
 		}
 
@@ -553,7 +553,9 @@ class MyCoursesContent extends mixinBehaviors([
 			'd2l.my-courses.root-enrollments.response'
 		);
 
-		const enrollmentsSearchUrl = this._createFetchEnrollmentsUrl();
+		// The pinned tab gets added and removed and needs to be refreshed each time
+		// For other tabs, we know this is their first time loading and do not need to bust the cache
+		const enrollmentsSearchUrl = this._createFetchEnrollmentsUrl(this._isPinnedTab);
 		this.performanceMark('d2l.my-courses.search-enrollments.request');
 
 		this._onEnrollmentsRootEntityChange(enrollmentsSearchUrl);

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -159,6 +159,7 @@ describe('d2l-my-courses', () => {
 	});
 
 	it('should have search pinned enrollments action and hide the only saved search action', () => {
+		sandbox.stub(component, '_tryGetItemLocalStorage').withArgs('myCourses.pinnedTab').returns({previouslyShown: true});
 		component._enrollmentsSearchAction = searchAction;
 		component._pinnedTabAction = searchPinnedEnrollmentsAction;
 		component._onPromotedSearchEntityChange();
@@ -166,6 +167,7 @@ describe('d2l-my-courses', () => {
 	});
 
 	it('should have search pinned enrollments action with two saved search actions', () => {
+		sandbox.stub(component, '_tryGetItemLocalStorage').withArgs('myCourses.pinnedTab').returns({previouslyShown: true});
 		component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 		component._enrollmentsSearchAction = searchAction;
 		component._pinnedTabAction = searchPinnedEnrollmentsAction;


### PR DESCRIPTION
A few things going on in this PR:
- Determining whether the pinned tab should be shown or hidden on load
  - We try to get the previous state from local browser cache
  - If we can't get this, we won't add the pinned tab yet
  - After making this choice, we asynchronously check that we were correct and add/remove if we were not
- Determining whether to hide/show the pinned tab as the user pins and unpins courses
- Keeping the overlay and main widget tabs in sync
- If there are no pinned or semester/department/role tabs, hide the all tab (no work here to do this, that is done for us in the tabs component)

I need to write new tests, but wanted to get this up early for feedback since we're down to the wire.