### PR TITLE
US114856 - DE36186 - Add new lit my courses filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "d2l-search-widget": "Brightspace/d2l-search-widget-ui#semver:^5",
     "d2l-simple-overlay": "Brightspace/simple-overlay.git#semver:^3",
     "d2l-typography": "BrightspaceUI/typography#semver:^7",
+    "lit-element": "^2",
     "@polymer/iron-a11y-announcer": "^3.0.0",
     "@polymer/iron-a11y-keys-behavior": "^3.0.0",
     "@polymer/iron-menu-behavior": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-lit": "^1",
     "eslint-plugin-sort-class-members": "^1",
     "polymer-cli": "^1.9.8",
+    "sinon": "^9",
     "wct-browser-legacy": "^1.0.1"
   },
   "version": "11.22.0",

--- a/src/d2l-utility-helpers.js
+++ b/src/d2l-utility-helpers.js
@@ -74,7 +74,10 @@ export function parseEntity(entity) {
 	return SirenParse(entity);
 }
 
-// This is only used by the filter menu and can hopefully be removed after that is moved to the shared component
+/* Ideally we would be using performSirenAction from siren-sdk/src/es6/SirenAction.js instead of this.
+ * However, the LMS is encoding the "via" field of the "set-role-filters" action, which cause it to be
+ * double-encoded and not understood by the LMS. The LMS needs to be updated, which will affect legacy as well.
+ */
 export function fetchSirenEntity(url, clearCache) {
 	if (!url) {
 		return;

--- a/src/localize-behavior.js
+++ b/src/localize-behavior.js
@@ -20,8 +20,9 @@ import zh from './lang/zh.js';
 import zhtw from './lang/zh-tw.js';
 
 // eslint-disable-next-line sort-imports
-import {dedupingMixin} from '@polymer/polymer/lib/utils/mixin.js';
-import {mixinBehaviors} from '@polymer/polymer/lib/legacy/class.js';
+import { dedupingMixin } from '@polymer/polymer/lib/utils/mixin.js';
+import { LocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 const MyCoursesLocalizeBehaviorImpl = (superClass) => {
 	return class extends mixinBehaviors([D2L.PolymerBehaviors.LocalizeBehavior], superClass) {
@@ -58,3 +59,83 @@ const MyCoursesLocalizeBehaviorImpl = (superClass) => {
 };
 
 export const MyCoursesLocalizeBehavior = dedupingMixin(MyCoursesLocalizeBehaviorImpl);
+
+export const MyCoursesLocalizeMixin = superclass => class extends LocalizeMixin(superclass) {
+
+	static async getLocalizeResources(langs) {
+		let translations;
+		for await (const lang of langs) {
+			switch (lang) {
+				case 'ar':
+					translations = ar;
+					break;
+				case 'cy-gb':
+					translations = cygb;
+					break;
+				case 'da-dk':
+					translations = dadk;
+					break;
+				case 'de':
+					translations = de;
+					break;
+				case 'en':
+					translations = en;
+					break;
+				case 'es':
+					translations = es;
+					break;
+				case 'es-es':
+					translations = eses;
+					break;
+				case 'fi':
+					translations = fi;
+					break;
+				case 'fr':
+					translations = fr;
+					break;
+				case 'fr-fr':
+					translations = frfr;
+					break;
+				case 'ja':
+					translations = ja;
+					break;
+				case 'ko':
+					translations = ko;
+					break;
+				case 'nb':
+					translations = nb;
+					break;
+				case 'nl':
+					translations = nl;
+					break;
+				case 'pt':
+					translations = pt;
+					break;
+				case 'sv':
+					translations = sv;
+					break;
+				case 'tr':
+					translations = tr;
+					break;
+				case 'zh':
+					translations = zh;
+					break;
+				case 'zh-tw':
+					translations = zhtw;
+					break;
+			}
+
+			if (translations) {
+				return {
+					language: lang,
+					resources: translations
+				};
+			}
+		}
+		translations = en;
+		return {
+			language: 'en',
+			resources: translations
+		};
+	}
+};

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -63,7 +63,7 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 				});
 			}
 			this._loadCategories();
-		};
+		}
 	}
 
 	render() {
@@ -84,20 +84,20 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 						?disable-search="${this._hasFiltersClass(category) || (!category.isSearched && category.options && category.options.length === 0)}"
 						selected-option-count="${category.selectedOptions ? category.selectedOptions.length : 0}">
 
-						${category.options && category.options.map(option => html`
-							<d2l-filter-dropdown-option
-								?selected="${category.selectedOptions.findIndex(optionKey => optionKey === option.key) > -1}"
-								text="${ifDefined(option.name)}"
-								value="${option.key}">
-							</d2l-filter-dropdown-option>
-						`)}
-
 						${category.optionsLoaded ? html`
-							<div
-								class="d2l-my-courses-filter-no-options-text d2l-body-compact"
-								?hidden="${category.options && category.options.length > 0}">
-								${category.isSearched ? this.localize('noSearchResults') : category.noOptionsText}
-							</div>` : html`
+							${category.options && category.options.length > 0 ? html`
+								${category.options.map(option => html`
+									<d2l-filter-dropdown-option
+										?selected="${category.selectedOptions.findIndex(optionKey => optionKey === option.key) > -1}"
+										text="${ifDefined(option.name)}"
+										value="${option.key}">
+									</d2l-filter-dropdown-option>
+								`)}` : html`
+								<div class="d2l-my-courses-filter-no-options-text d2l-body-compact">
+									${category.isSearched ? this.localize('noSearchResults') : category.noOptionsText}
+								</div>
+							`}
+						` : html`
 							<d2l-loading-spinner></d2l-loading-spinner>
 						`}
 					</d2l-filter-dropdown-category>

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -1,0 +1,291 @@
+/*
+`d2l-my-courses-filter`
+Lit web component for the my courses filter.
+*/
+
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-category.js';
+import 'd2l-facet-filter-sort/components/d2l-filter-dropdown/d2l-filter-dropdown-option.js';
+import { createActionUrl, fetchSirenEntity } from '../d2l-utility-helpers.js';
+import { css, html, LitElement } from 'lit-element';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles.js';
+import { ifDefined } from 'lit-html/directives/if-defined.js';
+import { MyCoursesLocalizeMixin } from '../localize-behavior.js';
+
+class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
+
+	static get properties() {
+		return {
+			filterCategories: { type: Array },
+			_hasBeenOpened: { attribute: false, type: Boolean },
+			_totalSelectedCount: { attribute: false, type: Number}
+		};
+	}
+
+	static get styles() {
+		return [bodyCompactStyles, css`
+			d2l-loading-spinner {
+				width: 100%;
+			}
+			.d2l-my-courses-filter-no-options-text {
+				@apply --d2l-body-compact-text;
+				display: block;
+				padding: 0 1rem 1rem 1rem;
+			}
+			[hidden].d2l-my-courses-filter-no-options-text {
+				display: none;
+			}
+		`];
+	}
+
+	constructor() {
+		super();
+		this.filterCategories = [];
+		this._hasBeenOpened = false;
+		this._totalSelectedCount = 0;
+	}
+
+	clear() {
+		this._onFilterDropdownCleared();
+	}
+
+	updated(changedProperties) {
+		super.updated(changedProperties);
+
+		changedProperties.forEach((oldValue, propName) => {
+			if (propName === 'filterCategories') {
+				for (let i = 0; i < this.filterCategories.length; i++) {
+					Object.assign(this.filterCategories[i], {
+						isSearched: false,
+						options: [],
+						optionsLoaded: false,
+						optionsLoadRequested: false,
+						selectedOptions: []
+					});
+				}
+				this._loadCategories();
+			}
+		});
+	}
+
+	render() {
+		return html`
+			<d2l-filter-dropdown
+				@d2l-dropdown-open="${this._onDropdownOpen}"
+				@d2l-filter-dropdown-cleared="${this._onFilterDropdownCleared}"
+				min-width="350"
+				total-selected-option-count="${this._totalSelectedCount}">
+
+				${this.filterCategories.map(category => html`
+					<d2l-filter-dropdown-category
+						@d2l-filter-dropdown-category-selected="${this._onFilterDropdownCategorySelected}"
+						@d2l-filter-dropdown-category-searched="${this._onFilterDropdownCategorySearched}"
+						@d2l-filter-dropdown-option-change="${this._onFilterDropdownOptionChange}"
+						key="${category.key}"
+						category-text="${ifDefined(category.name)}"
+						?disable-search="${this._hasFiltersClass(category) || (!category.isSearched && category.options && category.options.length === 0)}"
+						selected-option-count="${category.selectedOptions ? category.selectedOptions.length : 0}">
+
+						${category.options && category.options.map(option => html`
+							<d2l-filter-dropdown-option
+								?selected="${category.selectedOptions.findIndex(optionKey => optionKey === option.key) > -1}"
+								text="${ifDefined(option.name)}"
+								value="${option.key}">
+							</d2l-filter-dropdown-option>
+						`)}
+
+						${category.optionsLoaded ? html`
+							<div
+								class="d2l-my-courses-filter-no-options-text d2l-body-compact"
+								?hidden="${category.options && category.options.length > 0}">
+								${category.isSearched ? this.localize('noSearchResults') : category.noOptionsText}
+							</div>` : html`
+							<d2l-loading-spinner></d2l-loading-spinner>
+						`}
+					</d2l-filter-dropdown-category>
+				`)}
+			</d2l-filter-dropdown>
+		`;
+	}
+
+	/* This filter supports two different types of HM filtering methods, which we distinguish throughout
+	 * by checking for the "filters" class on the entity containing the options
+	 */
+	_hasFiltersClass(category) {
+		return category.optionsEntity && category.optionsEntity.hasClass('filters');
+	}
+
+	_loadCategories() {
+		for (let i = 0; i < this.filterCategories.length; i++) {
+			const filter = this.filterCategories[i];
+			if (filter.optionsLoaded) {
+				continue;
+			}
+			const href = createActionUrl(filter.filterAction);
+			fetchSirenEntity(href).then(resultingEntity => {
+				filter.optionsEntity = resultingEntity;
+				if (filter.optionsLoadRequested) {
+					if (this._hasFiltersClass(filter)) {
+						this._parseOptions(filter);
+					} else {
+						this._fetchOptions(filter);
+					}
+				}
+			});
+		}
+	}
+
+	_loadOptions(category) {
+		if (!category || category.optionsLoaded) {
+			return;
+		}
+
+		if (!category.optionsEntity) {
+			// The call to get the options entity hasn't finished, so we request it to get the options when it's done
+			category.optionsLoadRequested = true;
+			return;
+		}
+
+		if (!this._hasFiltersClass(category)) {
+			this._fetchOptions(category);
+		} else {
+			this._parseOptions(category);
+		}
+	}
+
+	_fetchOptions(category) {
+		let options = [];
+		if (category.optionsEntity && category.optionsEntity.entities) {
+			options = category.optionsEntity.entities.map(option => {
+				return {
+					key: option.href
+				};
+			});
+		}
+
+		category.options = options;
+
+		const promises = [];
+		for (let j = 0; j < options.length; j++) {
+			promises.push(
+				fetchSirenEntity(options[j].key)
+					.then(result => {
+						category.options[j].name = result.properties.name;
+					})
+					.catch((e) => {
+						// eslint-disable-next-line no-console
+						console.log(e);
+					})
+			);
+		}
+
+		Promise.all(promises)
+			.then(() => {
+				category.optionsLoaded = true;
+				this.requestUpdate();
+			})
+			.catch((e) => {
+				// eslint-disable-next-line no-console
+				console.log(e);
+			});
+	}
+
+	_parseOptions(category) {
+		const options = [];
+		if (category.optionsEntity && category.optionsEntity.entities) {
+			const entities = category.optionsEntity.entities;
+			for (let i = 0; i < entities.length; i++) {
+				// Options with the same name should be grouped together for this filter type
+				const alreadyAdded = options.find(option => option.key === entities[i].title);
+				if (!alreadyAdded) {
+					options.push({
+						name: entities[i].title,
+						key: entities[i].title
+					});
+				}
+			}
+		}
+
+		category.options = options;
+		category.optionsLoaded = true;
+		this.requestUpdate();
+	}
+
+	_onDropdownOpen() {
+		this._hasBeenOpened = true;
+		this._loadOptions(this.filterCategories[0]);
+	}
+
+	_onFilterDropdownCategorySearched(e) {
+		const category = this.filterCategories.find(filter => filter.key === e.detail.categoryKey);
+
+		category.isSearched = e.detail.value ? true : false;
+		this.requestUpdate();
+
+		const searchActionHref = createActionUrl(category.filterAction, {
+			search: encodeURIComponent(e.detail.value)
+		});
+
+		fetchSirenEntity(searchActionHref).then((resultingEntity) => {
+			category.optionsEntity = resultingEntity;
+			// We don't need to check the filters class here, since if the filters class is present search is disabled
+			this._fetchOptions(category);
+		});
+	}
+
+	_onFilterDropdownCategorySelected(e) {
+		if (!this._hasBeenOpened) {
+			return; // Don't load any options until the filter has been opened
+		}
+		const category = this.filterCategories.find(category => category.key === e.detail.categoryKey);
+		this._loadOptions(category);
+	}
+
+	_onFilterDropdownCleared() {
+		this._totalSelectedCount = 0;
+
+		for (let i = 0; i < this.filterCategories.length; i++) {
+			this.filterCategories[i].selectedOptions = [];
+		}
+		this.requestUpdate();
+
+		this.dispatchEvent(new CustomEvent('d2l-my-courses-filter-clear'));
+	}
+
+	_onFilterDropdownOptionChange(e) {
+		const category = this.filterCategories.find(category => category.key === e.detail.categoryKey);
+		const optionIndex = category.selectedOptions.findIndex(optionKey => optionKey === e.detail.menuItemKey);
+
+		if (e.detail.selected) {
+			this._totalSelectedCount++;
+			if (optionIndex === -1) {
+				category.selectedOptions.push(e.detail.menuItemKey);
+				this.requestUpdate();
+			}
+		} else {
+			this._totalSelectedCount--;
+			if (optionIndex > -1) {
+				category.selectedOptions.splice(optionIndex, 1);
+				this.requestUpdate();
+			}
+		}
+
+		const selectedFilters = this.filterCategories.map(category => {
+			return {
+				key: category.key,
+				selectedOptions: category.selectedOptions
+			};
+		});
+
+		this.dispatchEvent(new CustomEvent('d2l-my-courses-filter-change', {
+			detail: {
+				categoryChanged: e.detail.categoryKey,
+				selectedFilters: selectedFilters
+			}
+		}));
+	}
+
+}
+
+window.customElements.define('d2l-my-courses-filter', MyCoursesFilter);

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -109,6 +109,13 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 		`;
 	}
 
+	/* Wrapped for easier test stubbing. Ideally, this will eventually use the entity store
+	 * (see the note in d2l-utility-helpers.js)
+	 */
+	_fetchSirenEntity(url) {
+		return fetchSirenEntity(url);
+	}
+
 	/* This filter supports two different types of HM filtering methods, which we distinguish throughout
 	 * by checking for the "filters" class on the entity containing the options
 	 */
@@ -123,7 +130,7 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 				continue;
 			}
 			const href = createActionUrl(filter.filterAction);
-			fetchSirenEntity(href).then(resultingEntity => {
+			this._fetchSirenEntity(href).then(resultingEntity => {
 				filter.optionsEntity = resultingEntity;
 				if (filter.optionsLoadRequested) {
 					if (this._hasFiltersClass(filter)) {
@@ -169,7 +176,7 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 		const promises = [];
 		for (let j = 0; j < options.length; j++) {
 			promises.push(
-				fetchSirenEntity(options[j].key)
+				this._fetchSirenEntity(options[j].key)
 					.then(result => {
 						category.options[j].name = result.properties.name;
 					})
@@ -227,7 +234,7 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 			search: encodeURIComponent(e.detail.value)
 		});
 
-		fetchSirenEntity(searchActionHref).then((resultingEntity) => {
+		this._fetchSirenEntity(searchActionHref).then((resultingEntity) => {
 			category.optionsEntity = resultingEntity;
 			// We don't need to check the filters class here, since if the filters class is present search is disabled
 			this._fetchOptions(category);

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -52,20 +52,18 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 	updated(changedProperties) {
 		super.updated(changedProperties);
 
-		changedProperties.forEach((oldValue, propName) => {
-			if (propName === 'filterCategories') {
-				for (let i = 0; i < this.filterCategories.length; i++) {
-					Object.assign(this.filterCategories[i], {
-						isSearched: false,
-						options: [],
-						optionsLoaded: false,
-						optionsLoadRequested: false,
-						selectedOptions: []
-					});
-				}
-				this._loadCategories();
+		if (changedProperties.has('filterCategories')) {
+			for (let i = 0; i < this.filterCategories.length; i++) {
+				Object.assign(this.filterCategories[i], {
+					isSearched: false,
+					options: [],
+					optionsLoaded: false,
+					optionsLoadRequested: false,
+					selectedOptions: []
+				});
 			}
-		});
+			this._loadCategories();
+		};
 	}
 
 	render() {
@@ -163,37 +161,25 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 	_fetchSearchOptions(category) {
 		let options = [];
 		if (category.optionsEntity && category.optionsEntity.entities) {
-			options = category.optionsEntity.entities.map(option => {
-				return {
-					key: option.href
-				};
-			});
+			options = category.optionsEntity.entities.map(option => ({ key: option.href }));
 		}
 
 		category.options = options;
 
-		const promises = [];
-		for (let j = 0; j < options.length; j++) {
-			promises.push(
-				this._fetchSirenEntity(options[j].key)
-					.then(result => {
-						category.options[j].name = result.properties.name;
-					})
-					.catch((e) => {
-						// eslint-disable-next-line no-console
-						console.log(e);
-					})
-			);
-		}
+		const promises = options.map(option => this._fetchSirenEntity(option.key)
+			.then(result => {
+				option.name = result.properties.name;
+			})
+			.catch((e) => {
+				// eslint-disable-next-line no-console
+				console.log(e);
+			})
+		);
 
 		Promise.all(promises)
 			.then(() => {
 				category.optionsLoaded = true;
 				this.requestUpdate();
-			})
-			.catch((e) => {
-				// eslint-disable-next-line no-console
-				console.log(e);
 			});
 	}
 

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -29,7 +29,6 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 				width: 100%;
 			}
 			.d2l-my-courses-filter-no-options-text {
-				@apply --d2l-body-compact-text;
 				display: block;
 				padding: 0 1rem 1rem 1rem;
 			}
@@ -134,9 +133,9 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 				filter.optionsEntity = resultingEntity;
 				if (filter.optionsLoadRequested) {
 					if (this._hasFiltersClass(filter)) {
-						this._parseOptions(filter);
+						this._parseFilterOptions(filter);
 					} else {
-						this._fetchOptions(filter);
+						this._fetchSearchOptions(filter);
 					}
 				}
 			});
@@ -155,13 +154,13 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 		}
 
 		if (!this._hasFiltersClass(category)) {
-			this._fetchOptions(category);
+			this._fetchSearchOptions(category);
 		} else {
-			this._parseOptions(category);
+			this._parseFilterOptions(category);
 		}
 	}
 
-	_fetchOptions(category) {
+	_fetchSearchOptions(category) {
 		let options = [];
 		if (category.optionsEntity && category.optionsEntity.entities) {
 			options = category.optionsEntity.entities.map(option => {
@@ -198,12 +197,12 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 			});
 	}
 
-	_parseOptions(category) {
+	_parseFilterOptions(category) {
 		const options = [];
 		if (category.optionsEntity && category.optionsEntity.entities) {
 			const entities = category.optionsEntity.entities;
 			for (let i = 0; i < entities.length; i++) {
-				// Options with the same name should be grouped together for this filter type
+				// Options with the same name should be grouped together for this filter type (DE27982)
 				const alreadyAdded = options.find(option => option.key === entities[i].title);
 				if (!alreadyAdded) {
 					options.push({
@@ -237,7 +236,7 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 		this._fetchSirenEntity(searchActionHref).then((resultingEntity) => {
 			category.optionsEntity = resultingEntity;
 			// We don't need to check the filters class here, since if the filters class is present search is disabled
-			this._fetchOptions(category);
+			this._fetchSearchOptions(category);
 		});
 	}
 

--- a/src/search-filter/d2l-my-courses-filter.js
+++ b/src/search-filter/d2l-my-courses-filter.js
@@ -32,9 +32,6 @@ class MyCoursesFilter extends MyCoursesLocalizeMixin(LitElement) {
 				display: block;
 				padding: 0 1rem 1rem 1rem;
 			}
-			[hidden].d2l-my-courses-filter-no-options-text {
-				display: none;
-			}
 		`];
 	}
 

--- a/test/d2l-my-courses-filter/d2l-my-courses-filter.html
+++ b/test/d2l-my-courses-filter/d2l-my-courses-filter.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script type="module" src="../../../siren-parser/global.js"></script>
+		<script type="module" src="../../src/search-filter/d2l-my-courses-filter.js"></script>
+	</head>
+	<body>
+		<test-fixture id="d2l-my-courses-filter-fixture">
+			<template>
+				<d2l-my-courses-filter></d2l-my-courses-filter>
+			</template>
+		</test-fixture>
+
+		<script type="module" src="./d2l-my-courses-filter.js"></script>
+	</body>
+</html>

--- a/test/d2l-my-courses-filter/d2l-my-courses-filter.js
+++ b/test/d2l-my-courses-filter/d2l-my-courses-filter.js
@@ -17,9 +17,6 @@ function sirenParse(entity) {
 }
 
 function timeout(ms) {
-	if (ms === 0) {
-		return new Promise(requestAnimationFrame);
-	}
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
 

--- a/test/d2l-my-courses-filter/d2l-my-courses-filter.js
+++ b/test/d2l-my-courses-filter/d2l-my-courses-filter.js
@@ -261,8 +261,8 @@ describe('d2l-my-courses-filter', () => {
 		});
 
 		it('should not reload the first tab\'s options if they have already been loaded', async() => {
-			const stubFetchOptions = sandbox.stub(component, '_fetchOptions');
-			const stubParseOptions = sandbox.stub(component, '_parseOptions');
+			const stubFetchSearchOptions = sandbox.stub(component, '_fetchSearchOptions');
+			const stubParseFilterOptions = sandbox.stub(component, '_parseFilterOptions');
 			component.filterCategories = [departmentFilterType];
 			await component.updateComplete;
 
@@ -273,8 +273,8 @@ describe('d2l-my-courses-filter', () => {
 
 			await timeout(0);
 			expect(component.filterCategories[0].optionsLoadRequested).to.be.false;
-			expect(stubFetchOptions).to.not.be.called;
-			expect(stubParseOptions).to.not.be.called;
+			expect(stubFetchSearchOptions).to.not.be.called;
+			expect(stubParseFilterOptions).to.not.be.called;
 		});
 	});
 

--- a/test/d2l-my-courses-filter/d2l-my-courses-filter.js
+++ b/test/d2l-my-courses-filter/d2l-my-courses-filter.js
@@ -1,0 +1,672 @@
+import sinon from 'sinon';
+
+let sandbox,
+	component,
+	semesterFilterType,
+	semesterEntity,
+	semester1,
+	semester2,
+	departmentFilterType,
+	departmentEntity,
+	roleFilterType,
+	roleEntity,
+	fetchStub;
+
+function sirenParse(entity) {
+	return window.D2L.Hypermedia.Siren.Parse(entity);
+}
+
+function timeout(ms) {
+	if (ms === 0) {
+		return new Promise(requestAnimationFrame);
+	}
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+beforeEach(() => {
+	semesterFilterType = {
+		key: 'semesters',
+		name: 'Semesters',
+		noOptionsText: 'No Semesters',
+		filterAction: {
+			name: 'search-my-semesters',
+			href: '/semesters',
+			fields: [{
+				name: 'search',
+				value: ''
+			}]
+		}
+	};
+	semesterEntity = {
+		actions: [{
+			name: 'search-my-semesters',
+			href: '/semesters'
+		}],
+		class: ['collection', 'organization'],
+		entities: [{
+			class: ['active', 'semester'],
+			href: '/semester/1',
+			rel: ['https://api.brightspace.com/rels/organization']
+		}]
+	};
+	semester1 = {
+		href: '/semester/1',
+		properties: {
+			name: 'Semester 1'
+		}
+	};
+	semester2 = {
+		href: '/semester/2',
+		properties: {
+			name: 'Semester 2'
+		}
+	};
+
+	departmentFilterType = {
+		key: 'departments',
+		name: 'Departments',
+		noOptionsText: 'No Departments',
+		filterAction: {
+			name: 'search-my-departments',
+			href: '/departments',
+			fields: [{
+				name: 'search',
+				value: ''
+			}]
+		}
+	};
+	departmentEntity = {
+		actions: [{
+			name: 'search-my-departments',
+			href: '/departments'
+		}],
+		class: ['collection', 'organization'],
+	};
+
+	roleFilterType = {
+		key: 'roles',
+		name: 'Roles',
+		noOptionsText: 'No Roles',
+		filterAction: {
+			name: 'set-role-filters',
+			href: '/role-filters',
+			fields: [{
+				name: 'include',
+				value: ''
+			}]
+		}
+	};
+	roleEntity = {
+		actions: [{
+			name: 'apply-role-filters',
+			href: '/apply-role-filter'
+		}, {
+			name: 'clear-role-filters',
+			href: '/clear-role-filter'
+		}],
+		class: ['collection', 'filters'],
+		entities: [{
+			actions: [{
+				name: 'add-filter',
+				href: 'role/1'
+			}],
+			class: ['filter', 'off'],
+			rel: ['item'],
+			title: 'Student'
+		},
+		{
+			actions: [{
+				name: 'add-filter',
+				href: 'role/2'
+			}],
+			class: ['filter', 'off'],
+			rel: ['item'],
+			title: 'Instructor'
+		},
+		{
+			actions: [{
+				name: 'add-filter',
+				href: 'role/3'
+			}],
+			class: ['filter', 'off'],
+			rel: ['item'],
+			title: 'Student'
+		}]
+	};
+
+	sandbox = sinon.createSandbox();
+	component = fixture('d2l-my-courses-filter-fixture');
+
+	fetchStub = sandbox.stub(component, '_fetchSirenEntity');
+	fetchStub.withArgs(sinon.match(/\/semesters\?search=$/)).returns(Promise.resolve(sirenParse(semesterEntity)));
+	fetchStub.withArgs(sinon.match(/\/semesters\?search=1$/)).returns(Promise.resolve(sirenParse(semesterEntity)));
+	fetchStub.withArgs(sinon.match(/\/semester\/1/)).returns(Promise.resolve(sirenParse(semester1)));
+	fetchStub.withArgs(sinon.match(/\/semester\/2/)).returns(Promise.resolve(sirenParse(semester2)));
+	fetchStub.withArgs(sinon.match(/\/departments/)).returns(Promise.resolve(sirenParse(departmentEntity)));
+	fetchStub.withArgs(sinon.match(/\/role-filters/)).returns(Promise.resolve(sirenParse(roleEntity)));
+});
+
+afterEach(() => {
+	sandbox.restore();
+});
+
+describe('d2l-my-courses-filter', () => {
+	describe('Loading', () => {
+		it('should initialize categories with extra properties', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+
+			const category = component.filterCategories[0];
+			expect(category.isSearched).to.equal(false);
+			expect(category.options).to.deep.equal([]);
+			expect(category.optionsLoaded).to.equal(false);
+			expect(category.optionsLoadRequested).to.equal(false);
+			expect(category.selectedOptions).to.deep.equal([]);
+		});
+
+		it('should call to get the options entity for each category immediately, but not the options', async() => {
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+
+			expect(fetchStub.callCount).to.equal(2); // Once for each filter and once
+			expect(component.filterCategories[0].optionsEntity).to.deep.equal(sirenParse(semesterEntity));
+			expect(component.filterCategories[0].options).to.be.empty;
+			expect(component.filterCategories[1].optionsEntity).to.deep.equal(sirenParse(roleEntity));
+			expect(component.filterCategories[1].options).to.be.empty;
+		});
+
+		it('should load the options right after if a request was made while the entity was loading', async() => {
+			fetchStub.withArgs(sinon.match(/\/semesters/)).callsFake(async() => {
+				await timeout(150);
+				return Promise.resolve(sirenParse(semesterEntity));
+			});
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+
+			component.filterCategories[0].optionsLoadRequested = true;
+			await timeout(150);
+			expect(fetchStub.callCount).to.equal(3); // Once for each filter and once to get the semester option
+			expect(component.filterCategories[0].optionsEntity).to.deep.equal(sirenParse(semesterEntity));
+			expect(component.filterCategories[0].options.length).to.equal(1);
+			expect(component.filterCategories[1].optionsEntity).to.deep.equal(sirenParse(roleEntity));
+			expect(component.filterCategories[1].options).to.be.empty;
+		});
+
+		it('should show a loading spinner if the options are not loaded', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			const loadingSpinner = category.querySelector('d2l-loading-spinner');
+
+			expect(loadingSpinner).to.not.be.null;
+		});
+
+		it('should properly load the options that require fetching', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			expect(fetchStub.callCount).to.equal(2); // Once for the filter and once for the semester option
+			const category = component.filterCategories[0];
+			expect(category.optionsEntity.entities.length).to.equal(1);
+			expect(category.options.length).to.equal(1);
+			expect(category.options[0].key).to.equal('/semester/1');
+			expect(category.options[0].name).to.equal('Semester 1');
+		});
+
+		it('should properly load the options that require parsing and combine duplicates', async() => {
+			component.filterCategories = [roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			expect(fetchStub.callCount).to.equal(1); // Only once for the filter
+			const category = component.filterCategories[0];
+			expect(category.optionsEntity.entities.length).to.equal(3);
+			expect(category.options.length).to.equal(2);
+			expect(category.options[0].key).to.equal('Student');
+			expect(category.options[0].name).to.equal('Student');
+			expect(category.options[1].key).to.equal('Instructor');
+			expect(category.options[1].name).to.equal('Instructor');
+		});
+
+		it('should display the "noOptionsText" if there are no options', async() => {
+			component.filterCategories = [departmentFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			expect(fetchStub.callCount).to.equal(1); // Only once for the filter
+			const category = component.filterCategories[0];
+			expect(category.optionsEntity.entities).to.be.undefined;
+			expect(category.options.length).to.equal(0);
+			const noOptionsText = component.shadowRoot.querySelector('.d2l-my-courses-filter-no-options-text');
+			expect(noOptionsText.innerText).to.include('No Departments');
+		});
+	});
+
+	describe('Opening the Filter', () => {
+		it('should set _hasBeenOpened and load the first tab\'s options', async() => {
+			component.filterCategories = [departmentFilterType];
+			await component.updateComplete;
+
+			expect(component._hasBeenOpened).to.be.false;
+			expect(component.filterCategories[0].optionsLoaded).to.be.false;
+
+			const filter = component.shadowRoot.querySelector('d2l-filter-dropdown');
+			filter.dispatchEvent(new CustomEvent('d2l-dropdown-open'));
+
+			await timeout(0);
+			expect(component._hasBeenOpened).to.be.true;
+			expect(component.filterCategories[0].optionsLoaded).to.be.true;
+		});
+
+		it('should not reload the first tab\'s options if they have already been loaded', async() => {
+			const stubFetchOptions = sandbox.stub(component, '_fetchOptions');
+			const stubParseOptions = sandbox.stub(component, '_parseOptions');
+			component.filterCategories = [departmentFilterType];
+			await component.updateComplete;
+
+			component.filterCategories[0].optionsLoaded = true;
+
+			const filter = component.shadowRoot.querySelector('d2l-filter-dropdown');
+			filter.dispatchEvent(new CustomEvent('d2l-dropdown-open'));
+
+			await timeout(0);
+			expect(component.filterCategories[0].optionsLoadRequested).to.be.false;
+			expect(stubFetchOptions).to.not.be.called;
+			expect(stubParseOptions).to.not.be.called;
+		});
+	});
+
+	describe('Selecting a Filter Category', () => {
+		it('should do nothing if the filter has not been opened yet', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+
+			expect(component.filterCategories[0].optionsLoaded).to.be.false;
+			expect(component.filterCategories[0].options.length).to.be.empty;
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			category.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
+				detail: {
+					categoryKey: 'semesters'
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].optionsLoaded).to.be.false;
+			expect(component.filterCategories[0].options.length).to.be.empty;
+		});
+
+		it('should load that category\'s options if the filter has been opened', async() => {
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+
+			expect(component.filterCategories[0].optionsLoaded).to.be.false;
+			expect(component.filterCategories[0].options.length).to.be.empty;
+			expect(component.filterCategories[1].optionsLoaded).to.be.false;
+			expect(component.filterCategories[1].options.length).to.be.empty;
+
+			component._hasBeenOpened = true;
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			category.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
+				detail: {
+					categoryKey: 'semesters'
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].optionsLoaded).to.be.true;
+			expect(component.filterCategories[0].options.length).to.equal(1);
+
+			category.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-selected', {
+				detail: {
+					categoryKey: 'roles'
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[1].optionsLoaded).to.be.true;
+			expect(component.filterCategories[1].options.length).to.equal(2);
+		});
+	});
+
+	describe('Searching a Filter Category', () => {
+		it('should be disabled for the filter type with the class of "filters"', async() => {
+			component.filterCategories = [roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			expect(category.disableSearch).to.be.true;
+		});
+
+		it('should be disabled if the filter category has no options', async() => {
+			component.filterCategories = [departmentFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			expect(category.disableSearch).to.be.true;
+		});
+
+		it('should be enabled if the filter category supports it and has options', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			expect(category.disableSearch).to.be.false;
+		});
+
+		it('should remove values that do not match the search value, but keep selected values the same', async() => {
+			semesterEntity.entities.push({
+				class: ['active', 'semester'],
+				href: '/semester/2',
+				rel: ['https://api.brightspace.com/rels/organization']
+			});
+			fetchStub.withArgs(sinon.match(/\/semesters\?search=$/)).returns(Promise.resolve(sirenParse(semesterEntity)));
+
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			component.filterCategories[0].selectedOptions.push('/semester/2');
+			await component.requestUpdate();
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			category.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-searched', {
+				detail: {
+					categoryKey: 'semesters',
+					value: '1'
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].selectedOptions.length).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions[0]).to.equal('/semester/2');
+			expect(component.filterCategories[0].options.length).to.equal(1);
+			expect(component.filterCategories[0].options[0].key).to.equal('/semester/1');
+		});
+
+		it('should show the correct text and not disable the search input if all options are filtered out', async() => {
+			semesterEntity.entities = [];
+			fetchStub.withArgs(sinon.match(/\/semesters\?search=test$/)).returns(Promise.resolve(sirenParse(semesterEntity)));
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelector('d2l-filter-dropdown-category');
+			category.dispatchEvent(new CustomEvent('d2l-filter-dropdown-category-searched', {
+				detail: {
+					categoryKey: 'semesters',
+					value: 'test'
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].options).to.be.empty;
+			expect(category.disableSearch).to.be.false;
+			const noOptionsText = component.shadowRoot.querySelector('.d2l-my-courses-filter-no-options-text');
+			expect(noOptionsText.innerText).to.include('No results.');
+		});
+	});
+
+	describe('Selecting Filter Options', () => {
+		it('should increase the counts and set the selectedOptions array accordingly when a filter option is selected', async() => {
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+			expect(category[0].selectedOptionCount).to.equal(0);
+			expect(category[1].selectedOptionCount).to.equal(0);
+			expect(component.filterCategories[0].selectedOptions).to.be.empty;
+			expect(component.filterCategories[1].selectedOptions).to.be.empty;
+			expect(component._totalSelectedCount).to.equal(0);
+
+			category[0].dispatchEvent(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: true
+				}
+			}));
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(1);
+			expect(category[1].selectedOptionCount).to.equal(0);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+			expect(component.filterCategories[1].selectedOptions).to.be.empty;
+			expect(component._totalSelectedCount).to.equal(1);
+
+			category[1].dispatchEvent(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'roles',
+					menuItemKey: 'Student',
+					selected: true
+				}
+			}));
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(1);
+			expect(category[1].selectedOptionCount).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+			expect(component.filterCategories[1].selectedOptions).to.deep.equal(['Student']);
+			expect(component._totalSelectedCount).to.equal(2);
+		});
+
+		it('should decrease the counts and set the selectedOptions array accordingly when a filter option is unselected', async() => {
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: true
+				}
+			}));
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'roles',
+					menuItemKey: 'Student',
+					selected: true
+				}
+			}));
+			await timeout(0);
+
+			const category = component.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+			expect(category[0].selectedOptionCount).to.equal(1);
+			expect(category[1].selectedOptionCount).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+			expect(component.filterCategories[1].selectedOptions).to.deep.equal(['Student']);
+			expect(component._totalSelectedCount).to.equal(2);
+
+			category[0].dispatchEvent(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: false
+				}
+			}));
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(0);
+			expect(category[1].selectedOptionCount).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions).to.be.empty;
+			expect(component.filterCategories[1].selectedOptions).to.deep.equal(['Student']);
+			expect(component._totalSelectedCount).to.equal(1);
+
+			category[1].dispatchEvent(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'roles',
+					menuItemKey: 'Student',
+					selected: false
+				}
+			}));
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(0);
+			expect(category[1].selectedOptionCount).to.equal(0);
+			expect(component.filterCategories[0].selectedOptions).to.be.empty;
+			expect(component.filterCategories[1].selectedOptions).to.be.empty;
+			expect(component._totalSelectedCount).to.equal(0);
+		});
+
+		it('should only add each key to the selectedOptions array once', async() => {
+			component.filterCategories = [semesterFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: true
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: true
+				}
+			}));
+
+			await timeout(0);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+		});
+
+		it('should send a "d2l-my-courses-filter-change" event with the filter category that changed and the current state of all selected filters for each category', async() => {
+			component.filterCategories = [semesterFilterType, departmentFilterType, roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+
+			component.filterCategories[2].selectedOptions = ['Student', 'Instructor'];
+			await timeout(0);
+
+			function getEvent() {
+				return new Promise(resolve => {
+					component.addEventListener('d2l-my-courses-filter-change', (e) => resolve(e));
+				});
+			}
+
+			setTimeout(() => {
+				component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+					detail: {
+						categoryKey: 'semesters',
+						menuItemKey: '/semester/1',
+						selected: true
+					}
+				}));
+			}, 0);
+
+			const event = await getEvent();
+			expect(event.detail.categoryChanged).to.equal('semesters');
+			expect(event.detail.selectedFilters[0]).to.deep.equal({
+				key: 'semesters',
+				selectedOptions: ['/semester/1']
+			});
+			expect(event.detail.selectedFilters[1]).to.deep.equal({
+				key: 'departments',
+				selectedOptions: []
+			});
+			expect(event.detail.selectedFilters[2]).to.deep.equal({
+				key: 'roles',
+				selectedOptions: ['Student', 'Instructor']
+			});
+		});
+	});
+
+	describe('Clearing Filter Options', () => {
+		beforeEach(async() => {
+			component.filterCategories = [semesterFilterType, roleFilterType];
+			await component.updateComplete;
+			component._onDropdownOpen();
+
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'semesters',
+					menuItemKey: '/semester/1',
+					selected: true
+				}
+			}));
+			component._onFilterDropdownOptionChange(new CustomEvent('d2l-filter-dropdown-option-change', {
+				detail: {
+					categoryKey: 'roles',
+					menuItemKey: 'Student',
+					selected: true
+				}
+			}));
+			await timeout(0);
+		});
+		it('should reset the counts back to 0 and the selectedOptions array back to empty', async() => {
+			const filter = component.shadowRoot.querySelector('d2l-filter-dropdown');
+			const category = component.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+			expect(category[0].selectedOptionCount).to.equal(1);
+			expect(category[1].selectedOptionCount).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+			expect(component.filterCategories[1].selectedOptions).to.deep.equal(['Student']);
+			expect(component._totalSelectedCount).to.equal(2);
+
+			filter.dispatchEvent(new CustomEvent('d2l-filter-dropdown-cleared'));
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(0);
+			expect(category[1].selectedOptionCount).to.equal(0);
+			expect(component.filterCategories[0].selectedOptions).to.be.empty;
+			expect(component.filterCategories[1].selectedOptions).to.be.empty;
+			expect(component._totalSelectedCount).to.equal(0);
+		});
+
+		it('should do the same when the public function is called', async() => {
+			const category = component.shadowRoot.querySelectorAll('d2l-filter-dropdown-category');
+			expect(category[0].selectedOptionCount).to.equal(1);
+			expect(category[1].selectedOptionCount).to.equal(1);
+			expect(component.filterCategories[0].selectedOptions).to.deep.equal(['/semester/1']);
+			expect(component.filterCategories[1].selectedOptions).to.deep.equal(['Student']);
+			expect(component._totalSelectedCount).to.equal(2);
+
+			component.clear();
+
+			await timeout(0);
+			expect(category[0].selectedOptionCount).to.equal(0);
+			expect(category[1].selectedOptionCount).to.equal(0);
+			expect(component.filterCategories[0].selectedOptions).to.be.empty;
+			expect(component.filterCategories[1].selectedOptions).to.be.empty;
+			expect(component._totalSelectedCount).to.equal(0);
+		});
+
+		it('should send a "d2l-my-courses-filter-clear" event', async() => {
+			function getEvent() {
+				return new Promise(resolve => {
+					component.addEventListener('d2l-my-courses-filter-clear', (e) => resolve(e));
+				});
+			}
+
+			setTimeout(() => {
+				component._onFilterDropdownCleared();
+			}, 0);
+
+			const event = await getEvent();
+			expect(event.type).to.equal('d2l-my-courses-filter-clear');
+		});
+	});
+
+});

--- a/test/index.all.html
+++ b/test/index.all.html
@@ -17,6 +17,7 @@
 				'./d2l-my-courses-card-grid/d2l-my-courses-card-grid.html',
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
+				'./d2l-my-courses-filter/d2l-my-courses-filter.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',
 				'./d2l-utility-helpers/d2l-utility-helpers.html',
 				'./localize-behavior/localize-behavior.html',

--- a/test/index.high-priority.html
+++ b/test/index.high-priority.html
@@ -17,6 +17,7 @@
 				'./d2l-my-courses-card-grid/d2l-my-courses-card-grid.html',
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
+				'./d2l-my-courses-filter/d2l-my-courses-filter.html',
 				'./d2l-search-widget-custom/d2l-search-widget-custom.html',
 				'./d2l-utility-helpers/d2l-utility-helpers.html',
 				'./localize-behavior/localize-behavior.html'

--- a/test/localize-behavior/consumer-element.js
+++ b/test/localize-behavior/consumer-element.js
@@ -1,4 +1,5 @@
-import { MyCoursesLocalizeBehavior } from '../../src/localize-behavior.js';
+import { MyCoursesLocalizeBehavior, MyCoursesLocalizeMixin } from '../../src/localize-behavior.js';
+import { LitElement } from 'lit-element';
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class ConsumerElement extends MyCoursesLocalizeBehavior(PolymerElement) {
@@ -6,4 +7,10 @@ class ConsumerElement extends MyCoursesLocalizeBehavior(PolymerElement) {
 }
 
 window.customElements.define(ConsumerElement.is, ConsumerElement);
+
+class ConsumerElementLit extends MyCoursesLocalizeMixin(LitElement) {
+	static get is() { return 'consumer-element-lit'; }
+}
+
+window.customElements.define(ConsumerElementLit.is, ConsumerElementLit);
 

--- a/test/localize-behavior/localize-behavior.html
+++ b/test/localize-behavior/localize-behavior.html
@@ -15,6 +15,12 @@
 			</template>
 		</test-fixture>
 
-		<script src="./localize-behavior.js"></script>
+		<test-fixture id="lit-fixture">
+			<template>
+				<consumer-element-lit></consumer-element-lit>
+			</template>
+		</test-fixture>
+
+		<script type="module" src="./localize-behavior.js"></script>
 	</body>
 </html>

--- a/test/localize-behavior/localize-behavior.js
+++ b/test/localize-behavior/localize-behavior.js
@@ -1,45 +1,86 @@
-describe('localize behavior', function() {
+import { getDocumentLocaleSettings } from '@brightspace-ui/intl/lib/common.js';
+
+describe('localize-behavior', function() {
 	let component;
 
-	beforeEach(function() {
-		document.documentElement.removeAttribute('lang');
-	});
+	describe('Polymer Behavior', function() {
+		beforeEach(() => {
+			document.documentElement.removeAttribute('lang');
+		});
 
-	it('should have default language', done => {
-		component = fixture('default-fixture');
+		it('should have default language', done => {
+			component = fixture('default-fixture');
 
-		requestAnimationFrame(() => {
-			expect(component.language).to.equal('en');
-			expect(component.localize('allCourses')).to.equal('All Courses');
-			done();
+			requestAnimationFrame(() => {
+				expect(component.language).to.equal('en');
+				expect(component.localize('allCourses')).to.equal('All Courses');
+				done();
+			});
+		});
+
+		it('should use lang specified', done => {
+			document.documentElement.setAttribute('lang', 'fr');
+
+			component = fixture('default-fixture');
+
+			requestAnimationFrame(() => {
+				expect(component.language).to.equal('fr');
+				expect(component.localize('allCourses')).to.equal('Tous les cours');
+				done();
+			});
+		});
+
+		it('should use default language if provided language does not exist', done => {
+			document.documentElement.setAttribute('lang', 'zz-ZZ');
+
+			component = fixture('default-fixture');
+
+			requestAnimationFrame(() => {
+				expect(component.language).to.equal('en');
+				expect(component.localize('allCourses')).to.equal('All Courses');
+				done();
+			});
 		});
 	});
 
-	it('should use lang specified', done => {
-		document.documentElement.setAttribute('lang', 'fr');
+	describe('Lit Mixin', function() {
+		const documentLocaleSettings = getDocumentLocaleSettings();
 
-		component = fixture('default-fixture');
+		afterEach(() => {
+			documentLocaleSettings.reset();
+		});
 
-		requestAnimationFrame(() => {
-			expect(component.language).to.equal('fr');
-			expect(component.localize('allCourses')).to.equal('Tous les cours');
-			done();
+		it('should have default language', done => {
+			component = fixture('lit-fixture');
+
+			requestAnimationFrame(() => {
+				expect(component.localize('allCourses')).to.equal('All Courses');
+				done();
+			});
+		});
+
+		it('should use lang specified', done => {
+			documentLocaleSettings.language = 'fr';
+			component = fixture('lit-fixture');
+
+			requestAnimationFrame(() => {
+				expect(component.localize('allCourses')).to.equal('Tous les cours');
+				done();
+			});
+		});
+
+		it('should use default language if provided language does not exist', done => {
+			documentLocaleSettings.language = 'zz-ZZ';
+			component = fixture('lit-fixture');
+
+			requestAnimationFrame(() => {
+				expect(component.localize('allCourses')).to.equal('All Courses');
+				done();
+			});
 		});
 	});
 
-	it('should use default language if provided language does not exist', done => {
-		document.documentElement.setAttribute('lang', 'zz-ZZ');
-
-		component = fixture('default-fixture');
-
-		requestAnimationFrame(() => {
-			expect(component.language).to.equal('en');
-			expect(component.localize('allCourses')).to.equal('All Courses');
-			done();
-		});
-	});
-
-	describe('localize mappings', function() {
+	describe('Verify Mappings', function() {
 		it('should have translation for every english term', function() {
 			component = fixture('default-fixture');
 			const terms = Object.keys(component.resources['en']);
@@ -53,6 +94,7 @@ describe('localize behavior', function() {
 		});
 
 		it('should have no empty mappings for supported langs', function() {
+			component = fixture('default-fixture');
 			const locales = Object.keys(component.resources);
 			for (let i = 0; i < locales.length; i++) {
 				const currentLocale = locales[i];
@@ -60,9 +102,7 @@ describe('localize behavior', function() {
 				for (let j = 0; j < mappings.length; j++) {
 					expect(mappings[j].trim()).to.not.equal('');
 				}
-
 			}
 		});
 	});
-
 });


### PR DESCRIPTION
This PR adds the new Lit `d2l-my-courses-filter`, and the next PR will use it in `d2l-all-courses`.  This is the first Lit component in this repo so I adjusted the `localize-behavior` to also export a mixin that uses the `LocalizeMixin` from `core`.

This component understands how to load its options given a Siren Action, but then simply returns the requested filter changes back to the consumer in an event (rather than applying the filters itself like in the old `d2l-filer-menu`, `d2l-filter-menu-tab`, and `d2l-filter-menu-tab-roles`).  This means the logic in `d2l-all-courses` will get a bit more complicated, but it greatly reduces the logic of the new filter and the amount of things it needs to be passed.

Because the semester and departments filters act differently than the roles filter, you'll see two different ways to deal with the options when they are loaded.  I differentiate using the "filters" class on the entity, to avoid hardcoding in this filter to specifically look for the "roles" filter.