### PR TITLE
[4] US117308 - Prep for Gutting Search

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -11,22 +11,18 @@ import '@brightspace-ui/core/components/tabs/tabs.js';
 import '@brightspace-ui/core/components/tabs/tab-panel.js';
 import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown.js';
 import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdown-option.js';
-import 'd2l-organization-hm-behavior/d2l-organization-hm-behavior.js';
 import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import './d2l-my-courses-card-grid.js';
-import './search-filter/d2l-search-widget-custom.js';
+import './search-filter/d2l-my-courses-search.js';
 import { Actions, Classes } from 'd2l-hypermedia-constants';
 import { createActionUrl, fetchSirenEntity } from './d2l-utility-helpers.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
-import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 import { MyCoursesFilterCategory } from './search-filter/d2l-my-courses-filter.js';
 import { MyCoursesLocalizeBehavior } from './localize-behavior.js';
 
-class AllCourses extends mixinBehaviors([
-	D2L.PolymerBehaviors.Hypermedia.OrganizationHMBehavior
-], MyCoursesLocalizeBehavior(PolymerElement)) {
+class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 	static get is() { return 'd2l-all-courses'; }
 
@@ -178,21 +174,21 @@ class AllCourses extends mixinBehaviors([
 				.advanced-search-link[hidden] {
 					display: none;
 				}
-				d2l-search-widget-custom {
+				d2l-my-courses-search {
 					min-width: 300px;
 					width: 100%;
 				}
-				#searchAndLink,
-				#filterAndSort {
+				#search-and-link,
+				#filter-and-sort {
 					display: flex;
 					margin-top: 0.5rem;
 				}
-				#searchAndLink {
+				#search-and-link {
 					flex: 1;
 					flex-direction: row;
 					flex-wrap: wrap;
 				}
-				#filterAndSort {
+				#filter-and-sort {
 					flex: 1.4;
 					justify-content: flex-end;
 				}
@@ -224,18 +220,18 @@ class AllCourses extends mixinBehaviors([
 					</iron-scroll-threshold>
 
 					<div id="search-and-filter">
-						<div id="searchAndLink">
-							<d2l-search-widget-custom
+						<div id="search-and-link">
+							<d2l-my-courses-search
 								id="search-widget"
-								on-d2l-search-widget-results-changed="_onSearchResultsChanged"
+								on-d2l-search-widget-results-changed="_onSearchChange"
 								org-unit-type-ids="[[orgUnitTypeIds]]"
 								search-action="[[_enrollmentsSearchAction]]"
 								search-url="[[_searchUrl]]">
-							</d2l-search-widget-custom>
+							</d2l-my-courses-search>
 							<d2l-link class="advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]" href$="[[advancedSearchUrl]]">[[localize('advancedSearch')]]</d2l-link>
 						</div>
 
-						<div id="filterAndSort">
+						<div id="filter-and-sort">
 							<d2l-my-courses-filter
 								on-d2l-my-courses-filter-change="_onFilterChange"
 								on-d2l-my-courses-filter-clear="_onFilterClear"
@@ -355,7 +351,7 @@ class AllCourses extends mixinBehaviors([
 		);
 	}
 
-	_onSearchResultsChanged(e) {
+	_onSearchChange(e) {
 		this._isSearched = !!e.detail.searchValue;
 
 		this._handleNewEnrollmentsEntity(e.detail.searchResponse);
@@ -469,7 +465,7 @@ class AllCourses extends mixinBehaviors([
 			}
 		}
 
-		this._clearSearchWidget();
+		this.shadowRoot.querySelector('d2l-my-courses-search').clear();
 		this.shadowRoot.querySelector('d2l-my-courses-filter').clear();
 		this.shadowRoot.querySelector(`d2l-sort-by-dropdown-option[value=${this._sortMap[0].name}]`).click();
 
@@ -625,10 +621,6 @@ class AllCourses extends mixinBehaviors([
 		index = suffix.indexOf('&');
 		suffix = index === -1 ? '' : suffix.substring(index, suffix.length);
 		return prefix + this._bustCacheToken + suffix;
-	}
-
-	_clearSearchWidget() {
-		this.$['search-widget'].clear();
 	}
 
 	_computeHasMoreEnrollments(lastResponse, showTabContent) {

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -222,7 +222,6 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 					<div id="search-and-filter">
 						<div id="search-and-link">
 							<d2l-my-courses-search
-								id="search-widget"
 								on-d2l-search-widget-results-changed="_onSearchChange"
 								org-unit-type-ids="[[orgUnitTypeIds]]"
 								search-action="[[_enrollmentsSearchAction]]"

--- a/src/search-filter/d2l-my-courses-search.js
+++ b/src/search-filter/d2l-my-courses-search.js
@@ -1,8 +1,8 @@
 /*
-`d2l-search-widget-custom`
-Polymer-based web component for the search widget, with added "Recent Searches" functionality.
-Should be converted to a new input shared component.
+`d2l-my-courses-search`
+Polymer-based web component for the search input, with added "Recent Searches" functionality.
 */
+
 import '@brightspace-ui/core/components/dropdown/dropdown.js';
 import '@brightspace-ui/core/components/dropdown/dropdown-content.js';
 import 'd2l-search-widget/d2l-search-widget.js';
@@ -14,9 +14,7 @@ import { afterNextRender } from '@polymer/polymer/lib/utils/render-status.js';
 import { isComposedAncestor } from '@brightspace-ui/core/helpers/dom.js';
 import { MyCoursesLocalizeBehavior } from '../localize-behavior.js';
 
-class SearchWidgetCustom extends MyCoursesLocalizeBehavior(PolymerElement) {
-
-	static get is() { return 'd2l-search-widget-custom'; }
+class MyCoursesSearch extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 	static get properties() {
 		return {
@@ -65,7 +63,7 @@ class SearchWidgetCustom extends MyCoursesLocalizeBehavior(PolymerElement) {
 			d2l-dropdown-content {
 				--d2l-dropdown-verticaloffset: 5px;
 			}
-			.d2l-search-widget-custom-item {
+			.d2l-search-custom-item {
 				@apply --d2l-body-compact-text;
 			}
 		</style>
@@ -88,7 +86,7 @@ class SearchWidgetCustom extends MyCoursesLocalizeBehavior(PolymerElement) {
 					<d2l-search-listbox>
 						<div data-list-title disabled>[[localize('recentSearches')]]</div>
 						<template is="dom-repeat" items="[[_previousSearches]]">
-							<div class="d2l-search-widget-custom-item" selectable data-text$="[[item]]" role="option">
+							<div class="d2l-search-custom-item" selectable data-text$="[[item]]" role="option">
 								[[item]]
 							</div>
 						</template>
@@ -235,7 +233,7 @@ class SearchWidgetCustom extends MyCoursesLocalizeBehavior(PolymerElement) {
 	}
 	_onSearchInputBlur(e) {
 		const className = e.relatedTarget ? e.relatedTarget.className : '';
-		if (e.relatedTarget !== this._getListbox() && className.indexOf('d2l-search-widget-custom-item') === -1) {
+		if (e.relatedTarget !== this._getListbox() && className.indexOf('d2l-search-custom-item') === -1) {
 			this.$.dropdown.close();
 		}
 	}
@@ -253,4 +251,4 @@ class SearchWidgetCustom extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 }
 
-window.customElements.define(SearchWidgetCustom.is, SearchWidgetCustom);
+window.customElements.define('d2l-my-courses-search', MyCoursesSearch);

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -22,7 +22,7 @@ describe('d2l-all-courses', function() {
 		sandbox = sinon.sandbox.create();
 
 		widget = fixture('d2l-all-courses-fixture');
-		sandbox.stub(widget, '_onSearchResultsChanged');
+		sandbox.stub(widget, '_onSearchChange');
 
 		enrollmentsEntity = {
 			actions: [
@@ -681,15 +681,15 @@ describe('d2l-all-courses', function() {
 		});
 
 		it('should clear search text', function(done) {
-			const spy = sandbox.spy(widget, '_clearSearchWidget');
-			const searchField = widget.$['search-widget'];
+			const search = widget.shadowRoot.querySelector('d2l-my-courses-search');
+			const spy = sandbox.spy(search, 'clear');
 
-			searchField._getSearchWidget()._getSearchInput().value = 'foo';
+			search._getSearchWidget()._getSearchInput().value = 'foo';
 			widget._onSimpleOverlayClosed();
 
 			requestAnimationFrame(() => {
 				expect(spy.called).to.be.true;
-				expect(searchField._getSearchWidget()._getSearchInput().value).to.equal('');
+				expect(search._getSearchWidget()._getSearchInput().value).to.equal('');
 				done();
 			});
 		});

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -398,7 +398,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.not.have.been.called;
 						expect(stubAllCourses).to.not.have.been.called;
 						done();
-					}, 10);
+					}, 20);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (just all tab)', done => {
@@ -412,7 +412,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					}, 10);
+					}, 20);
 				});
 			});
 			it('should call refreshCardGridImages on the content and all-courses (grouped by semesters)', done => {
@@ -427,7 +427,7 @@ describe('d2l-my-courses', () => {
 						expect(stubContent).to.have.been.called;
 						expect(stubAllCourses).to.have.been.called;
 						done();
-					}, 10);
+					}, 20);
 				});
 			});
 		});

--- a/test/d2l-my-courses-search/d2l-my-courses-search.html
+++ b/test/d2l-my-courses-search/d2l-my-courses-search.html
@@ -6,19 +6,15 @@
 		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
 		<script src="../../../wct-browser-legacy/browser.js"></script>
 
-		<script type="module" src="../../src/search-filter/d2l-search-widget-custom.js"></script>
+		<script type="module" src="../../src/search-filter/d2l-my-courses-search.js"></script>
 	</head>
 	<body>
-		<test-fixture id="d2l-search-widget-custom-fixture">
+		<test-fixture id="d2l-my-courses-search-fixture">
 			<template>
-				<d2l-search-widget-custom
-					cache-responses
-					parent-organizations="[]"
-					sort="OrgUnitName,OrgUnitId">
-				</d2l-search-widget-custom>
+				<d2l-my-courses-search></d2l-my-courses-search>
 			</template>
 		</test-fixture>
 
-		<script src="./d2l-search-widget-custom.js"></script>
+		<script src="./d2l-my-courses-search.js"></script>
 	</body>
 </html>

--- a/test/d2l-my-courses-search/d2l-my-courses-search.js
+++ b/test/d2l-my-courses-search/d2l-my-courses-search.js
@@ -1,4 +1,4 @@
-describe('<d2l-search-widget-custom>', function() {
+describe('d2l-my-courses-search', function() {
 	let sandbox,
 		widget,
 		clock;
@@ -36,8 +36,7 @@ describe('<d2l-search-widget-custom>', function() {
 		clock = sinon.useFakeTimers();
 
 		sandbox.stub(window.d2lfetch, 'fetch').returns(Promise.resolve());
-		widget = fixture('d2l-search-widget-custom-fixture');
-		widget._searchResultsCache = {};
+		widget = fixture('d2l-my-courses-search-fixture');
 		widget.searchAction = searchAction;
 		widget.searchFieldName = searchFieldName;
 	});

--- a/test/index.all.html
+++ b/test/index.all.html
@@ -14,7 +14,7 @@
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
 				'./d2l-my-courses-filter/d2l-my-courses-filter.html',
-				'./d2l-search-widget-custom/d2l-search-widget-custom.html',
+				'./d2l-my-courses-search/d2l-my-courses-search.html',
 				'./d2l-utility-helpers/d2l-utility-helpers.html',
 				'./localize-behavior/localize-behavior.html',
 				'../legacy-test/d2l-all-courses-legacy/d2l-all-courses-legacy.html',

--- a/test/index.high-priority.html
+++ b/test/index.high-priority.html
@@ -14,7 +14,7 @@
 				'./d2l-my-courses-container/d2l-my-courses-container.html',
 				'./d2l-my-courses-content/d2l-my-courses-content.html',
 				'./d2l-my-courses-filter/d2l-my-courses-filter.html',
-				'./d2l-search-widget-custom/d2l-search-widget-custom.html',
+				'./d2l-my-courses-search/d2l-my-courses-search.html',
 				'./d2l-utility-helpers/d2l-utility-helpers.html',
 				'./localize-behavior/localize-behavior.html'
 			]);


### PR DESCRIPTION
Doing a bunch of renaming and organizing now, to make the next PR cleaner.  The next PR will redo the search component so it no long uses `d2l-search-widget` (and is therefore no longer responsible for data loading).