### PR TITLE
US117308 - DE39401 - Store Action Params

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -35,7 +35,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			// Standard Semester OU Type name to be displayed in the filter dropdown
 			filterStandardSemesterName: String,
 			// Configuration value passed in to toggle Learning Paths code
-			orgUnitTypeIds: Array,
+			orgUnitTypeIds: {
+				type: Array,
+				observer: '_onOrgUnitTypeIdsChange'
+			},
 			// URL to fetch widget settings
 			presentationUrl: String,
 			// Set by the image selector when it experiences an error trying to set a new course image
@@ -278,8 +281,8 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			</d2l-simple-overlay>`;
 	}
 
-	connectedCallback() {
-		super.connectedCallback();
+	ready() {
+		super.ready();
 		this._actionParams = {
 			autoPinCourses: false,
 			embedDepth: 0,
@@ -349,6 +352,12 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 					}
 				});
 			}
+		}
+	}
+
+	_onOrgUnitTypeIdsChange(newValue) {
+		if (this._actionParams) {
+			this._actionParams.orgUnitTypeId = newValue;
 		}
 	}
 

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -53,8 +53,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
 			token: String,
 
+			// Action params to keep filtering/sorting/searching options between tab changes
+			_actionParams: Object,
 			_bustCacheToken: Number,
-			// search-my-enrollments Action
+			// Current tab's search-my-enrollments Action
 			_enrollmentsSearchAction: Object,
 			// Info about filter categories and options to pass down to the filter component
 			_filterCategories: {
@@ -276,6 +278,19 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			</d2l-simple-overlay>`;
 	}
 
+	connectedCallback() {
+		super.connectedCallback();
+		this._actionParams = {
+			autoPinCourses: false,
+			embedDepth: 0,
+			orgUnitTypeId: this.orgUnitTypeIds,
+			pageSize: 20,
+			promotePins: this._sortMap[0].promotePins,
+			search: '',
+			sort: this._sortMap[0].action
+		};
+	}
+
 	/*
 	* Public API methods
 	*/
@@ -340,23 +355,20 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 	_onSortOrderChanged(e) {
 		const sortData = this._mapSortOption(e.detail.value, 'name');
 
+		this._actionParams.sort = sortData.action;
+		this._actionParams.promotePins = sortData.promotePins;
+
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-			createActionUrl(this._enrollmentsSearchAction, {
-				sort: sortData.action,
-				orgUnitTypeId: this.orgUnitTypeIds,
-				promotePins: sortData.promotePins
-			})
+			createActionUrl(this._enrollmentsSearchAction, this._actionParams)
 		);
 	}
 
 	_onSearchChange(e) {
 		this._isSearched = !!e.detail.value;
 
+		this._actionParams.search = encodeURIComponent(e.detail.value);
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-			createActionUrl(this._enrollmentsSearchAction, {
-				orgUnitTypeId: this.orgUnitTypeIds,
-				search: encodeURIComponent(e.detail.value)
-			})
+			createActionUrl(this._enrollmentsSearchAction, this._actionParams)
 		);
 	}
 
@@ -377,11 +389,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			const selectedSemesters = semesterFilters ? semesterFilters.selectedOptions : [];
 			const selectedDepartments = departmentFilters ? departmentFilters.selectedOptions : [];
 			const semesterDepartmentFilters = selectedSemesters.concat(selectedDepartments);
+
+			this._actionParams.parentOrganizations = semesterDepartmentFilters.join(',');
 			this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-				createActionUrl(this._enrollmentsSearchAction, {
-					orgUnitTypeId: this.orgUnitTypeIds,
-					parentOrganizations: semesterDepartmentFilters.join(',')
-				})
+				createActionUrl(this._enrollmentsSearchAction, this._actionParams)
 			);
 		}
 	}
@@ -412,6 +423,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		);
 
 		const actionUrl = createActionUrl(applyAction);
+		this._actionParams.roles = applyAction.getFieldByName('roles').value;
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(actionUrl);
 	}
 
@@ -422,18 +434,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			roles: 0
 		};
 
-		const params = {};
-		// Only clear if My Courses is not grouped by semesters/departments
-		if (this.tabSearchType !== 'BySemester' && this.tabSearchType !== 'ByDepartment') {
-			params.parentOrganizations = '';
-		}
-		// Only clear if My Courses is not grouped by role
-		if (this.tabSearchType !== 'ByRoleAlias') {
-			params.roles = '';
-		}
+		this._clearParentOrganizationsAndRolesParams();
 
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-			createActionUrl(this._enrollmentsSearchAction, params)
+			createActionUrl(this._enrollmentsSearchAction, this._actionParams)
 		);
 	}
 
@@ -448,31 +452,28 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 	}
 
 	_onSimpleOverlayClosed() {
-		if (this._enrollmentsSearchAction && this._enrollmentsSearchAction.hasFieldByName) {
-			if (this._enrollmentsSearchAction.hasFieldByName('search')) {
-				this._enrollmentsSearchAction.getFieldByName('search').value = '';
-			}
-			if (this._enrollmentsSearchAction.hasFieldByName('sort')) {
-				this._enrollmentsSearchAction.getFieldByName('sort').value = this._sortMap[0].action;
-			}
-			if (this._enrollmentsSearchAction.hasFieldByName('promotePins')) {
-				this._enrollmentsSearchAction.getFieldByName('promotePins').value = this._sortMap[0].promotePins;
-			}
-			// Only clear if My Courses is not grouped by semesters/departments
-			if (this.tabSearchType !== 'BySemester' && this.tabSearchType !== 'ByDepartment' && this._enrollmentsSearchAction.hasFieldByName('parentOrganizations')) {
-				this._enrollmentsSearchAction.getFieldByName('parentOrganizations').value = '';
-			}
-			// Only clear if My Courses is not grouped by role
-			if (this.tabSearchType !== 'ByRoleAlias' && this._enrollmentsSearchAction.hasFieldByName('roles')) {
-				this._enrollmentsSearchAction.getFieldByName('roles').value = '';
-			}
-		}
+		this._actionParams.search = '';
+		this._actionParams.sort = this._sortMap[0].action;
+		this._actionParams.promotePins = this._sortMap[0].promotePins;
+
+		this._clearParentOrganizationsAndRolesParams();
 
 		this.shadowRoot.querySelector('d2l-my-courses-search').clear();
 		this.shadowRoot.querySelector('d2l-my-courses-filter').clear();
 		this.shadowRoot.querySelector(`d2l-sort-by-dropdown-option[value=${this._sortMap[0].name}]`).click();
 
 		this.dispatchEvent(new CustomEvent('d2l-all-courses-close'));
+	}
+
+	_clearParentOrganizationsAndRolesParams() {
+		// Only clear if My Courses is not grouped by semesters/departments
+		if (this.tabSearchType !== 'BySemester' && this.tabSearchType !== 'ByDepartment' && this._actionParams.parentOrganizations) {
+			this._actionParams.parentOrganizations = '';
+		}
+		// Only clear if My Courses is not grouped by role
+		if (this.tabSearchType !== 'ByRoleAlias' && this._actionParams.roles) {
+			this._actionParams.roles = '';
+		}
 	}
 
 	// Triggered when the tabs are first rendered, which then fetches the enrollment data by setting _searchUrl
@@ -495,33 +496,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			return;
 		}
 
-		const search = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('search') ?
-			this._enrollmentsSearchAction.getFieldByName('search').value : '';
-
-		const sort = this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('sort') ?
-			this._enrollmentsSearchAction.getFieldByName('sort').value : this._sortMap[0].action;
-
-		const sortData = this._mapSortOption(sort, 'action');
-
 		this._showTabContent = false;
-		const params = {
-			search: search,
-			orgUnitTypeId: this.orgUnitTypeIds,
-			autoPinCourses: false,
-			sort: sortData.action,
-			embedDepth: 0,
-			promotePins: sortData.promotePins,
-			pageSize: 20
-		};
-		if ((this._filterCounts.departments > 0 || this._filterCounts.semesters > 0) && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('parentOrganizations')) {
-			params.parentOrganizations =  this._enrollmentsSearchAction.getFieldByName('parentOrganizations').value;
-		}
-		if (this._filterCounts.roles > 0 && this._enrollmentsSearchAction && this._enrollmentsSearchAction.getFieldByName('roles')) {
-			params.roles =  this._enrollmentsSearchAction.getFieldByName('roles').value;
-		}
 
 		this._searchUrl = this._appendOrUpdateBustCacheQueryString(
-			createActionUrl(tabAction.enrollmentsSearchAction, params)
+			createActionUrl(tabAction.enrollmentsSearchAction, this._actionParams)
 		);
 	}
 

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -53,6 +53,8 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			_presentationUrl: String,
 			_currentTabId: String,
 			_enrollmentsSearchAction: Object,
+			// Array form of orgUnitTypeIds
+			_orgUnitTypeIds: Array,
 			_pinnedTabAction: Object,
 			_tabSearchActions: {
 				type: Array,
@@ -116,7 +118,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 							show-image-error="[[_showImageError]]"
 							token="[[token]]"
 							enrollments-search-action="[[item.enrollmentsSearchAction]]"
-							org-unit-type-ids="[[orgUnitTypeIds]]"
+							org-unit-type-ids="[[_orgUnitTypeIds]]"
 							tab-search-type="[[_tabSearchType]]"
 							update-user-settings-action="[[_updateUserSettingsAction]]">
 						</d2l-my-courses-content>
@@ -129,7 +131,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 				advanced-search-url="[[advancedSearchUrl]]"
 				filter-standard-department-name="[[standardDepartmentName]]"
 				filter-standard-semester-name="[[standardSemesterName]]"
-				org-unit-type-ids="[[orgUnitTypeIds]]"
+				org-unit-type-ids="[[_orgUnitTypeIds]]"
 				presentation-url="[[_presentationUrl]]"
 				show-image-error="[[_showImageError]]"
 				tab-search-type="[[_tabSearchType]]"
@@ -172,14 +174,14 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 
-		let ouTypeIds = []; //default value
+		let ouTypeIds = []; // default value
 		try {
 			ouTypeIds = JSON.parse(this.orgUnitTypeIds).value;
 		} catch (e) {
 			// default value used
 		}
 
-		this.orgUnitTypeIds = ouTypeIds;
+		this._orgUnitTypeIds = ouTypeIds;
 	}
 
 	disconnectedCallback() {

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -257,7 +257,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3&sort=&search=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3&sort=Current&search=&bustCache=');
 						done();
 					});
 				});
@@ -274,7 +274,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=4,5,6&sort=&search=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=4,5,6&sort=Current&search=&bustCache=');
 						done();
 					});
 				});
@@ -294,7 +294,7 @@ describe('d2l-all-courses', function() {
 						}]
 					});
 					requestAnimationFrame(() => {
-						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3,4,5,6&sort=&search=&bustCache=');
+						expect(widget._searchUrl).to.equal('/enrollments/users/169?parentOrganizations=1,2,3,4,5,6&sort=Current&search=&bustCache=');
 						done();
 					});
 				});
@@ -479,6 +479,11 @@ describe('d2l-all-courses', function() {
 			});
 
 			it('should clear expected _searchUrl params', function(done) {
+				Object.assign(widget._actionParams, {
+					parentOrganizations: '123',
+					roles: '456',
+					sort: 'LastAccessed'
+				});
 				widget._enrollmentsSearchAction = {
 					name: 'search-my-enrollments',
 					href: '/enrollments/users/169',
@@ -501,6 +506,10 @@ describe('d2l-all-courses', function() {
 			});
 
 			it('should not clear parentOrganizations param if grouped by semesters', function(done) {
+				Object.assign(widget._actionParams, {
+					parentOrganizations: '123',
+					roles: '456'
+				});
 				widget.tabSearchType = 'BySemester';
 				widget._enrollmentsSearchAction = {
 					name: 'search-my-enrollments',
@@ -521,6 +530,10 @@ describe('d2l-all-courses', function() {
 			});
 
 			it('should not clear parentOrganizations param if grouped by departments', function(done) {
+				Object.assign(widget._actionParams, {
+					parentOrganizations: '123',
+					roles: '456'
+				});
 				widget.tabSearchType = 'ByDepartment';
 				widget._enrollmentsSearchAction = {
 					name: 'search-my-enrollments',
@@ -541,6 +554,10 @@ describe('d2l-all-courses', function() {
 			});
 
 			it('should not clear roles param if grouped by role', function(done) {
+				Object.assign(widget._actionParams, {
+					parentOrganizations: '123',
+					roles: '456'
+				});
 				widget.tabSearchType = 'ByRoleAlias';
 				widget._enrollmentsSearchAction = {
 					name: 'search-my-enrollments',
@@ -580,7 +597,7 @@ describe('d2l-all-courses', function() {
 				value: 'testing'
 			});
 			requestAnimationFrame(() => {
-				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=&search=testing');
+				expect(widget._searchUrl).to.include('/enrollments/users/169?parentOrganizations=&sort=Current&search=testing');
 				done();
 			});
 		});
@@ -667,31 +684,23 @@ describe('d2l-all-courses', function() {
 
 	describe('Closing the Overlay', function() {
 
-		it('should prep _enrollmentsSearchAction for component resets', function(done) {
-			sandbox.stub(widget, '_handleNewEnrollmentsEntity');
-			const entity = SirenParse({
-				actions: [{
-					name: 'search-my-enrollments',
-					method: 'GET',
-					href: '/enrollments/users/169',
-					fields: [
-						{ name: 'search', type: 'search', value: 'testing' },
-						{ name: 'sort', type: 'text', value: 'LastAccessed' },
-						{ name: 'promotePins', type: 'checkbox', value: false },
-						{ name: 'parentOrganizations', type: 'hidden', value: '123' },
-						{ name: 'roles', type: 'hidden', value: '456' }
-					]
-				}]
+		it('should prep _actionParams for component resets', function(done) {
+			Object.assign(widget._actionParams, {
+				search: 'testing',
+				sort: 'LastAccessed',
+				parentOrganizations: '123',
+				promotePins: false,
+				roles: '456'
 			});
-			widget._enrollmentsSearchAction = entity.actions[0];
+
 			widget._onSimpleOverlayClosed();
 
 			requestAnimationFrame(() => {
-				expect(widget._enrollmentsSearchAction.getFieldByName('search').value).to.be.equal('');
-				expect(widget._enrollmentsSearchAction.getFieldByName('sort').value).to.be.equal('Current');
-				expect(widget._enrollmentsSearchAction.getFieldByName('promotePins').value).to.be.true;
-				expect(widget._enrollmentsSearchAction.getFieldByName('parentOrganizations').value).to.equal('');
-				expect(widget._enrollmentsSearchAction.getFieldByName('roles').value).to.equal('');
+				expect(widget._actionParams.search).to.be.equal('');
+				expect(widget._actionParams.sort).to.be.equal('Current');
+				expect(widget._actionParams.promotePins).to.be.true;
+				expect(widget._actionParams.parentOrganizations).to.equal('');
+				expect(widget._actionParams.roles).to.equal('');
 				done();
 			});
 		});


### PR DESCRIPTION
To make things simpler when switching tabs, and to cleanup the logic to remove the race conditions when closing the overlay, we can store the current state of the params and use those each time we fetch enrollments.  For now I've kept the rest of the fetching workflow in place, but an upcoming PR will wrap common code in a function and call that instead of using an observer.