### PR TITLE
US117308 - DE39401 - Stop using d2l-search-widget and instead let All Courses fetch enrollments data

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -525,7 +525,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		);
 	}
 
-	async _fetchEnrollments(url) {
+	_fetchEnrollments(url) {
 		entityFactory(EnrollmentCollectionEntity, url, this.token, entity => {
 			if (entity) {
 				this._handleNewEnrollmentsEntity(entity);

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -89,8 +89,11 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			_isSearched: Boolean,
 			// Object containing the last response from an enrollments fetch
 			_lastEnrollmentCollectionResponse: Object,
-			// URL passed to search widget, called for searching
-			_searchUrl: String,
+			// URL to fetch enrollments, set by filtering, sorting, searching, and selecting a tab
+			_searchUrl: {
+				type: String,
+				observer: '_fetchEnrollments'
+			},
 			_selectedTabId: String,
 			_showAdvancedSearchLink: {
 				type: Boolean,
@@ -222,10 +225,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 					<div id="search-and-filter">
 						<div id="search-and-link">
 							<d2l-my-courses-search
-								on-d2l-search-widget-results-changed="_onSearchChange"
-								org-unit-type-ids="[[orgUnitTypeIds]]"
-								search-action="[[_enrollmentsSearchAction]]"
-								search-url="[[_searchUrl]]">
+								on-d2l-my-courses-search-change="_onSearchChange">
 							</d2l-my-courses-search>
 							<d2l-link class="advanced-search-link" hidden$="[[!_showAdvancedSearchLink]]" href$="[[advancedSearchUrl]]">[[localize('advancedSearch')]]</d2l-link>
 						</div>
@@ -350,10 +350,14 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 	}
 
 	_onSearchChange(e) {
-		this._isSearched = !!e.detail.searchValue;
+		this._isSearched = !!e.detail.value;
 
-		const enrollmentsEntity = new EnrollmentCollectionEntity(e.detail.searchResponse, this.token);
-		this._handleNewEnrollmentsEntity(enrollmentsEntity);
+		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
+			createActionUrl(this._enrollmentsSearchAction, {
+				orgUnitTypeId: this.orgUnitTypeIds,
+				search: encodeURIComponent(e.detail.value)
+			})
+		);
 	}
 
 	_onFilterChange(e) {
@@ -506,7 +510,8 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			autoPinCourses: false,
 			sort: sortData.action,
 			embedDepth: 0,
-			promotePins: sortData.promotePins
+			promotePins: sortData.promotePins,
+			pageSize: 20
 		};
 		if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
 			params.parentOrganizations =  this._enrollmentsSearchAction.getFieldByName('parentOrganizations').value;
@@ -518,6 +523,14 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
 			createActionUrl(tabAction.enrollmentsSearchAction, params)
 		);
+	}
+
+	async _fetchEnrollments(url) {
+		entityFactory(EnrollmentCollectionEntity, url, this.token, entity => {
+			if (entity) {
+				this._handleNewEnrollmentsEntity(entity);
+			}
+		});
 	}
 
 	_handleNewEnrollmentsEntity(enrollmentsEntity) {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -23,7 +23,6 @@ describe('d2l-all-courses', function() {
 		sandbox = sinon.sandbox.create();
 
 		widget = fixture('d2l-all-courses-fixture');
-		sandbox.stub(widget, '_onSearchChange');
 
 		enrollmentsEntity = {
 			actions: [
@@ -45,6 +44,9 @@ describe('d2l-all-courses', function() {
 						value: ''
 					}, {
 						name: 'sort',
+						value: ''
+					}, {
+						name: 'search',
 						value: ''
 					}]
 				}
@@ -255,7 +257,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3&sort=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3&sort=&search=&bustCache=');
 						done();
 					});
 				});
@@ -272,7 +274,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=4,5,6&sort=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=4,5,6&sort=&search=&bustCache=');
 						done();
 					});
 				});
@@ -292,7 +294,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3,4,5,6&sort=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3,4,5,6&sort=&search=&bustCache=');
 						done();
 					});
 				});
@@ -566,7 +568,19 @@ describe('d2l-all-courses', function() {
 				value: 'LastAccessed'
 			});
 			requestAnimationFrame(() => {
-				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=LastAccessed');
+				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=LastAccessed&search=');
+				done();
+			});
+		});
+	});
+
+	describe('Searching', function() {
+		it('should set the _searchUrl', function(done) {
+			fireEvent(widget.shadowRoot.querySelector('d2l-my-courses-search'), 'd2l-my-courses-search-change', {
+				value: 'testing'
+			});
+			requestAnimationFrame(() => {
+				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=&search=testing');
 				done();
 			});
 		});
@@ -654,6 +668,7 @@ describe('d2l-all-courses', function() {
 	describe('Closing the Overlay', function() {
 
 		it('should prep _enrollmentsSearchAction for component resets', function(done) {
+			sandbox.stub(widget, '_handleNewEnrollmentsEntity');
 			const entity = SirenParse({
 				actions: [{
 					name: 'search-my-enrollments',
@@ -685,12 +700,12 @@ describe('d2l-all-courses', function() {
 			const search = widget.shadowRoot.querySelector('d2l-my-courses-search');
 			const spy = sandbox.spy(search, 'clear');
 
-			search._getSearchWidget()._getSearchInput().value = 'foo';
+			search._getSearchInput().value = 'foo';
 			widget._onSimpleOverlayClosed();
 
 			requestAnimationFrame(() => {
 				expect(spy.called).to.be.true;
-				expect(search._getSearchWidget()._getSearchInput().value).to.equal('');
+				expect(search._getSearchInput().value).to.equal('');
 				done();
 			});
 		});

--- a/test/d2l-my-courses-search/d2l-my-courses-search.js
+++ b/test/d2l-my-courses-search/d2l-my-courses-search.js
@@ -1,58 +1,34 @@
 describe('d2l-my-courses-search', function() {
-	let sandbox,
-		widget,
-		clock;
+	let widget;
 
-	const searchAction = {
-			name: 'search-my-enrollments',
-			method: 'GET',
-			href: '/enrollments/users/169',
-			fields: [{
-				name: 'search',
-				type: 'search',
-				value: ''
-			}, {
-				name: 'pageSize',
-				type: 'number',
-				value: 20
-			}, {
-				name: 'embedDepth',
-				type: 'number',
-				value: 0
-			}, {
-				name: 'sort',
-				type: 'text',
-				value: 'OrgUnitName,OrgUnitId'
-			}, {
-				name: 'parentOrganizations',
-				type: 'hidden',
-				value: ''
-			}]
-		},
-		searchFieldName = 'search';
-
-	beforeEach(function() {
-		sandbox = sinon.sandbox.create();
-		clock = sinon.useFakeTimers();
-
-		sandbox.stub(window.d2lfetch, 'fetch').returns(Promise.resolve());
+	beforeEach(function(done) {
 		widget = fixture('d2l-my-courses-search-fixture');
-		widget.searchAction = searchAction;
-		widget.searchFieldName = searchFieldName;
-	});
-
-	afterEach(function() {
-		sandbox.restore();
-		clock.restore();
-	});
-
-	it('should perform a search when the searchUrl changes', function(done) {
-		requestAnimationFrame(function() {
-			const spy = sandbox.spy(widget, '_handleSearchUrlChange');
-			widget.searchUrl = '/organizations/1234';
-			clock.tick(501);
-			expect(spy.called).to.be.true;
+		requestAnimationFrame(() => {
 			done();
+		});
+	});
+
+	describe('Event', function() {
+		it('should fire an event when a search is done', function(done) {
+			widget.addEventListener('d2l-my-courses-search-change', (e) => {
+				expect(e.detail.value).to.equal('test');
+				done();
+			});
+
+			widget._getSearchInput().value = 'test';
+			widget._getSearchInput().search();
+		});
+	});
+
+	describe('Clear', function() {
+		it('should fire an event and clear the search input', function(done) {
+			widget.addEventListener('d2l-my-courses-search-change', (e) => {
+				expect(e.detail.value).to.equal('');
+				done();
+			});
+
+			widget._getSearchInput().value = 'test';
+			widget.clear();
 		});
 	});
 });


### PR DESCRIPTION
Instead of having the data flow go through searching, and manually setting the `_searchUrl` of the search widget to trick it into doing a fetch, we're now going to let the All Courses overlay do the fetching.  It can then request data the same way the "load more" workflow does, and filter/sort/search all work the same.  Since all search is now responsible for is firing an event (and all the saved searches stuff), it can just use `d2l-input-search` from `core` directly.

The next PR is going to cleanup the `_searchUrl` part, to keep track of the current state of the parameters instead of passing around the full url.