### PR TITLE
US120538 - Cleanup pre-pinned tab code

### DIFF
--- a/demo/d2l-my-courses/d2l-my-courses-alerts.html
+++ b/demo/d2l-my-courses/d2l-my-courses-alerts.html
@@ -6,6 +6,11 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../d2l-my-courses.js';
+
+			// Turn off the PUT call to attempt to update the user settings on tab change
+			window.D2L.Siren.ActionQueue.enqueue = function() {
+				return Promise.resolve();
+			};
 		</script>
 		<title>d2l-my-courses - Alerts Demo</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/demo/d2l-my-courses/d2l-my-courses-completion-tracking.html
+++ b/demo/d2l-my-courses/d2l-my-courses-completion-tracking.html
@@ -6,6 +6,11 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../d2l-my-courses.js';
+
+			// Turn off the PUT call to attempt to update the user settings on tab change
+			window.D2L.Siren.ActionQueue.enqueue = function() {
+				return Promise.resolve();
+			};
 		</script>
 		<title>d2l-my-courses - Completion Tracking Demo</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/demo/d2l-my-courses/d2l-my-courses.html
+++ b/demo/d2l-my-courses/d2l-my-courses.html
@@ -6,6 +6,11 @@
 		<script type="module">
 			import '@brightspace-ui/core/components/demo/demo-page.js';
 			import '../../d2l-my-courses.js';
+
+			// Turn off the PUT call to attempt to update the user settings on tab change
+			window.D2L.Siren.ActionQueue.enqueue = function() {
+				return Promise.resolve();
+			};
 		</script>
 		<title>d2l-my-courses - Demo</title>
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/demo/data/my-enrollments
+++ b/demo/data/my-enrollments
@@ -186,5 +186,10 @@
       "rel": ["next"],
       "href": "../data/my-enrollments-next"
     }
-  ]
+  ],
+    "actions": [{
+    "name": "search-my-enrollments",
+    "href": "../data/my-enrollments",
+    "method": "GET"
+  }]
 }

--- a/demo/data/my-enrollments
+++ b/demo/data/my-enrollments
@@ -187,9 +187,11 @@
       "href": "../data/my-enrollments-next"
     }
   ],
-    "actions": [{
-    "name": "search-my-enrollments",
-    "href": "../data/my-enrollments",
-    "method": "GET"
-  }]
+  "actions": [
+    {
+      "name": "search-my-enrollments",
+      "href": "../data/my-enrollments",
+      "method": "GET"
+    }
+  ]
 }

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -327,7 +327,10 @@ class AllCourses extends mixinBehaviors([
 
 	// After a user-uploaded image is set, this is called to try to update the image
 	refreshCardGridImages(organization) {
-		this._getCardGrid().refreshCardGridImages(organization);
+		const cardGrid = this._getCardGrid();
+		if (cardGrid) {
+			cardGrid.refreshCardGridImages(organization);
+		}
 	}
 
 	_getCardGrid() {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -35,8 +35,6 @@ class AllCourses extends mixinBehaviors([
 		return {
 			// URL that directs to the advanced search page
 			advancedSearchUrl: String,
-			// Initial search action, should combine with _enrollmentsSearchAction
-			enrollmentsSearchAction: Object,
 			// Standard Department OU Type name to be displayed in the filter dropdown
 			filterStandardDepartmentName: String,
 			// Standard Semester OU Type name to be displayed in the filter dropdown
@@ -113,10 +111,6 @@ class AllCourses extends mixinBehaviors([
 			_showContent: {
 				type: Boolean,
 				value: false
-			},
-			_showGroupByTabs: {
-				type: Boolean,
-				computed: '_computeShowGroupByTabs(tabSearchActions.length)'
 			},
 			_showTabContent: {
 				type: Boolean,
@@ -274,30 +268,22 @@ class AllCourses extends mixinBehaviors([
 						[[localize('error.settingImage')]]
 					</d2l-alert>
 
-					<template is="dom-if" if="[[_showGroupByTabs]]">
-						<d2l-tabs on-d2l-tab-panel-selected="_onTabSelected">
-							<template items="[[tabSearchActions]]" is="dom-repeat">
-								<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
-									<div hidden$="[[!_showTabContent]]">
-										<d2l-my-courses-card-grid token="[[token]]" presentation-url="[[presentationUrl]]">
-											<span id="infoMessage" hidden$="[[!_infoMessageText]]">
-												[[_infoMessageText]]
-											</span>
-										</d2l-my-courses-card-grid>
-									</div>
-									<d2l-loading-spinner hidden$="[[_showTabContent]]" size="100">
-									</d2l-loading-spinner>
-								</d2l-tab-panel>
-							</template>
-						</d2l-tabs>
-					</template>
-					<template is="dom-if" if="[[!_showGroupByTabs]]">
-						<d2l-my-courses-card-grid token="[[token]]" presentation-url="[[presentationUrl]]">
-							<span id="infoMessage" hidden$="[[!_infoMessageText]]">
-								[[_infoMessageText]]
-							</span>
-						</d2l-my-courses-card-grid>
-					</template>
+					<d2l-tabs on-d2l-tab-panel-selected="_onTabSelected">
+						<template items="[[tabSearchActions]]" is="dom-repeat">
+							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
+								<div hidden$="[[!_showTabContent]]">
+									<d2l-my-courses-card-grid token="[[token]]" presentation-url="[[presentationUrl]]">
+										<span id="infoMessage" hidden$="[[!_infoMessageText]]">
+											[[_infoMessageText]]
+										</span>
+									</d2l-my-courses-card-grid>
+								</div>
+								<d2l-loading-spinner hidden$="[[_showTabContent]]" size="100">
+								</d2l-loading-spinner>
+							</d2l-tab-panel>
+						</template>
+					</d2l-tabs>
+
 					<d2l-loading-spinner id="lazyLoadSpinner" hidden$="[[!_hasMoreEnrollments]]" size="100">
 					</d2l-loading-spinner>
 				</div>
@@ -311,7 +297,7 @@ class AllCourses extends mixinBehaviors([
 	*/
 
 	courseEnrollmentChanged(newValue) {
-		if (this._showGroupByTabs) {
+		if (this.tabSearchActions.length > 0) {
 			this._bustCacheToken = Math.random();
 			const actionName = this._selectedTabId.replace('all-courses-tab-', '');
 			if (!newValue.isPinned && actionName === Actions.enrollments.searchMyPinnedEnrollments && this._searchUrl) {
@@ -325,24 +311,6 @@ class AllCourses extends mixinBehaviors([
 	load() {
 		this.$['all-courses-scroll-threshold'].scrollTarget = this.$['all-courses'].scrollRegion;
 		this.$['all-courses-scroll-threshold'].clearTriggers();
-		if (this._showGroupByTabs) {
-			return;
-		}
-		this._showTabContent = true;
-
-		if (!this.enrollmentsSearchAction) {
-			return;
-		}
-
-		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-			createActionUrl(this.enrollmentsSearchAction, {
-				autoPinCourses: false,
-				orgUnitTypeId: this.orgUnitTypeIds,
-				embedDepth: 0,
-				sort: this._sortMap[0].action,
-				promotePins: this._sortMap[0].promotePins
-			})
-		);
 	}
 
 	open() {
@@ -362,9 +330,7 @@ class AllCourses extends mixinBehaviors([
 	}
 
 	_getCardGrid() {
-		return this._showGroupByTabs
-			? this.shadowRoot.querySelector(`#${this._selectedTabId} d2l-my-courses-card-grid`)
-			: this.shadowRoot.querySelector('d2l-my-courses-card-grid');
+		return this.shadowRoot.querySelector(`#${this._selectedTabId} d2l-my-courses-card-grid`);
 	}
 
 	/*
@@ -705,10 +671,6 @@ class AllCourses extends mixinBehaviors([
 
 	_computeShowAdvancedSearchLink(link) {
 		return !!link;
-	}
-
-	_computeShowGroupByTabs(tabLength) {
-		return tabLength > 0;
 	}
 
 	_mapSortOption(identifier, identifierName) {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -297,6 +297,7 @@ class AllCourses extends mixinBehaviors([
 	*/
 
 	courseEnrollmentChanged(newValue) {
+		// Only bust the cache and reload the pinned tab if the tabs have been set (ie the overlay has been opened)
 		if (this.tabSearchActions.length > 0) {
 			this._bustCacheToken = Math.random();
 			const actionName = this._selectedTabId.replace('all-courses-tab-', '');
@@ -315,8 +316,8 @@ class AllCourses extends mixinBehaviors([
 
 	open() {
 		// Initially hide the content, until we have some data to show
-		// (set back to true in _onSearchResultsChanged). The exception
-		// to this is when the overlay is closed then reopened - we want
+		// (triggered by _onTabSelected and set back to true in _onSearchResultsChanged).
+		// The exception to this is when the overlay is closed then reopened - we want
 		// to immediately show the already-loaded content.
 		this._showContent = !!this._searchUrl;
 
@@ -506,6 +507,7 @@ class AllCourses extends mixinBehaviors([
 		this.dispatchEvent(new CustomEvent('d2l-all-courses-close'));
 	}
 
+	// Triggered when the tabs are first rendered, which then fetches the enrollment data by setting _searchUrl
 	_onTabSelected(e) {
 		e.stopPropagation();
 

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -193,7 +193,10 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 		if (success) {
 			this.$['basic-image-selector-overlay'].close();
 
-			this._getContentComponent().refreshCardGridImages(this._setImageOrg);
+			const contentComponent = this._getContentComponent();
+			if (contentComponent) {
+				contentComponent.refreshCardGridImages(this._setImageOrg);
+			}
 			this._getAllCoursesComponent().refreshCardGridImages(this._setImageOrg);
 		}
 	}
@@ -252,7 +255,10 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	}
 	_onAllCoursesClose() {
 		this._showImageError = false; // Clear image error when opening and closing the all courses overlay
-		this._getContentComponent().allCoursesOverlayClosed();
+		const contentComponent = this._getContentComponent();
+		if (contentComponent) {
+			contentComponent.allCoursesOverlayClosed();
+		}
 	}
 
 	_onEnrollmentAndUserSettingsEntityChange() {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -54,10 +54,6 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			_currentTabId: String,
 			_enrollmentsSearchAction: Object,
 			_pinnedTabAction: Object,
-			_showGroupByTabs: {
-				type: Boolean,
-				value: false
-			},
 			_tabSearchActions: {
 				type: Array,
 				value: []
@@ -105,45 +101,32 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 					display: none;
 				}
 			</style>
-			<template is="dom-if" if="[[_showGroupByTabs]]">
-				<div class="spinner-container">
-					<d2l-loading-spinner hidden$="[[_showContent]]" size="100">
-					</d2l-loading-spinner>
-				</div>
-				<d2l-tabs hidden$="[[!_showContent]]">
-					<template items="[[_tabSearchActions]]" is="dom-repeat">
-						<!-- item.name is an OrgUnitId, and querySelector does not work with components with ids that start with a number -->
-						<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
-							<d2l-my-courses-content
-								on-d2l-my-courses-content-open-all-courses="_openAllCoursesOverlay"
-								presentation-url="[[_presentationUrl]]"
-								show-image-error="[[_showImageError]]"
-								token="[[token]]"
-								enrollments-search-action="[[item.enrollmentsSearchAction]]"
-								org-unit-type-ids="[[orgUnitTypeIds]]"
-								tab-search-type="[[_tabSearchType]]"
-								update-user-settings-action="[[_updateUserSettingsAction]]">
-							</d2l-my-courses-content>
-						</d2l-tab-panel>
-					</template>
-				</d2l-tabs>
-			</template>
-			<template is="dom-if" if="[[!_showGroupByTabs]]">
-				<d2l-my-courses-content
-					no-tabs
-					on-d2l-my-courses-content-open-all-courses="_openAllCoursesOverlay"
-					presentation-url="[[_presentationUrl]]"
-					show-image-error="[[_showImageError]]"
-					token="[[token]]"
-					org-unit-type-ids="[[orgUnitTypeIds]]"
-					enrollments-search-action="[[_enrollmentsSearchAction]]">
-				</d2l-my-courses-content>
-			</template>
+
+			<div class="spinner-container">
+				<d2l-loading-spinner hidden$="[[_showContent]]" size="100">
+				</d2l-loading-spinner>
+			</div>
+			<d2l-tabs hidden$="[[!_showContent]]">
+				<template items="[[_tabSearchActions]]" is="dom-repeat">
+					<!-- item.name is an OrgUnitId, and querySelector does not work with components with ids that start with a number -->
+					<d2l-tab-panel id="panel-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
+						<d2l-my-courses-content
+							on-d2l-my-courses-content-open-all-courses="_openAllCoursesOverlay"
+							presentation-url="[[_presentationUrl]]"
+							show-image-error="[[_showImageError]]"
+							token="[[token]]"
+							enrollments-search-action="[[item.enrollmentsSearchAction]]"
+							org-unit-type-ids="[[orgUnitTypeIds]]"
+							tab-search-type="[[_tabSearchType]]"
+							update-user-settings-action="[[_updateUserSettingsAction]]">
+						</d2l-my-courses-content>
+					</d2l-tab-panel>
+				</template>
+			</d2l-tabs>
 
 			<d2l-all-courses
 				on-d2l-all-courses-close="_onAllCoursesClose"
 				advanced-search-url="[[advancedSearchUrl]]"
-				enrollments-search-action="[[_enrollmentsSearchAction]]"
 				filter-standard-department-name="[[standardDepartmentName]]"
 				filter-standard-semester-name="[[standardSemesterName]]"
 				org-unit-type-ids="[[orgUnitTypeIds]]"
@@ -251,9 +234,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	}
 
 	_getContentComponent() {
-		return this._showGroupByTabs === false || !this._currentTabId
-			? this.shadowRoot.querySelector('d2l-my-courses-content')
-			: this.shadowRoot.querySelector(`#${this._currentTabId} d2l-my-courses-content`);
+		return this.shadowRoot.querySelector(`#${this._currentTabId} d2l-my-courses-content`);
 	}
 	_getAllCoursesComponent() {
 		return this.shadowRoot.querySelector('d2l-all-courses');
@@ -297,7 +278,6 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		this._updateUserSettingsAction = userSettingsEntity.userSettingsAction();
 
-		this._showGroupByTabs = !!(this.promotedSearches || (this._enrollmentsSearchAction && this._pinnedTabAction));
 		this._fetchTabSearchActions();
 	}
 	_onPromotedSearchEntityChange() {
@@ -312,11 +292,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		this._showContent = true;
 		if (!promotedSearchesEntity.actions()) {
-			if ((this._enrollmentsSearchAction && this._pinnedTabAction)) {
-				this._tabSearchActions = this._getPinTabAndAllTabActions(lastEnrollmentsSearchName);
-			} else {
-				this._showGroupByTabs = false;
-			}
+			this._tabSearchActions = this._getPinTabAndAllTabActions(lastEnrollmentsSearchName);
 			return;
 		}
 
@@ -456,7 +432,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			return;
 		}
 
-		if (!this.promotedSearches && this._enrollmentsSearchAction && this._pinnedTabAction) {
+		if (!this.promotedSearches) {
 			const lastEnrollmentsSearchName = this._userSettingsEntity.mostRecentEnrollmentsSearchName();
 			this._tabSearchActions = this._getPinTabAndAllTabActions(lastEnrollmentsSearchName);
 			this._showContent = true;

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -408,6 +408,7 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 	_onInitiallyVisibleCourseTile() {
 		this._initiallyVisibleCourseTileCount++;
 	}
+	// Triggered when the tabs are first rendered, which then fetches the enrollment data
 	_onTabSelected(e) {
 		// Only handle if tab selected corresponds to this panel
 		if (!this.parentElement || e.composedPath()[0].id !== this.parentElement.id) {

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -41,11 +41,6 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 			presentationUrl: String,
 			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
 			token: String,
-			// Once the pinned tab feature flag is removed, we can remove this code path
-			noTabs: {
-				type: Boolean,
-				value: false
-			},
 			_courseTileOrganizationEventCount: {
 				type: Number,
 				value: 0
@@ -140,12 +135,6 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 				value: false
 			}
 		};
-	}
-
-	static get observers() {
-		return [
-			'_enrollmentSearchActionChanged(enrollmentsSearchAction)'
-		];
 	}
 
 	static get template() {
@@ -259,7 +248,7 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 			updateEntity(changedEnrollmentId, this.token);
 		}
 
-		if (this.noTabs || this._thisTabSelected) {
+		if (this._thisTabSelected) {
 			// Only want to move pinned/unpinned enrollment if it exists in the panel
 			if (!changedEnrollmentId) {
 				this._refetchEnrollments();
@@ -284,13 +273,6 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 
 	_getCardGrid() {
 		return this.shadowRoot.querySelector('d2l-my-courses-card-grid');
-	}
-	_enrollmentSearchActionChanged() {
-		if (this.noTabs) {
-			// We only need to manually fetch if we're not using tabs;
-			// otherwise, the fetch is initiated when a tab is selected.
-			this._fetchRoot();
-		}
 	}
 	_computeCourseInfoAlertText(enrollmentsLength, viewableEnrollmentsLength, hidePastCourses) {
 		if (enrollmentsLength === 0) {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -61,11 +61,11 @@ describe('d2l-all-courses', function() {
 		}));
 
 		function afterTabsReady() {
-			flush();
-			requestAnimationFrame(() => {
-				done();
-			});
 			widget.shadowRoot.querySelector('d2l-tabs').removeEventListener('d2l-tab-panel-selected', afterTabsReady);
+			flush();
+			setTimeout(() => {
+				done();
+			}, 0);
 		}
 
 		widget.shadowRoot.querySelector('d2l-tabs').addEventListener('d2l-tab-panel-selected', afterTabsReady);

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -23,17 +23,6 @@ describe('d2l-all-courses', function() {
 
 		widget = fixture('d2l-all-courses-fixture');
 		widget.$['search-widget']._setSearchUrl = sandbox.stub();
-		widget._enrollmentsSearchAction = {
-			name: 'search-my-enrollments',
-			href: '/enrollments/users/169',
-			fields: [{
-				name: 'parentOrganizations',
-				value: ''
-			}, {
-				name: 'sort',
-				value: ''
-			}]
-		};
 
 		enrollmentsEntity = {
 			actions: [
@@ -47,10 +36,22 @@ describe('d2l-all-courses', function() {
 					name: 'set-role-filters',
 					href: '/setRoles',
 				},
-				widget._enrollmentsSearchAction
+				{
+					name: 'search-my-enrollments',
+					href: '/enrollments/users/169',
+					fields: [{
+						name: 'parentOrganizations',
+						value: ''
+					}, {
+						name: 'sort',
+						value: ''
+					}]
+				}
 			],
 			class: ['enrollments', 'collection']
 		};
+
+		widget._enrollmentsSearchAction = SirenParse(enrollmentsEntity).actions.find(action => action.name === 'search-my-enrollments');
 
 		fetchStub = sandbox.stub(window.d2lfetch, 'fetch').returns(Promise.resolve({
 			ok: true,
@@ -59,10 +60,18 @@ describe('d2l-all-courses', function() {
 			}
 		}));
 
-		flush();
-		requestAnimationFrame(() => {
-			done();
-		});
+		function afterTabsReady() {
+			flush();
+			requestAnimationFrame(() => {
+				done();
+			});
+			widget.shadowRoot.querySelector('d2l-tabs').removeEventListener('d2l-tab-panel-selected', afterTabsReady);
+		}
+
+		widget.shadowRoot.querySelector('d2l-tabs').addEventListener('d2l-tab-panel-selected', afterTabsReady);
+
+		widget._selectedTabId = 'all-courses-tab-search-my-enrollments';
+		widget.tabSearchActions = [{name: 'search-my-enrollments'}];
 	});
 
 	afterEach(function() {
@@ -73,8 +82,13 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('Loading', function() {
-		it('should show loading spinner before content has loaded', function() {
-			expect(widget.shadowRoot.querySelector('d2l-loading-spinner:not(#lazyLoadSpinner)').hasAttribute('hidden')).to.be.false;
+		it('should show loading spinner before content has loaded', function(done) {
+			widget.tabSearchActions = null;
+			widget.open();
+			requestAnimationFrame(() => {
+				expect(widget.shadowRoot.querySelector('d2l-loading-spinner:not(#lazyLoadSpinner)').hasAttribute('hidden')).to.be.false;
+				done();
+			});
 		});
 	});
 
@@ -211,11 +225,11 @@ describe('d2l-all-courses', function() {
 				it(`should not set _searchUrl if the categoryChanged is "${testCase.categoryChanged}" but its selected filters info is missing`, function(done) {
 					const spy = sandbox.spy(widget, '_appendOrUpdateBustCacheQueryString');
 					fireEvent(widget.shadowRoot.querySelector('d2l-my-courses-filter'), 'd2l-my-courses-filter-change', {
-						categoryChanged: 'testCase.categoryChanged',
+						categoryChanged: testCase.categoryChanged,
 						selectedFilters: []
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.be.undefined;
+						expect(widget._searchUrl).to.be.null;
 						expect(spy).to.not.be.called;
 						done();
 					});
@@ -541,14 +555,15 @@ describe('d2l-all-courses', function() {
 	});
 
 	describe('Sorting', function() {
-		it('should set the _searchUrl', function() {
+		it('should set the _searchUrl', function(done) {
 			fireEvent(widget.shadowRoot.querySelector('d2l-sort-by-dropdown'), 'd2l-sort-by-dropdown-change', {
 				value: 'LastAccessed'
 			});
-
-			expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=LastAccessed');
+			requestAnimationFrame(() => {
+				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=LastAccessed');
+				done();
+			});
 		});
-
 	});
 
 	describe('Info Message', function() {
@@ -632,7 +647,7 @@ describe('d2l-all-courses', function() {
 
 	describe('Closing the Overlay', function() {
 
-		it('should prep _enrollmentsSearchAction for component resets', function() {
+		it('should prep _enrollmentsSearchAction for component resets', function(done) {
 			const entity = window.D2L.Hypermedia.Siren.Parse({
 				actions: [{
 					name: 'search-my-enrollments',
@@ -648,28 +663,33 @@ describe('d2l-all-courses', function() {
 				}]
 			});
 			widget._enrollmentsSearchAction = entity.actions[0];
-
 			widget._onSimpleOverlayClosed();
 
-			expect(widget._enrollmentsSearchAction.getFieldByName('search').value).to.be.equal('');
-			expect(widget._enrollmentsSearchAction.getFieldByName('sort').value).to.be.equal('Current');
-			expect(widget._enrollmentsSearchAction.getFieldByName('promotePins').value).to.be.true;
-			expect(widget._enrollmentsSearchAction.getFieldByName('parentOrganizations').value).to.equal('');
-			expect(widget._enrollmentsSearchAction.getFieldByName('roles').value).to.equal('');
+			requestAnimationFrame(() => {
+				expect(widget._enrollmentsSearchAction.getFieldByName('search').value).to.be.equal('');
+				expect(widget._enrollmentsSearchAction.getFieldByName('sort').value).to.be.equal('Current');
+				expect(widget._enrollmentsSearchAction.getFieldByName('promotePins').value).to.be.true;
+				expect(widget._enrollmentsSearchAction.getFieldByName('parentOrganizations').value).to.equal('');
+				expect(widget._enrollmentsSearchAction.getFieldByName('roles').value).to.equal('');
+				done();
+			});
 		});
 
-		it('should clear search text', function() {
+		it('should clear search text', function(done) {
 			const spy = sandbox.spy(widget, '_clearSearchWidget');
 			const searchField = widget.$['search-widget'];
 
 			searchField._getSearchWidget()._getSearchInput().value = 'foo';
 			widget._onSimpleOverlayClosed();
 
-			expect(spy.called).to.be.true;
-			expect(searchField._getSearchWidget()._getSearchInput().value).to.equal('');
+			requestAnimationFrame(() => {
+				expect(spy.called).to.be.true;
+				expect(searchField._getSearchWidget()._getSearchInput().value).to.equal('');
+				done();
+			});
 		});
 
-		it('should clear filters', function() {
+		it('should clear filters', function(done) {
 			const spy = sandbox.spy(widget.shadowRoot.querySelector('d2l-my-courses-filter'), 'clear');
 
 			widget._filterCounts = {
@@ -679,15 +699,19 @@ describe('d2l-all-courses', function() {
 			};
 
 			widget._onSimpleOverlayClosed();
-			expect(spy.called).to.be.true;
-			expect(widget._filterCounts).to.deep.equal({
-				departments: 0,
-				semesters: 0,
-				roles: 0
+
+			requestAnimationFrame(() => {
+				expect(spy.called).to.be.true;
+				expect(widget._filterCounts).to.deep.equal({
+					departments: 0,
+					semesters: 0,
+					roles: 0
+				});
+				done();
 			});
 		});
 
-		it('should clear sort', function() {
+		it('should clear sort', function(done) {
 			const sortDropdown = widget.shadowRoot.querySelector('d2l-sort-by-dropdown');
 
 			const event = {
@@ -700,15 +724,20 @@ describe('d2l-all-courses', function() {
 			expect(widget._searchUrl).to.contain('sort=OrgUnitCode,OrgUnitId');
 
 			widget._onSimpleOverlayClosed();
-			expect(widget._searchUrl).to.contain('sort=Current');
+			requestAnimationFrame(() => {
+				expect(widget._searchUrl).to.contain('sort=Current');
+				done();
+			});
 		});
-
 	});
 
-	describe('Tabbed View', function() {
+	describe('Multiple Tabs', function() {
+
 		beforeEach(function(done) {
-			widget.updatedSortLogic = true;
 			widget.tabSearchActions = [{
+				name: 'search-my-enrollments',
+				selected: false
+			}, {
 				name: '12345',
 				title: 'Search Foo Action',
 				selected: true,
@@ -765,8 +794,9 @@ describe('d2l-all-courses', function() {
 				enrollmentsSearchAction: {}
 			});
 
-			expect(widget.tabSearchActions[0].selected).to.be.true;
-			expect(widget.tabSearchActions[1].selected).to.be.false;
+			expect(widget.tabSearchActions[0].selected).to.be.false;
+			expect(widget.tabSearchActions[1].selected).to.be.true;
+			expect(widget.tabSearchActions[2].selected).to.be.false;
 
 			widget._onTabSelected({
 				type: 'd2l-tab-panel-selected',
@@ -775,7 +805,8 @@ describe('d2l-all-courses', function() {
 			});
 
 			expect(widget.tabSearchActions[0].selected).to.be.false;
-			expect(widget.tabSearchActions[1].selected).to.be.true;
+			expect(widget.tabSearchActions[1].selected).to.be.false;
+			expect(widget.tabSearchActions[2].selected).to.be.true;
 		});
 	});
 });

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -113,6 +113,7 @@ describe('d2l-my-courses', () => {
 		component = fixture('d2l-my-courses-container-fixture');
 		setLocalStorageStub = sandbox.stub(component, '_trySetItemLocalStorage');
 		sandbox.stub(component, '_setUserSettingsEntity');
+		sandbox.stub(component, '_setEnrollmentCollectionEntity');
 
 		setTimeout(() => {
 			component.enrollmentsUrl = enrollmentsHref;
@@ -293,17 +294,25 @@ describe('d2l-my-courses', () => {
 		});
 
 		describe('_addPinnedTab', () => {
-			it('should add the pinned tab to content and force each tab to refresh because of dom-repeat issues', () => {
-				const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
-				const contentRefreshStub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'requestRefresh');
-				component._tabSearchActions = [{ name: 'search-my-enrollments'}];
+			it('should add the pinned tab to content and force each tab to refresh because of dom-repeat issues', (done) => {
+				component._currentTabId = 'panel-search-my-enrollments';
+				component._tabSearchActions = [{
+					name: 'search-my-enrollments',
+					enrollmentsSearchAction: searchAction
+				}];
 
-				component._addPinnedTab();
+				requestAnimationFrame(() => {
+					const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
+					const contentRefreshStub = sandbox.stub(component._getContentComponent(), 'requestRefresh');
 
-				expect(component._tabSearchActions.length).to.equal(2);
-				expect(allCoursesSpliceStub).to.not.have.been.called;
-				expect(contentRefreshStub).to.have.been.called;
-				expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': true});
+					component._addPinnedTab();
+
+					expect(component._tabSearchActions.length).to.equal(2);
+					expect(allCoursesSpliceStub).to.not.have.been.called;
+					expect(contentRefreshStub).to.have.been.called;
+					expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': true});
+					done();
+				});
 			});
 			it('should add the pinned tab to all-courses as well if it has been opened already', () => {
 				const allCourses = component._getAllCoursesComponent();
@@ -328,17 +337,29 @@ describe('d2l-my-courses', () => {
 		});
 
 		describe('_removePinnedTab', () => {
-			it('should remove the pinned tab to content and force each tab to refresh because of dom-repeat issues', () => {
-				const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
-				const contentRefreshStub = sandbox.stub(component.shadowRoot.querySelector('d2l-my-courses-content'), 'requestRefresh');
-				component._tabSearchActions = [{ name: 'search-my-enrollments'}, { name: 'search-my-pinned-enrollments'}];
+			it('should remove the pinned tab to content and force each tab to refresh because of dom-repeat issues', (done) => {
+				component._currentTabId = 'panel-search-my-enrollments';
+				component._tabSearchActions = [{
+					name: 'search-my-enrollments',
+					enrollmentsSearchAction: searchAction
+				},
+				{
+					name: 'search-my-pinned-enrollments'
+				}];
 
-				component._removePinnedTab();
+				requestAnimationFrame(() => {
+					const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
+					const contentRefreshStub = sandbox.stub(component._getContentComponent(), 'requestRefresh');
+					component._tabSearchActions = [{ name: 'search-my-enrollments'}, { name: 'search-my-pinned-enrollments'}];
 
-				expect(component._tabSearchActions.length).to.equal(1);
-				expect(allCoursesSpliceStub).to.not.have.been.called;
-				expect(contentRefreshStub).to.have.been.called;
-				expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': false});
+					component._removePinnedTab();
+
+					expect(component._tabSearchActions.length).to.equal(1);
+					expect(allCoursesSpliceStub).to.not.have.been.called;
+					expect(contentRefreshStub).to.have.been.called;
+					expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': false});
+					done();
+				});
 			});
 			it('should remove the pinned tab from all-courses as well if it has been opened already', () => {
 				const allCourses = component._getAllCoursesComponent();
@@ -367,45 +388,54 @@ describe('d2l-my-courses', () => {
 
 		describe('courseImageUploadCompleted', () => {
 			it('should do nothing if image setting was not a success', done => {
-				component._showGroupByTabs = false;
+				component.promotedSearches = null;
+				component._onEnrollmentAndUserSettingsEntityChange();
 				flush(() => {
-					const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
-					const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
-					component.courseImageUploadCompleted(false);
-					expect(stubContent).to.not.have.been.called;
-					expect(stubAllCourses).to.not.have.been.called;
-					done();
+					requestAnimationFrame(() => {
+						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
+						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
+						component.courseImageUploadCompleted(false);
+						expect(stubContent).to.not.have.been.called;
+						expect(stubAllCourses).to.not.have.been.called;
+						done();
+					});
 				});
 			});
-			it('should call refreshCardGridImages on the content and all-courses (not grouped by tab)', done => {
-				component._showGroupByTabs = false;
+			it('should call refreshCardGridImages on the content and all-courses (just all tab)', done => {
+				component.promotedSearches = null;
+				component._onEnrollmentAndUserSettingsEntityChange();
 				flush(() => {
-					const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
-					const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
-					component.courseImageUploadCompleted(true);
-					expect(stubContent).to.have.been.called;
-					expect(stubAllCourses).to.have.been.called;
-					done();
+					requestAnimationFrame(() => {
+						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
+						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
+						component.courseImageUploadCompleted(true);
+						expect(stubContent).to.have.been.called;
+						expect(stubAllCourses).to.have.been.called;
+						done();
+					});
 				});
 			});
-			it('should call refreshCardGridImages on the content and all-courses (grouped by tab)', done => {
+			it('should call refreshCardGridImages on the content and all-courses (grouped by semesters)', done => {
 				component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 				component._onPromotedSearchEntityChange();
-				component._currentTabId = '6607';
+				component._currentTabId = 'panel-6607';
 				flush(() => {
-					const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
-					const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
-					component.courseImageUploadCompleted(true);
-					expect(stubContent).to.have.been.called;
-					expect(stubAllCourses).to.have.been.called;
-					done();
+					requestAnimationFrame(() => {
+						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
+						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
+						component.courseImageUploadCompleted(true);
+						expect(stubContent).to.have.been.called;
+						expect(stubAllCourses).to.have.been.called;
+						done();
+					});
 				});
 			});
 		});
 
 		describe('getLastOrgUnitId', () => {
-			it('should get the orgunit id from the organization entity in _setImageOrg (not grouped by tab)', done => {
-				component._showGroupByTabs = false;
+			it('should get the orgunit id from the organization entity in _setImageOrg (just all tab)', done => {
+				component.promotedSearches = null;
+				component._onEnrollmentAndUserSettingsEntityChange();
 				component._setImageOrg = window.D2L.Hypermedia.Siren.Parse({
 					properties: {
 						name: 'Course One'
@@ -422,7 +452,7 @@ describe('d2l-my-courses', () => {
 				});
 			});
 
-			it('should get the orgunit id from the organization entity in _setImageOrg (grouped by tab)', done => {
+			it('should get the orgunit id from the organization entity in _setImageOrg (grouped by semesters)', done => {
 				component._promotedSearchEntity = new PromotedSearchEntity(promotedSearchMultipleResponse);
 				component._onPromotedSearchEntityChange();
 				component._currentTabId = '6607';
@@ -483,11 +513,19 @@ describe('d2l-my-courses', () => {
 			expect(component._showImageError).to.be.false;
 		});
 
-		it('should remove a course image failure alert when the all courses overlay is closed', function() {
+		it('should remove a course image failure alert when the all courses overlay is closed', function(done) {
+			component._currentTabId = 'panel-search-my-enrollments';
+			component._tabSearchActions = [{
+				name: 'search-my-enrollments',
+				enrollmentsSearchAction: searchAction
+			}];
 			component._showImageError = true;
 
-			component._onAllCoursesClose();
-			expect(component._showImageError).to.be.false;
+			requestAnimationFrame(() => {
+				component._onAllCoursesClose();
+				expect(component._showImageError).to.be.false;
+				done();
+			});
 		});
 	});
 
@@ -602,18 +640,25 @@ describe('d2l-my-courses', () => {
 
 		describe('d2l-all-courses-close', () => {
 			it('should remove an existing course image failure alert and tell d2l-my-courses-content that the overlay closed', done => {
-				const stub = sandbox.stub(component._getContentComponent(), 'allCoursesOverlayClosed');
-				component._showImageError = true;
+				component._currentTabId = 'panel-search-my-enrollments';
+				component._tabSearchActions = [{
+					name: 'search-my-enrollments',
+					enrollmentsSearchAction: searchAction
+				}];
 
-				const event = new CustomEvent('d2l-all-courses-close');
-				component._getAllCoursesComponent().dispatchEvent(event);
+				requestAnimationFrame(() => {
+					const stub = sandbox.stub(component._getContentComponent(), 'allCoursesOverlayClosed');
+					component._showImageError = true;
 
-				setTimeout(() => {
-					expect(stub).to.have.been.called;
-					expect(component._showImageError).to.be.false;
-					done();
+					const event = new CustomEvent('d2l-all-courses-close');
+					component._getAllCoursesComponent().dispatchEvent(event);
+
+					setTimeout(() => {
+						expect(stub).to.have.been.called;
+						expect(component._showImageError).to.be.false;
+						done();
+					});
 				});
-
 			});
 		});
 
@@ -669,7 +714,7 @@ describe('d2l-my-courses', () => {
 			let _enrollmentEntity,
 				event;
 
-			beforeEach(() => {
+			beforeEach((done) => {
 				_enrollmentEntity = {
 					_entity: {},
 					organizationHref: function() { return '1234'; },
@@ -682,8 +727,13 @@ describe('d2l-my-courses', () => {
 					}
 				});
 
+				component._currentTabId = 'panel-search-my-enrollments';
 				component._enrollmentsSearchAction = searchAction;
 				component._onPromotedSearchEntityChange();
+
+				requestAnimationFrame(() => {
+					done();
+				});
 			});
 
 			[

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -193,12 +193,12 @@ describe('d2l-my-courses', () => {
 			};
 
 			component._changedCourseEnrollment = null;
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				component._onCourseEnrollmentChange(event);
 				expect(component._changedCourseEnrollment.orgUnitId).to.equal(testCase.orgUnitId);
 				expect(component._changedCourseEnrollment.isPinned).to.equal(testCase.isPinned);
 				done();
-			});
+			}, 0);
 		});
 	});
 
@@ -265,12 +265,12 @@ describe('d2l-my-courses', () => {
 
 			expect(verifySpy).to.have.been.calledOnce;
 
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				expect(component._tabSearchActions.length).to.equal(2);
 				expect(component._tabSearchActions[0].name).to.equal('search-my-enrollments');
 				expect(component._tabSearchActions[1].name).to.equal('search-my-pinned-enrollments');
 				done();
-			});
+			}, 0);
 		});
 
 		it('should remove the pinned tab if we verify there actually is no pinned courses', done => {
@@ -286,11 +286,11 @@ describe('d2l-my-courses', () => {
 
 			expect(verifySpy).to.have.been.calledOnce;
 
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				expect(component._tabSearchActions.length).to.equal(1);
 				expect(component._tabSearchActions[0].name).to.equal('search-my-enrollments');
 				done();
-			});
+			}, 0);
 		});
 
 		describe('_addPinnedTab', () => {
@@ -301,7 +301,7 @@ describe('d2l-my-courses', () => {
 					enrollmentsSearchAction: searchAction
 				}];
 
-				requestAnimationFrame(() => {
+				setTimeout(() => {
 					const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
 					const contentRefreshStub = sandbox.stub(component._getContentComponent(), 'requestRefresh');
 
@@ -312,7 +312,7 @@ describe('d2l-my-courses', () => {
 					expect(contentRefreshStub).to.have.been.called;
 					expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': true});
 					done();
-				});
+				}, 0);
 			});
 			it('should add the pinned tab to all-courses as well if it has been opened already', () => {
 				const allCourses = component._getAllCoursesComponent();
@@ -347,7 +347,7 @@ describe('d2l-my-courses', () => {
 					name: 'search-my-pinned-enrollments'
 				}];
 
-				requestAnimationFrame(() => {
+				setTimeout(() => {
 					const allCoursesSpliceStub = sandbox.stub(component._getAllCoursesComponent(), 'splice');
 					const contentRefreshStub = sandbox.stub(component._getContentComponent(), 'requestRefresh');
 					component._tabSearchActions = [{ name: 'search-my-enrollments'}, { name: 'search-my-pinned-enrollments'}];
@@ -359,7 +359,7 @@ describe('d2l-my-courses', () => {
 					expect(contentRefreshStub).to.have.been.called;
 					expect(setLocalStorageStub).to.have.been.calledWith('myCourses.pinnedTab', {'previouslyShown': false});
 					done();
-				});
+				}, 0);
 			});
 			it('should remove the pinned tab from all-courses as well if it has been opened already', () => {
 				const allCourses = component._getAllCoursesComponent();
@@ -391,28 +391,28 @@ describe('d2l-my-courses', () => {
 				component.promotedSearches = null;
 				component._onEnrollmentAndUserSettingsEntityChange();
 				flush(() => {
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
 						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
 						component.courseImageUploadCompleted(false);
 						expect(stubContent).to.not.have.been.called;
 						expect(stubAllCourses).to.not.have.been.called;
 						done();
-					});
+					}, 0);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (just all tab)', done => {
 				component.promotedSearches = null;
 				component._onEnrollmentAndUserSettingsEntityChange();
 				flush(() => {
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
 						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
 						component.courseImageUploadCompleted(true);
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					});
+					}, 0);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (grouped by semesters)', done => {
@@ -420,14 +420,14 @@ describe('d2l-my-courses', () => {
 				component._onPromotedSearchEntityChange();
 				component._currentTabId = 'panel-6607';
 				flush(() => {
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						const stubContent = sandbox.stub(component._getContentComponent(), 'refreshCardGridImages');
 						const stubAllCourses = sandbox.stub(component._getAllCoursesComponent(), 'refreshCardGridImages');
 						component.courseImageUploadCompleted(true);
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					});
+					}, 0);
 				});
 			});
 		});
@@ -521,11 +521,11 @@ describe('d2l-my-courses', () => {
 			}];
 			component._showImageError = true;
 
-			requestAnimationFrame(() => {
+			setTimeout(() => {
 				component._onAllCoursesClose();
 				expect(component._showImageError).to.be.false;
 				done();
-			});
+			}, 0);
 		});
 	});
 
@@ -574,10 +574,10 @@ describe('d2l-my-courses', () => {
 				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'open');
 
 				component.addEventListener('open-change-image-view', function() {
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						expect(spy).to.have.been.called;
 						done();
-					});
+					}, 0);
 				});
 
 				component.dispatchEvent(event);
@@ -591,15 +591,15 @@ describe('d2l-my-courses', () => {
 			it('should return correct org unit id if course tile used', done => {
 
 				component.addEventListener('open-change-image-view', function() {
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						expect(component.getLastOrgUnitId()).to.equal('1');
 						done();
-					});
+					}, 0);
 				});
 
-				requestAnimationFrame(() => {
+				setTimeout(() => {
 					component.dispatchEvent(event);
-				});
+				}, 0);
 			});
 
 		});
@@ -613,10 +613,10 @@ describe('d2l-my-courses', () => {
 
 					const event = new CustomEvent('clear-image-scroll-threshold');
 					component.dispatchEvent(event);
-					requestAnimationFrame(() => {
+					setTimeout(() => {
 						expect(spy).to.have.been.calledOnce;
 						done();
-					});
+					}, 0);
 				});
 
 			});

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -398,7 +398,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.not.have.been.called;
 						expect(stubAllCourses).to.not.have.been.called;
 						done();
-					}, 0);
+					}, 10);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (just all tab)', done => {
@@ -412,7 +412,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					}, 0);
+					}, 10);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (grouped by semesters)', done => {
@@ -427,7 +427,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					}, 0);
+					}, 10);
 				});
 			});
 		});

--- a/test/d2l-my-courses-content/d2l-my-courses-content.js
+++ b/test/d2l-my-courses-content/d2l-my-courses-content.js
@@ -586,8 +586,7 @@ describe('d2l-my-courses-content', () => {
 		});
 
 		it('should fetch enrollments using the constructed enrollmentsSearchUrl', done => {
-			component.noTabs = true;
-			component._enrollmentSearchActionChanged();
+			component._onTabSelected({ composedPath: () => [{ id: component.parentElement.id }] });
 
 			requestAnimationFrame(() => {
 				expect(fetchStub).to.have.been.calledWith(sinon.match('autoPinCourses=false'));

--- a/wct.conf.sauce-others.json
+++ b/wct.conf.sauce-others.json
@@ -6,7 +6,7 @@
         {
           "browserName": "safari",
           "platform": "OS X 10.13",
-          "version": "11.1"
+          "version": "12.1"
         }
       ]
     }


### PR DESCRIPTION
Now that the pinned tab flag is removed from code and we can always expect to be sent the pinned tab action, we can remove the code that used the " no tabs" path.  The tests required a lot of cleanup because they were mostly testing the old path ( where `_showGroupByTabs` was `false`).