### PR TITLE
Us114855 - Use shared d2l-sort-by-dropdown in d2l-all-courses

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@brightspace-ui/core": "^1",
     "d2l-course-image": "Brightspace/course-image#semver:^3",
     "d2l-enrollments": "BrightspaceHypermediaComponents/enrollments#semver:^4",
+    "d2l-facet-filter-sort": "BrightspaceUI/facet-filter-sort#semver:^3",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-hypermedia-constants": "^6",
     "d2l-image-selector": "Brightspace/image-selector#semver:^4",

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -8,14 +8,13 @@ import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
-import '@brightspace-ui/core/components/dropdown/dropdown-menu.js';
 import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
-import '@brightspace-ui/core/components/menu/menu.js';
-import '@brightspace-ui/core/components/menu/menu-item-radio.js';
 import '@brightspace-ui/core/components/tabs/tabs.js';
 import '@brightspace-ui/core/components/tabs/tab-panel.js';
+import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
+import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
 import 'd2l-organization-hm-behavior/d2l-organization-hm-behavior.js';
 import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import './d2l-my-courses-card-grid.js';
@@ -234,6 +233,13 @@ class AllCourses extends mixinBehaviors([
 						margin-top: 5px;
 					}
 				}
+				d2l-sort-by-dropdown {
+					margin-left: 1rem;
+				}
+				:host(:dir(rtl)) d2l-sort-by-dropdown {
+					margin-left: 0;
+					margin-right: 1rem;
+				}
 				.dropdown-opener-text {
 					font-size: 0.95rem;
 					font-family: Lato;
@@ -250,18 +256,6 @@ class AllCourses extends mixinBehaviors([
 				}
 				.dropdown-button > d2l-icon {
 					margin-left: 4px;
-				}
-				.dropdown-content-header {
-					box-sizing: border-box;
-					display: flex;
-					align-items: center;
-					justify-content: space-between;
-					border-bottom: 1px solid var(--d2l-color-mica);
-					width: 100%;
-					padding: 20px;
-				}
-				.dropdown-content-gradient {
-					background: linear-gradient(to top, white, var(--d2l-color-regolith));
 				}
 				button[aria-pressed="true"] {
 					color: var(--d2l-color-celestine);
@@ -329,25 +323,15 @@ class AllCourses extends mixinBehaviors([
 									</d2l-dropdown-content>
 								</d2l-dropdown>
 
-								<d2l-dropdown id="sortDropdown" on-d2l-menu-item-change="_onSortOrderChanged">
-									<button class="d2l-dropdown-opener dropdown-button" aria-labelledby="sortText">
-										<span id="sortText" class="dropdown-opener-text">[[localize('sorting.sortDefault')]]</span>
-										<d2l-icon icon="tier1:chevron-down" aria-hidden="true"></d2l-icon>
-									</button>
-									<d2l-dropdown-menu no-padding="" min-width="350">
-										<d2l-menu id="sortDropdownMenu" label="[[localize('sorting.sortBy')]]">
-											<div class="dropdown-content-header">
-												<span>[[localize('sorting.sortBy')]]</span>
-											</div>
-											<d2l-menu-item-radio class="dropdown-content-gradient" value="Default" text="[[localize('sorting.sortDefault')]]"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="OrgUnitName" text="[[localize('sorting.sortCourseName')]]"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="OrgUnitCode" text="[[localize('sorting.sortCourseCode')]]"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="PinDate" text="[[localize('sorting.sortDatePinned')]]"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="LastAccessed" text="[[localize('sorting.sortLastAccessed')]]"></d2l-menu-item-radio>
-											<d2l-menu-item-radio value="EnrollmentDate" text="[[localize('sorting.sortEnrollmentDate')]]"></d2l-menu-item-radio>
-										</d2l-menu>
-									</d2l-dropdown-menu>
-								</d2l-dropdown>
+								<d2l-sort-by-dropdown align="end" label="[[localize('sorting.sortBy')]]" value="[[_sortMap[0].name]]" on-d2l-sort-by-dropdown-change="_onSortOrderChanged">
+									<d2l-sort-by-dropdown-option value="Default" text="[[localize('sorting.sortDefault')]]"></d2l-sort-by-dropdown-option>
+									<d2l-sort-by-dropdown-option value="OrgUnitName" text="[[localize('sorting.sortCourseName')]]"></d2l-sort-by-dropdown-option>
+									<d2l-sort-by-dropdown-option value="OrgUnitCode" text="[[localize('sorting.sortCourseCode')]]"></d2l-sort-by-dropdown-option>
+									<d2l-sort-by-dropdown-option value="PinDate" text="[[localize('sorting.sortDatePinned')]]"></d2l-sort-by-dropdown-option>
+									<d2l-sort-by-dropdown-option value="LastAccessed" text="[[localize('sorting.sortLastAccessed')]]"></d2l-sort-by-dropdown-option>
+									<d2l-sort-by-dropdown-option value="EnrollmentDate" text="[[localize('sorting.sortEnrollmentDate')]]"></d2l-sort-by-dropdown-option>
+								</d2l-sort-by-dropdown>
+
 							</div>
 						</div>
 						<div class="search-and-filter-row advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]">
@@ -524,9 +508,6 @@ class AllCourses extends mixinBehaviors([
 				promotePins: sortData.promotePins
 			})
 		);
-
-		this.$.sortText.textContent = this.localize(sortData.langterm || '');
-		this.$.sortDropdown.toggleOpen();
 	}
 
 	_onSearchResultsChanged(e) {
@@ -569,7 +550,7 @@ class AllCourses extends mixinBehaviors([
 		this._clearSearchWidget();
 		this.$.filterMenu.clearFilters();
 		this._filterText = this.localize('filtering.filter');
-		this._resetSortDropdown();
+		this.shadowRoot.querySelector(`d2l-sort-by-dropdown-option[value=${this._sortMap[0].name}]`).click();
 
 		e.stopPropagation();
 		this.dispatchEvent(new CustomEvent('d2l-all-courses-close'));
@@ -635,18 +616,6 @@ class AllCourses extends mixinBehaviors([
 
 		const searchAction = myEnrollmentsEntity.getActionByName(Actions.enrollments.searchMyEnrollments);
 		this._enrollmentsSearchAction = searchAction;
-
-		if (searchAction && searchAction.hasFieldByName('sort')) {
-			const sortParameter = searchAction.getFieldByName('sort').value;
-			if (!sortParameter) {
-				return;
-			}
-
-			const sortData = this._mapSortOption(sortParameter, 'action');
-
-			this.$.sortText.textContent = this.localize(sortData.langterm || '');
-			this._selectSortOption(sortData.name);
-		}
 	}
 
 	/*
@@ -702,24 +671,6 @@ class AllCourses extends mixinBehaviors([
 		}
 
 		return this._sortMap[0];
-	}
-
-	_resetSortDropdown() {
-		this._selectSortOption(this._sortMap[0].name);
-
-		const content = this.$.sortDropdown.__getContentElement();
-		if (content) {
-			content.close();
-		}
-	}
-
-	_selectSortOption(sortName) {
-		const items = this.$.sortDropdownMenu.querySelectorAll('d2l-menu-item-radio');
-		for (let i = 0; i < items.length; i++) {
-			items[i].selected = false;
-		}
-
-		this.$.sortDropdownMenu.querySelector(`d2l-menu-item-radio[value=${sortName}]`).selected = true;
 	}
 
 	_updateFilteredEnrollments(enrollments, append) {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -141,37 +141,31 @@ class AllCourses extends mixinBehaviors([
 						{
 							name: 'Default',
 							action: 'Current',
-							langterm: 'sorting.sortDefault',
 							promotePins: true
 						},
 						{
 							name: 'OrgUnitName',
 							action: 'OrgUnitName,OrgUnitId',
-							langterm: 'sorting.sortCourseName',
 							promotePins: false
 						},
 						{
 							name: 'OrgUnitCode',
 							action: 'OrgUnitCode,OrgUnitId',
-							langterm: 'sorting.sortCourseCode',
 							promotePins: false
 						},
 						{
 							name: 'PinDate',
 							action: '-PinDate,OrgUnitId',
-							langterm: 'sorting.sortDatePinned',
 							promotePins: true
 						},
 						{
 							name: 'LastAccessed',
 							action: 'LastAccessed',
-							langterm: 'sorting.sortLastAccessed',
 							promotePins: false
 						},
 						{
 							name: 'EnrollmentDate',
 							action: '-LastModifiedDate,OrgUnitId',
-							langterm: 'sorting.sortEnrollmentDate',
 							promotePins: false
 						}
 					];

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "عمليات البحث الحديثة",
 	"search.searchCourses": "البحث في المقررات التعليمية",
 	"sorting.sortBy": "الفرز حسب",
-	"sorting.sortCourseCode": "الفرز: رمز المقرر التعليمي",
-	"sorting.sortCourseName": "الفرز: اسم المقرر التعليمي",
-	"sorting.sortDatePinned": "الفرز: تاريخ التثبيت",
-	"sorting.sortDefault": "الفرز: افتراضي",
-	"sorting.sortEnrollmentDate": "الفرز: تاريخ التسجيل",
-	"sorting.sortLastAccessed": "الفرز: آخر وصول",
+	"sorting.sortCourseCode": "رمز المقرر التعليمي",
+	"sorting.sortCourseName": "اسم المقرر التعليمي",
+	"sorting.sortDatePinned": "تاريخ التثبيت",
+	"sorting.sortDefault": "افتراضي",
+	"sorting.sortEnrollmentDate": "تاريخ التسجيل",
+	"sorting.sortLastAccessed": "آخر وصول",
 	"viewAllCourses": "عرض كل المقررات التعليمية"
 };

--- a/src/lang/cy-gb.js
+++ b/src/lang/cy-gb.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recent Searches",
 	"search.searchCourses": "Search Courses",
 	"sorting.sortBy": "Sort By",
-	"sorting.sortCourseCode": "Sort: Course Code",
-	"sorting.sortCourseName": "Sort: Course Name",
-	"sorting.sortDatePinned": "Sort: Date Pinned",
-	"sorting.sortDefault": "Sort: Default",
-	"sorting.sortEnrollmentDate": "Sort: Enrollment Date",
-	"sorting.sortLastAccessed": "Sort: Last Accessed",
+	"sorting.sortCourseCode": "Course Code",
+	"sorting.sortCourseName": "Course Name",
+	"sorting.sortDatePinned": "Date Pinned",
+	"sorting.sortDefault": "Default",
+	"sorting.sortEnrollmentDate": "Enrollment Date",
+	"sorting.sortLastAccessed": "Last Accessed",
 	"viewAllCourses": "View All Courses"
 };

--- a/src/lang/da-dk.js
+++ b/src/lang/da-dk.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Seneste søgninger",
 	"search.searchCourses": "Søg i kurser",
 	"sorting.sortBy": "Sortér efter",
-	"sorting.sortCourseCode": "Sortér: Kursuskode",
-	"sorting.sortCourseName": "Sortér: Kursusnavn",
-	"sorting.sortDatePinned": "Sortér: Dato for fastgørelse",
-	"sorting.sortDefault": "Sortér: Standard",
-	"sorting.sortEnrollmentDate": "Sortér: Tilmeldingsdato",
-	"sorting.sortLastAccessed": "Sortér: Senest åbnet",
+	"sorting.sortCourseCode": "Kursuskode",
+	"sorting.sortCourseName": "Kursusnavn",
+	"sorting.sortDatePinned": "Dato for fastgørelse",
+	"sorting.sortDefault": "Standard",
+	"sorting.sortEnrollmentDate": "Tilmeldingsdato",
+	"sorting.sortLastAccessed": "Senest åbnet",
 	"viewAllCourses": "Vis alle kurser"
 };

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Letzte Suchanfragen",
 	"search.searchCourses": "Kurse suchen",
 	"sorting.sortBy": "Sortieren nach",
-	"sorting.sortCourseCode": "Sortieren nach: Kurscode",
-	"sorting.sortCourseName": "Sortieren nach: Kursname",
-	"sorting.sortDatePinned": "Sortieren nach: Angeheftet am",
-	"sorting.sortDefault": "Sortieren: Standard",
-	"sorting.sortEnrollmentDate": "Sortieren: Anmeldedatum",
-	"sorting.sortLastAccessed": "Sortieren nach: Letzter Zugriff",
+	"sorting.sortCourseCode": "Kurscode",
+	"sorting.sortCourseName": "Kursname",
+	"sorting.sortDatePinned": "Angeheftet am",
+	"sorting.sortDefault": "Standard",
+	"sorting.sortEnrollmentDate": "Anmeldedatum",
+	"sorting.sortLastAccessed": "Letzter Zugriff",
 	"viewAllCourses": "Alle Kurse anzeigen"
 };

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recent Searches",
 	"search.searchCourses": "Search Courses",
 	"sorting.sortBy": "Sort By",
-	"sorting.sortCourseCode": "Sort: Course Code",
-	"sorting.sortCourseName": "Sort: Course Name",
-	"sorting.sortDatePinned": "Sort: Date Pinned",
-	"sorting.sortDefault": "Sort: Default",
-	"sorting.sortEnrollmentDate": "Sort: Enrollment Date",
-	"sorting.sortLastAccessed": "Sort: Last Accessed",
+	"sorting.sortCourseCode": "Course Code",
+	"sorting.sortCourseName": "Course Name",
+	"sorting.sortDatePinned": "Date Pinned",
+	"sorting.sortDefault": "Default",
+	"sorting.sortEnrollmentDate": "Enrollment Date",
+	"sorting.sortLastAccessed": "Last Accessed",
 	"viewAllCourses": "View All Courses"
 };

--- a/src/lang/es-es.js
+++ b/src/lang/es-es.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recent Searches",
 	"search.searchCourses": "Search Courses",
 	"sorting.sortBy": "Sort By",
-	"sorting.sortCourseCode": "Sort: Course Code",
-	"sorting.sortCourseName": "Sort: Course Name",
-	"sorting.sortDatePinned": "Sort: Date Pinned",
-	"sorting.sortDefault": "Sort: Default",
-	"sorting.sortEnrollmentDate": "Sort: Enrollment Date",
-	"sorting.sortLastAccessed": "Sort: Last Accessed",
+	"sorting.sortCourseCode": "Course Code",
+	"sorting.sortCourseName": "Course Name",
+	"sorting.sortDatePinned": "Date Pinned",
+	"sorting.sortDefault": "Default",
+	"sorting.sortEnrollmentDate": "Enrollment Date",
+	"sorting.sortLastAccessed": "Last Accessed",
 	"viewAllCourses": "View All Courses"
 };

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Búsquedas recientes",
 	"search.searchCourses": "Buscar cursos",
 	"sorting.sortBy": "Ordenar por",
-	"sorting.sortCourseCode": "Ordenar por: código del curso",
-	"sorting.sortCourseName": "Ordenar por: nombre del curso",
-	"sorting.sortDatePinned": "Ordenar por: fecha anclada",
-	"sorting.sortDefault": "Ordenar por: predeterminado",
-	"sorting.sortEnrollmentDate": "Ordenar por: fecha de inscripción",
-	"sorting.sortLastAccessed": "Ordenar por: último acceso",
+	"sorting.sortCourseCode": "Código del curso",
+	"sorting.sortCourseName": "Nombre del curso",
+	"sorting.sortDatePinned": "Fecha anclada",
+	"sorting.sortDefault": "Predeterminado",
+	"sorting.sortEnrollmentDate": "Fecha de inscripción",
+	"sorting.sortLastAccessed": "Último acceso",
 	"viewAllCourses": "Ver todos los cursos"
 };

--- a/src/lang/fi.js
+++ b/src/lang/fi.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Viimeisimmät haut",
 	"search.searchCourses": "Hae kursseja",
 	"sorting.sortBy": "Lajitteluperuste",
-	"sorting.sortCourseCode": "Lajittelu: kurssin koodi",
-	"sorting.sortCourseName": "Lajittelu: kurssin nimi",
-	"sorting.sortDatePinned": "Lajittelu: kiinnityspäivämäärä",
-	"sorting.sortDefault": "Lajittelu: oletus",
-	"sorting.sortEnrollmentDate": "Lajittelu: rekisteröitymispäivämäärä",
-	"sorting.sortLastAccessed": "Lajittelu: viimeisin käyttökerta",
+	"sorting.sortCourseCode": "Kurssin koodi",
+	"sorting.sortCourseName": "Kurssin nimi",
+	"sorting.sortDatePinned": "Kiinnityspäivämäärä",
+	"sorting.sortDefault": "Oletus",
+	"sorting.sortEnrollmentDate": "Rekisteröitymispäivämäärä",
+	"sorting.sortLastAccessed": "Viimeisin käyttökerta",
 	"viewAllCourses": "Näytä kaikki kurssit"
 };

--- a/src/lang/fr-fr.js
+++ b/src/lang/fr-fr.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recherches récentes",
 	"search.searchCourses": "Rechercher des cours",
 	"sorting.sortBy": "Trier par",
-	"sorting.sortCourseCode": "Tri : code du cours",
-	"sorting.sortCourseName": "Tri : nom du cours",
-	"sorting.sortDatePinned": "Tri : date de l’épinglement",
-	"sorting.sortDefault": "Tri : par défaut",
-	"sorting.sortEnrollmentDate": "Tri : date d’inscription",
-	"sorting.sortLastAccessed": "Tri : dernière connexion",
+	"sorting.sortCourseCode": "Code du cours",
+	"sorting.sortCourseName": "Nom du cours",
+	"sorting.sortDatePinned": "Date de l’épinglement",
+	"sorting.sortDefault": "Par défaut",
+	"sorting.sortEnrollmentDate": "Date d’inscription",
+	"sorting.sortLastAccessed": "Dernière connexion",
 	"viewAllCourses": "Afficher tous les cours"
 };

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recherches récentes",
 	"search.searchCourses": "Rechercher des cours",
 	"sorting.sortBy": "Trier par",
-	"sorting.sortCourseCode": "Trier : Code de cours",
-	"sorting.sortCourseName": "Trier : Nom de cours",
-	"sorting.sortDatePinned": "Trier : Date de l'épinglage",
-	"sorting.sortDefault": "Trier : Par défaut",
-	"sorting.sortEnrollmentDate": "Trier : Date d'inscription",
-	"sorting.sortLastAccessed": "Trier : Date de l'accès le plus récent",
+	"sorting.sortCourseCode": "Code de cours",
+	"sorting.sortCourseName": "Nom de cours",
+	"sorting.sortDatePinned": "Date de l'épinglage",
+	"sorting.sortDefault": "Par défaut",
+	"sorting.sortEnrollmentDate": "Date d'inscription",
+	"sorting.sortLastAccessed": "Date de l'accès le plus récent",
 	"viewAllCourses": "Afficher tous les cours"
 };

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "最近の検索",
 	"search.searchCourses": "コースの検索",
 	"sorting.sortBy": "並べ替え基準",
-	"sorting.sortCourseCode": "並べ替え: コースコード",
-	"sorting.sortCourseName": "並べ替え: コース名",
-	"sorting.sortDatePinned": "並べ替え: 固定した日付",
-	"sorting.sortDefault": "並べ替え: デフォルト",
-	"sorting.sortEnrollmentDate": "並べ替え: 登録日",
-	"sorting.sortLastAccessed": "並べ替え: 最終アクセス",
+	"sorting.sortCourseCode": "コースコード",
+	"sorting.sortCourseName": "コース名",
+	"sorting.sortDatePinned": "固定した日付",
+	"sorting.sortDefault": "デフォルト",
+	"sorting.sortEnrollmentDate": "登録日",
+	"sorting.sortLastAccessed": "最終アクセス",
 	"viewAllCourses": "すべてのコースの表示"
 };

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "최근 검색",
 	"search.searchCourses": "강의 검색",
 	"sorting.sortBy": "정렬 기준",
-	"sorting.sortCourseCode": "정렬: 강의 코드",
-	"sorting.sortCourseName": "정렬: 강의 이름",
-	"sorting.sortDatePinned": "정렬: 고정된 날짜",
-	"sorting.sortDefault": "정렬: 기본값",
-	"sorting.sortEnrollmentDate": "정렬: 등록 날짜",
-	"sorting.sortLastAccessed": "정렬: 최종 접속",
+	"sorting.sortCourseCode": "강의 코드",
+	"sorting.sortCourseName": "강의 이름",
+	"sorting.sortDatePinned": "고정된 날짜",
+	"sorting.sortDefault": "기본값",
+	"sorting.sortEnrollmentDate": "등록 날짜",
+	"sorting.sortLastAccessed": "최종 접속",
 	"viewAllCourses": "모든 강의 보기"
 };

--- a/src/lang/nb.js
+++ b/src/lang/nb.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Siste søk",
 	"search.searchCourses": "Søk i undervisningsenheter",
 	"sorting.sortBy": "Sorter etter",
-	"sorting.sortCourseCode": "Sorter: Kode for undervisningsenhet",
-	"sorting.sortCourseName": "Sorter: Navn på undervisningsenhet",
-	"sorting.sortDatePinned": "Sorter: Dato for festing",
-	"sorting.sortDefault": "Sort: Default",
-	"sorting.sortEnrollmentDate": "Sort: Enrollment Date",
-	"sorting.sortLastAccessed": "Sorter: Sist åpnet",
+	"sorting.sortCourseCode": "Kode for undervisningsenhet",
+	"sorting.sortCourseName": "Navn på undervisningsenhet",
+	"sorting.sortDatePinned": "Dato for festing",
+	"sorting.sortDefault": "Default",
+	"sorting.sortEnrollmentDate": "Enrollment Date",
+	"sorting.sortLastAccessed": "Sist åpnet",
 	"viewAllCourses": "Vis alle undervisningsenheter"
 };

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Recente zoekopdrachten",
 	"search.searchCourses": "Op cursus zoeken",
 	"sorting.sortBy": "Sorteren op",
-	"sorting.sortCourseCode": "Sorteren op: cursuscode",
-	"sorting.sortCourseName": "Sorteren op: cursusnaam",
-	"sorting.sortDatePinned": "Sorteren op: datum vastgepind",
-	"sorting.sortDefault": "Sorteren op: standaard",
-	"sorting.sortEnrollmentDate": "Sorteren op: inschrijvingsdatum",
-	"sorting.sortLastAccessed": "Sorteren op: laatst geopend",
+	"sorting.sortCourseCode": "Cursuscode",
+	"sorting.sortCourseName": "Cursusnaam",
+	"sorting.sortDatePinned": "Datum vastgepind",
+	"sorting.sortDefault": "Standaard",
+	"sorting.sortEnrollmentDate": "Inschrijvingsdatum",
+	"sorting.sortLastAccessed": "Laatst geopend",
 	"viewAllCourses": "Alle cursussen weergeven"
 };

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Pesquisas Recentes",
 	"search.searchCourses": "Pesquisar Cursos",
 	"sorting.sortBy": "Classificar por",
-	"sorting.sortCourseCode": "Classificar: Código do Curso",
-	"sorting.sortCourseName": "Classificar: Nome do Curso",
-	"sorting.sortDatePinned": "Classificar: Data Fixada",
-	"sorting.sortDefault": "Classificar: Padrão",
-	"sorting.sortEnrollmentDate": "Classificar: Data de Inscrição",
-	"sorting.sortLastAccessed": "Classificar: Data do Último Acesso",
+	"sorting.sortCourseCode": "Código do Curso",
+	"sorting.sortCourseName": "Nome do Curso",
+	"sorting.sortDatePinned": "Data Fixada",
+	"sorting.sortDefault": "Padrão",
+	"sorting.sortEnrollmentDate": "Data de Inscrição",
+	"sorting.sortLastAccessed": "Data do Último Acesso",
 	"viewAllCourses": "Exibir Todos os Cursos"
 };

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "Senaste sökningar",
 	"search.searchCourses": "Sök kurser",
 	"sorting.sortBy": "Sortera efter",
-	"sorting.sortCourseCode": "Sortera: kurskod",
-	"sorting.sortCourseName": "Sortera: kursnamn",
-	"sorting.sortDatePinned": "Sortera: datum markerat",
-	"sorting.sortDefault": "Sortera: standard",
-	"sorting.sortEnrollmentDate": "Sortera: inskrivningsdatum",
-	"sorting.sortLastAccessed": "Sortera: senast öppnad",
+	"sorting.sortCourseCode": "Kurskod",
+	"sorting.sortCourseName": "Kursnamn",
+	"sorting.sortDatePinned": "Datum markerat",
+	"sorting.sortDefault": "Standard",
+	"sorting.sortEnrollmentDate": "Inskrivningsdatum",
+	"sorting.sortLastAccessed": "Senast öppnad",
 	"viewAllCourses": "Visa alla kurser"
 };

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "En Son Aramalar",
 	"search.searchCourses": "Dersleri Ara",
 	"sorting.sortBy": "Sıralama Ölçütü",
-	"sorting.sortCourseCode": "Sırala: Ders Kodu",
-	"sorting.sortCourseName": "Sırala: Ders Adı",
-	"sorting.sortDatePinned": "Sırala: Sabitleme Tarihi",
-	"sorting.sortDefault": "Sırala: Varsayılan",
-	"sorting.sortEnrollmentDate": "Sırala: Kayıt Tarihi",
-	"sorting.sortLastAccessed": "Sırala: Son Erişim",
+	"sorting.sortCourseCode": "Ders Kodu",
+	"sorting.sortCourseName": "Ders Adı",
+	"sorting.sortDatePinned": "Sabitleme Tarihi",
+	"sorting.sortDefault": "Varsayılan",
+	"sorting.sortEnrollmentDate": "Kayıt Tarihi",
+	"sorting.sortLastAccessed": "Son Erişim",
 	"viewAllCourses": "Tüm Dersleri Görüntüle"
 };

--- a/src/lang/zh-tw.js
+++ b/src/lang/zh-tw.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "近期的搜尋",
 	"search.searchCourses": "搜尋課程",
 	"sorting.sortBy": "排序方式",
-	"sorting.sortCourseCode": "排序：課程代碼",
-	"sorting.sortCourseName": "排序：課程名稱",
-	"sorting.sortDatePinned": "排序：置頂日期",
-	"sorting.sortDefault": "排序：預設",
-	"sorting.sortEnrollmentDate": "排序：註冊日期",
-	"sorting.sortLastAccessed": "排序：上次存取時間",
+	"sorting.sortCourseCode": "課程代碼",
+	"sorting.sortCourseName": "課程名稱",
+	"sorting.sortDatePinned": "置頂日期",
+	"sorting.sortDefault": "預設",
+	"sorting.sortEnrollmentDate": "註冊日期",
+	"sorting.sortLastAccessed": "上次存取時間",
 	"viewAllCourses": "檢視所有課程"
 };

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -33,11 +33,11 @@ export default {
 	"recentSearches": "最近搜索",
 	"search.searchCourses": "搜索课程",
 	"sorting.sortBy": "排序依据",
-	"sorting.sortCourseCode": "排序：课程代码",
-	"sorting.sortCourseName": "排序：课程名称",
-	"sorting.sortDatePinned": "排序：锁定日期",
-	"sorting.sortDefault": "排序：默认",
-	"sorting.sortEnrollmentDate": "排序：报名日期",
-	"sorting.sortLastAccessed": "排序：上次访问",
+	"sorting.sortCourseCode": "课程代码",
+	"sorting.sortCourseName": "课程名称",
+	"sorting.sortDatePinned": "锁定日期",
+	"sorting.sortDefault": "默认",
+	"sorting.sortEnrollmentDate": "报名日期",
+	"sorting.sortLastAccessed": "上次访问",
 	"viewAllCourses": "查看所有课程"
 };

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -140,9 +140,9 @@ describe('d2l-all-courses', function() {
 		});
 	});
 
-	describe('d2l-menu-item-change event', function() {
+	describe('d2l-sort-by-dropdown-change event', function() {
 		it('should set the _searchUrl', function() {
-			fireEvent(widget.$.sortDropdown, 'd2l-menu-item-change', {
+			fireEvent(widget.shadowRoot.querySelector('d2l-sort-by-dropdown'), 'd2l-sort-by-dropdown-change', {
 				value: 'LastAccessed'
 			});
 
@@ -301,7 +301,7 @@ describe('d2l-all-courses', function() {
 		});
 
 		it('should clear sort', function() {
-			const spy = sandbox.spy(widget, '_resetSortDropdown');
+			const sortDropdown = widget.shadowRoot.querySelector('d2l-sort-by-dropdown');
 
 			const event = {
 				selected: true,
@@ -309,11 +309,11 @@ describe('d2l-all-courses', function() {
 			};
 
 			widget.load();
-			fireEvent(widget.shadowRoot.querySelector('d2l-dropdown-menu'), 'd2l-menu-item-change', event);
-			expect(widget._searchUrl).to.contain('OrgUnitCode,OrgUnitId');
+			fireEvent(sortDropdown, 'd2l-sort-by-dropdown-change', event);
+			expect(widget._searchUrl).to.contain('sort=OrgUnitCode,OrgUnitId');
 
 			widget._onSimpleOverlayClosed(closeEvent);
-			expect(spy.called).to.be.true;
+			expect(widget._searchUrl).to.contain('sort=Current');
 		});
 
 	});


### PR DESCRIPTION
This is blocked on https://github.com/BrightspaceHypermediaComponents/common/pull/36 and https://github.com/BrightspaceHypermediaComponents/activities/pull/1027 - otherwise BSI will break if someone tries to take the latest my-courses version (I plan on just doing a minor release).

This swaps out our homemade sort dropdown with the shared one in `facet-filter-sort`.  I'll be doing the same for the filter dropdown next.  Until then the openers will look a bit odd being different, but hopefully for only a few days.

![image](https://user-images.githubusercontent.com/13419300/89663016-e36b8f00-d8a2-11ea-8a3d-cf5890dda4f0.png)
