### PR TITLE
[1] US117308 - Fix loading spinner in all courses

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -340,27 +340,15 @@ class AllCourses extends mixinBehaviors([
 	_onAllCoursesLowerThreshold() {
 		if (this.$['all-courses'].opened && this._lastEnrollmentsSearchResponse) {
 			const lastResponseEntity = this._lastEnrollmentsSearchResponse;
-			if (!lastResponseEntity._entity) {
-				if (lastResponseEntity && lastResponseEntity.hasLinkByRel('next')) {
-					const url = lastResponseEntity.getLinkByRel('next').href;
-					this.$.lazyLoadSpinner.scrollIntoView();
-					entityFactory(EnrollmentCollectionEntity, url, this.token, entity => {
-						if (entity) {
-							this._updateFilteredEnrollments(entity, true);
-						}
-					});
-				}
-			}
-			else {
-				if (lastResponseEntity && lastResponseEntity._entity.hasLinkByRel('next')) {
-					const url = lastResponseEntity._entity.getLinkByRel('next').href;
-					this.$.lazyLoadSpinner.scrollIntoView();
-					entityFactory(EnrollmentCollectionEntity, url, this.token, entity => {
-						if (entity) {
-							this._updateFilteredEnrollments(entity, true);
-						}
-					});
-				}
+
+			if (lastResponseEntity && lastResponseEntity.hasLinkByRel('next')) {
+				const url = lastResponseEntity.getLinkByRel('next').href;
+				this.$.lazyLoadSpinner.scrollIntoView();
+				entityFactory(EnrollmentCollectionEntity, url, this.token, entity => {
+					if (entity) {
+						this._updateFilteredEnrollments(entity, true);
+					}
+				});
 			}
 		}
 	}
@@ -666,7 +654,6 @@ class AllCourses extends mixinBehaviors([
 			return false;
 		}
 
-		lastResponse = SirenParse(lastResponse);
 		return lastResponse.hasLinkByRel('next');
 	}
 
@@ -688,12 +675,14 @@ class AllCourses extends mixinBehaviors([
 	_updateFilteredEnrollments(enrollments, append) {
 		let gridEntities;
 		if (!enrollments._entity) {
+			this._lastEnrollmentsSearchResponse = enrollments;
 			const enrollmentEntities = enrollments.getSubEntitiesByClass(Classes.enrollments.enrollment);
 			gridEntities = enrollmentEntities.map((value) => {
 				return value.href;
 			});
 		}
 		else {
+			this._lastEnrollmentsSearchResponse = enrollments._entity;
 			gridEntities = enrollments.enrollmentsHref();
 		}
 
@@ -706,9 +695,8 @@ class AllCourses extends mixinBehaviors([
 
 		this._updateInfoMessage(cardGrid.filteredEnrollments.length);
 
-		this._lastEnrollmentsSearchResponse = enrollments;
 		requestAnimationFrame(() => {
-			window.dispatchEvent(new Event('resize')); // doing this so ie11 and older edge browser will get ms-grid style assigned
+			window.dispatchEvent(new Event('resize')); // doing this older edge browser will get ms-grid style assigned
 			this.$['all-courses-scroll-threshold'].clearTriggers();
 		});
 	}


### PR DESCRIPTION
Looks like the "load more" spinner in the View All Courses overlay has been broken for a long long time.  It will work the first time we load more, but all the times after that it won't appear because the entity is in a different form and we need to dig in and get `_entity`.  Rearranged the logic below to do so, and cleanup some duplication at the same time.

This will be the first of a number of PRs focused on simplifying the data flow in All Courses.