### PR TITLE
Use subtle button opener for the filter in the All Courses overlay

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -5,7 +5,6 @@ Polymer-based web component for the all courses overlay.
 
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import '@brightspace-ui/core/components/alert/alert.js';
-import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 import '@brightspace-ui/core/components/link/link.js';

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -6,9 +6,8 @@ Polymer-based web component for the all courses overlay.
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/colors/colors.js';
-import '@brightspace-ui/core/components/dropdown/dropdown.js';
+import '@brightspace-ui/core/components/dropdown/dropdown-button-subtle.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
-import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import '@brightspace-ui/core/components/tabs/tabs.js';
@@ -183,11 +182,6 @@ class AllCourses extends mixinBehaviors([
 				d2l-alert {
 					margin-bottom: 20px;
 				}
-				d2l-icon {
-					--d2l-icon-height: 15px;
-					--d2l-icon-width: 15px;
-					margin-top: -0.35rem;
-				}
 				d2l-loading-spinner {
 					margin-bottom: 30px;
 					padding-bottom: 30px;
@@ -227,42 +221,15 @@ class AllCourses extends mixinBehaviors([
 						margin-top: 5px;
 					}
 				}
+				d2l-dropdown-button-subtle,
 				d2l-sort-by-dropdown {
-					margin-left: 1rem;
+					margin-left: 0.5rem;
 				}
+				:host(:dir(rtl)) d2l-dropdown-button-subtle,
 				:host(:dir(rtl)) d2l-sort-by-dropdown {
 					margin-left: 0;
-					margin-right: 1rem;
+					margin-right: 0.5rem;
 				}
-				.dropdown-opener-text {
-					font-size: 0.95rem;
-					font-family: Lato;
-					cursor: pointer;
-					padding: 0;
-					margin-left: 1rem;
-				}
-				.dropdown-button {
-					background: none;
-					border: none;
-					cursor: pointer;
-					padding: 0;
-					color: var(--d2l-color-ferrite);
-				}
-				.dropdown-button > d2l-icon {
-					margin-left: 4px;
-				}
-				button[aria-pressed="true"] {
-					color: var(--d2l-color-celestine);
-				}
-				button:focus > d2l-icon,
-				button:hover > d2l-icon,
-				button:focus > span,
-				button:hover > span,
-				.focus {
-					text-decoration: underline;
-					color: var(--d2l-color-celestine);
-				}
-
 				#infoMessage {
 					padding-bottom: 20px;
 				}
@@ -292,11 +259,7 @@ class AllCourses extends mixinBehaviors([
 							</d2l-search-widget-custom>
 
 							<div id="filterAndSort">
-								<d2l-dropdown id="filterDropdown">
-									<button class="d2l-dropdown-opener dropdown-button" aria-labelledby="filterText">
-										<span id="filterText" class="dropdown-opener-text">[[_filterText]]</span>
-										<d2l-icon icon="tier1:chevron-down" aria-hidden="true"></d2l-icon>
-									</button>
+								<d2l-dropdown-button-subtle text="[[_filterText]]">
 									<d2l-dropdown-content
 										id="filterDropdownContent"
 										on-d2l-dropdown-open="_onFilterDropdownOpen"
@@ -315,7 +278,7 @@ class AllCourses extends mixinBehaviors([
 											filter-standard-department-name="[[filterStandardDepartmentName]]">
 										</d2l-filter-menu>
 									</d2l-dropdown-content>
-								</d2l-dropdown>
+								</d2l-dropdown-button-subtle>
 
 								<d2l-sort-by-dropdown align="end" label="[[localize('sorting.sortBy')]]" value="[[_sortMap[0].name]]" on-d2l-sort-by-dropdown-change="_onSortOrderChanged">
 									<d2l-sort-by-dropdown-option value="Default" text="[[localize('sorting.sortDefault')]]"></d2l-sort-by-dropdown-option>


### PR DESCRIPTION
Swapping the custom filter for `d2l-filter-dropdown` won't be making it in this release, so I'm just updating the opener to be a subtle button like the new `d2l-sort-by-dropdown`, to keep things looking nice for the September release.  Also lets me do some nice css cleanup earlier.

Before:
![image](https://user-images.githubusercontent.com/13419300/90165132-38594a80-dd66-11ea-9a94-017fbbb05b1c.png)
![image](https://user-images.githubusercontent.com/13419300/90165082-2677a780-dd66-11ea-8eaf-43198eabf7e9.png)

After:
![image](https://user-images.githubusercontent.com/13419300/90165184-4b6c1a80-dd66-11ea-913e-debe523f0c32.png)
![image](https://user-images.githubusercontent.com/13419300/90164990-0ea02380-dd66-11ea-8e99-2a3d5420e44c.png)
