### PR TITLE
Add a d2l-all-courses-close event

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -553,7 +553,7 @@ class AllCourses extends mixinBehaviors([
 		}
 	}
 
-	_onSimpleOverlayClosed() {
+	_onSimpleOverlayClosed(e) {
 		if (this._enrollmentsSearchAction && this._enrollmentsSearchAction.hasFieldByName) {
 			if (this._enrollmentsSearchAction.hasFieldByName('search')) {
 				this._enrollmentsSearchAction.getFieldByName('search').value = '';
@@ -570,6 +570,9 @@ class AllCourses extends mixinBehaviors([
 		this.$.filterMenu.clearFilters();
 		this._filterText = this.localize('filtering.filter');
 		this._resetSortDropdown();
+
+		e.stopPropagation();
+		this.dispatchEvent(new CustomEvent('d2l-all-courses-close'));
 	}
 
 	_onTabSelected(e) {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -553,7 +553,7 @@ class AllCourses extends mixinBehaviors([
 		}
 	}
 
-	_onSimpleOverlayClosed(e) {
+	_onSimpleOverlayClosed() {
 		if (this._enrollmentsSearchAction && this._enrollmentsSearchAction.hasFieldByName) {
 			if (this._enrollmentsSearchAction.hasFieldByName('search')) {
 				this._enrollmentsSearchAction.getFieldByName('search').value = '';
@@ -571,7 +571,6 @@ class AllCourses extends mixinBehaviors([
 		this._filterText = this.localize('filtering.filter');
 		this._resetSortDropdown();
 
-		e.stopPropagation();
 		this.dispatchEvent(new CustomEvent('d2l-all-courses-close'));
 	}
 

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -144,7 +144,7 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>
 
 			<d2l-all-courses
-				on-d2l-all-courses-close="_onAllCoursesOverlayClosed"
+				on-d2l-all-courses-close="_onAllCoursesClose"
 				advanced-search-url="[[advancedSearchUrl]]"
 				enrollments-search-action="[[_enrollmentsSearchAction]]"
 				filter-standard-department-name="[[standardDepartmentName]]"
@@ -272,7 +272,7 @@ class MyCoursesContainer extends mixinBehaviors([
 
 		this._showImageError = false; // Clear image error when opening and closing the all courses overlay
 	}
-	_onAllCoursesOverlayClosed() {
+	_onAllCoursesClose() {
 		this._showImageError = false; // Clear image error when opening and closing the all courses overlay
 		this._getContentComponent().allCoursesOverlayClosed();
 	}

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -144,7 +144,7 @@ class MyCoursesContainer extends mixinBehaviors([
 			</template>
 
 			<d2l-all-courses
-				on-d2l-simple-overlay-closed="_onAllCoursesOverlayClosed"
+				on-d2l-all-courses-close="_onAllCoursesOverlayClosed"
 				advanced-search-url="[[advancedSearchUrl]]"
 				enrollments-search-action="[[_enrollmentsSearchAction]]"
 				filter-standard-department-name="[[standardDepartmentName]]"

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -247,6 +247,7 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('closing the overlay', function() {
+		const closeEvent = new CustomEvent('d2l-simple-overlay-closed');
 
 		it('should prep _enrollmentsSearchAction for component resets', function() {
 			const entity = window.D2L.Hypermedia.Siren.Parse({
@@ -263,7 +264,7 @@ describe('d2l-all-courses', function() {
 			});
 			widget._enrollmentsSearchAction = entity.actions[0];
 
-			widget._onSimpleOverlayClosed();
+			widget._onSimpleOverlayClosed(closeEvent);
 
 			expect(widget._enrollmentsSearchAction.getFieldByName('search').value).to.be.equal('');
 			expect(widget._enrollmentsSearchAction.getFieldByName('sort').value).to.be.equal('Current');
@@ -275,7 +276,7 @@ describe('d2l-all-courses', function() {
 			const searchField = widget.$['search-widget'];
 
 			searchField._getSearchWidget()._getSearchInput().value = 'foo';
-			widget._onSimpleOverlayClosed();
+			widget._onSimpleOverlayClosed(closeEvent);
 
 			expect(spy.called).to.be.true;
 			expect(searchField._getSearchWidget()._getSearchInput().value).to.equal('');
@@ -294,7 +295,7 @@ describe('d2l-all-courses', function() {
 			fireEvent(widget.$.filterDropdownContent, 'd2l-dropdown-close', {});
 
 			expect(widget._filterText).to.equal('Filter: 1 Filter');
-			widget._onSimpleOverlayClosed();
+			widget._onSimpleOverlayClosed(closeEvent);
 			expect(spy.called).to.be.true;
 			expect(widget._filterText).to.equal('Filter');
 		});
@@ -311,7 +312,7 @@ describe('d2l-all-courses', function() {
 			fireEvent(widget.shadowRoot.querySelector('d2l-dropdown-menu'), 'd2l-menu-item-change', event);
 			expect(widget._searchUrl).to.contain('OrgUnitCode,OrgUnitId');
 
-			widget._onSimpleOverlayClosed();
+			widget._onSimpleOverlayClosed(closeEvent);
 			expect(spy.called).to.be.true;
 		});
 

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -247,7 +247,6 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('closing the overlay', function() {
-		const closeEvent = new CustomEvent('d2l-simple-overlay-closed');
 
 		it('should prep _enrollmentsSearchAction for component resets', function() {
 			const entity = window.D2L.Hypermedia.Siren.Parse({
@@ -264,7 +263,7 @@ describe('d2l-all-courses', function() {
 			});
 			widget._enrollmentsSearchAction = entity.actions[0];
 
-			widget._onSimpleOverlayClosed(closeEvent);
+			widget._onSimpleOverlayClosed();
 
 			expect(widget._enrollmentsSearchAction.getFieldByName('search').value).to.be.equal('');
 			expect(widget._enrollmentsSearchAction.getFieldByName('sort').value).to.be.equal('Current');
@@ -276,7 +275,7 @@ describe('d2l-all-courses', function() {
 			const searchField = widget.$['search-widget'];
 
 			searchField._getSearchWidget()._getSearchInput().value = 'foo';
-			widget._onSimpleOverlayClosed(closeEvent);
+			widget._onSimpleOverlayClosed();
 
 			expect(spy.called).to.be.true;
 			expect(searchField._getSearchWidget()._getSearchInput().value).to.equal('');
@@ -295,7 +294,7 @@ describe('d2l-all-courses', function() {
 			fireEvent(widget.$.filterDropdownContent, 'd2l-dropdown-close', {});
 
 			expect(widget._filterText).to.equal('Filter: 1 Filter');
-			widget._onSimpleOverlayClosed(closeEvent);
+			widget._onSimpleOverlayClosed();
 			expect(spy.called).to.be.true;
 			expect(widget._filterText).to.equal('Filter');
 		});
@@ -312,7 +311,7 @@ describe('d2l-all-courses', function() {
 			fireEvent(widget.shadowRoot.querySelector('d2l-dropdown-menu'), 'd2l-menu-item-change', event);
 			expect(widget._searchUrl).to.contain('OrgUnitCode,OrgUnitId');
 
-			widget._onSimpleOverlayClosed(closeEvent);
+			widget._onSimpleOverlayClosed();
 			expect(spy.called).to.be.true;
 		});
 

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -476,7 +476,7 @@ describe('d2l-my-courses', () => {
 		it('should remove a course image failure alert when the all courses overlay is closed', function() {
 			component._showImageError = true;
 
-			component._onAllCoursesOverlayClosed();
+			component._onAllCoursesClose();
 			expect(component._showImageError).to.be.false;
 		});
 	});
@@ -595,15 +595,20 @@ describe('d2l-my-courses', () => {
 			});
 		});
 
-		describe('d2l-simple-overlay-closed', () => {
-			it('should remove an existing course image failure alert and tell d2l-my-courses-content that the overlay closed', () => {
+		describe('d2l-all-courses-close', () => {
+			it('should remove an existing course image failure alert and tell d2l-my-courses-content that the overlay closed', done => {
 				const stub = sandbox.stub(component._getContentComponent(), 'allCoursesOverlayClosed');
 				component._showImageError = true;
 
-				component._onAllCoursesOverlayClosed();
+				const event = new CustomEvent('d2l-all-courses-close');
+				component._getAllCoursesComponent().dispatchEvent(event);
 
-				expect(stub).to.have.been.called;
-				expect(component._showImageError).to.be.false;
+				setTimeout(() => {
+					expect(stub).to.have.been.called;
+					expect(component._showImageError).to.be.false;
+					done();
+				});
+
 			});
 		});
 


### PR DESCRIPTION
Because of https://github.com/Brightspace/simple-overlay/blob/master/d2l-simple-overlay.js#L109, listening to the `d2l-simple-overlay-closed` event on the `d2l-all-courses` component meant `_onAllCoursesOverlayClosed` was being called over ten times for one overlay close.  To stop this, I'm now sending a custom `d2l-all-courses-close` event, which feels better anyways - `d2l-my-courses-container` shouldn't know that `d2l-all-courses` contains a `d2l-simple-overlay` anyways.
