### PR TITLE
[20.20.7] DE39771 - Fix Group By Tabs when Pinned Tab is on

### DIFF
--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -309,6 +309,7 @@ class MyCoursesContainer extends mixinBehaviors([
 		}
 		const promotedSearchesEntity = this._promotedSearchEntity;
 		const userSettingsEntity = this._userSettingsEntity;
+		const lastEnrollmentsSearchName = userSettingsEntity.mostRecentEnrollmentsSearchName();
 
 		this._tabSearchActions = [];
 
@@ -325,8 +326,6 @@ class MyCoursesContainer extends mixinBehaviors([
 		if (promotedSearchesEntity.userEnrollmentsSearchType()) {
 			this._tabSearchType = promotedSearchesEntity.userEnrollmentsSearchType();
 		}
-
-		const lastEnrollmentsSearchName = userSettingsEntity.mostRecentEnrollmentsSearchName();
 
 		// DE36672 - need to check here if there's only one semester/department/etc but you have
 		// some courses that are not in any semester/department


### PR DESCRIPTION
This is obviously broken when you look at it (we try to use `lastEnrollmentsSearchName` before we set it), but we didn't catch it because:
1. It's been like this forever (at least April), but is only being triggered now that pinned tab is on
2. To get a user that sees this, they need to meet these 3 requirements:
  - Pinned tab is on (everyone now)
  - Group-by tabs are on
  - The user doesn't have any tabs (i.e. they are not in any courses that are in a semester/department/whatever you are grouping by)

Side note - should linting not have caught this?