### PR TITLE
[5] US117308 - Make all responses an EnrollmentCollectionEntity

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -14,9 +14,9 @@ import 'd2l-facet-filter-sort/components/d2l-sort-by-dropdown/d2l-sort-by-dropdo
 import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import './d2l-my-courses-card-grid.js';
 import './search-filter/d2l-my-courses-search.js';
-import { Actions, Classes } from 'd2l-hypermedia-constants';
 import { createActionUrl, fetchSirenEntity } from './d2l-utility-helpers.js';
 import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { Actions } from 'd2l-hypermedia-constants';
 import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
 import { MyCoursesFilterCategory } from './search-filter/d2l-my-courses-filter.js';

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -1,3 +1,4 @@
+import { EnrollmentCollectionEntity } from 'siren-sdk/src/enrollments/EnrollmentCollectionEntity.js';
 import { flush } from '@polymer/polymer/lib/utils/render-status.js';
 import SirenParse from 'siren-parser';
 
@@ -132,7 +133,7 @@ describe('d2l-all-courses', function() {
 	describe('Filtering', function() {
 		let entity;
 		beforeEach(() => {
-			entity = SirenParse(enrollmentsEntity);
+			entity = new EnrollmentCollectionEntity(SirenParse(enrollmentsEntity));
 		});
 		describe('Loading', function() {
 			it('should create filter categories from the enrollment entity', function() {
@@ -172,7 +173,7 @@ describe('d2l-all-courses', function() {
 				entity = enrollmentsEntity;
 				entity.actions = enrollmentsEntity.actions.filter(action => action.name !== 'search-my-semesters');
 
-				widget._handleNewEnrollmentsEntity(SirenParse(entity));
+				widget._handleNewEnrollmentsEntity(new EnrollmentCollectionEntity(SirenParse(entity)));
 				expect(widget._filterCategories.length).to.equal(2);
 				expect(widget._filterCategories[0].key).to.equal('departments');
 				expect(widget._filterCategories[1].key).to.equal('roles');


### PR DESCRIPTION
Making the search response also an `EnrollmentCollectionEntity` (not just the "load more" response) means we can simplify the code path and use more shared functions.