### PR TITLE
US116107 - Move the loading spinner into the card grid

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -254,15 +254,11 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 					<d2l-tabs on-d2l-tab-panel-selected="_onTabSelected">
 						<template items="[[tabSearchActions]]" is="dom-repeat">
 							<d2l-tab-panel id="all-courses-tab-[[item.name]]" text="[[item.title]]" selected="[[item.selected]]">
-								<div hidden$="[[!_showTabContent]]">
-									<d2l-my-courses-card-grid token="[[token]]" presentation-url="[[presentationUrl]]">
-										<span id="infoMessage" hidden$="[[!_infoMessageText]]">
-											[[_infoMessageText]]
-										</span>
-									</d2l-my-courses-card-grid>
-								</div>
-								<d2l-loading-spinner hidden$="[[_showTabContent]]" size="100">
-								</d2l-loading-spinner>
+								<d2l-my-courses-card-grid loading="[[!_showTabContent]]" token="[[token]]" presentation-url="[[presentationUrl]]">
+									<span id="infoMessage" hidden$="[[!_infoMessageText]]">
+										[[_infoMessageText]]
+									</span>
+								</d2l-my-courses-card-grid>
 							</d2l-tab-panel>
 						</template>
 					</d2l-tabs>

--- a/src/d2l-my-courses-card-grid.js
+++ b/src/d2l-my-courses-card-grid.js
@@ -3,6 +3,7 @@
 Lit web component for the grid of enrollment cards.
 */
 
+import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import 'd2l-enrollments/components/d2l-enrollment-card/d2l-enrollment-card.js';
 import { css, html, LitElement } from 'lit-element';
 import { entityFactory } from 'siren-sdk/src/es6/EntityFactory.js';
@@ -18,6 +19,8 @@ class MyCoursesCardGrid extends LitElement {
 			// If true, will hide courses that are "closed" (only needed if a closed course was just unpinned,
 			// since we remove closed courses from the filteredEnrollments array on load)
 			hidePastCourses: { attribute: 'hide-past-courses', reflect: true, type: Boolean },
+			// Whether to display the loading spinner instead of the card grid
+			loading: { type: Boolean },
 			// URL to fetch widget settings
 			presentationUrl: { type: String },
 			// Token JWT Token for brightspace | a function that returns a JWT token for brightspace
@@ -83,6 +86,12 @@ class MyCoursesCardGrid extends LitElement {
 			:host([hide-past-courses]) .course-card-grid d2l-enrollment-card[closed]:not([pinned]) {
 				display: none;
 			}
+
+			d2l-loading-spinner {
+				margin: auto;
+				padding-bottom: 20px;
+				width: 100%;
+			}
 		`];
 	}
 
@@ -92,6 +101,7 @@ class MyCoursesCardGrid extends LitElement {
 
 		this.filteredEnrollments = [];
 		this.hidePastCourses = false;
+		this.loading = false;
 		this.widgetView = false;
 		this._hideCourseStartDate = false;
 		this._hideCourseEndDate = false;
@@ -143,7 +153,10 @@ class MyCoursesCardGrid extends LitElement {
 			};
 		}
 
-		return html`
+		return this.loading ? html`
+			<d2l-loading-spinner size="100">
+			</d2l-loading-spinner>
+			` : html`
 			<slot></slot>
 			<div class="course-card-grid columns-${this._numColumns}">
 				${this.filteredEnrollments.map((item, index) => html`

--- a/src/d2l-my-courses-content.js
+++ b/src/d2l-my-courses-content.js
@@ -5,7 +5,6 @@ Polymer-based web component for the my-courses content.
 
 import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/link/link.js';
-import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import 'd2l-typography/d2l-typography-shared-styles.js';
 import './d2l-my-courses-card-grid.js';
 
@@ -149,11 +148,6 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 					user-select: none;
 				}
 			}
-			.spinner-container {
-				display: flex;
-				justify-content: center;
-				align-items: center;
-			}
 			d2l-alert {
 				margin-bottom: 20px;
 				clear: both;
@@ -168,32 +162,28 @@ class MyCoursesContent extends StatusMixin(MyCoursesLocalizeBehavior(PolymerElem
 				margin: 0;
 			}
 		</style>
+		
+		<d2l-my-courses-card-grid
+			filtered-enrollments="[[_enrollments]]"
+			hide-past-courses="[[_hidePastCourses]]"
+			loading="[[!_showContent]]"
+			token="[[token]]"
+			presentation-url="[[presentationUrl]]"
+			widget-view>
 
-		<div class="spinner-container">
-			<d2l-loading-spinner hidden$="[[_showContent]]" size="100">
-			</d2l-loading-spinner>
-		</div>
+			<d2l-alert id="imageErrorAlert" hidden$="[[!showImageError]]" type="warning">
+				[[localize('error.settingImage')]]
+			</d2l-alert>
+			<d2l-alert id="courseInfoAlert" hidden$="[[!_courseInfoAlertText]]" type="call-to-action">
+				[[_courseInfoAlertText]]
+			</d2l-alert>
+			<d2l-alert id="newEnrollmentAlert" hidden$="[[!_newEnrollmentAlertText]]" type="call-to-action">
+				[[_newEnrollmentAlertText]]
+			</d2l-alert>
 
-		<div hidden$="[[!_showContent]]" class="my-courses-content">
-			<d2l-my-courses-card-grid
-				filtered-enrollments="[[_enrollments]]"
-				hide-past-courses="[[_hidePastCourses]]"
-				token="[[token]]"
-				presentation-url="[[presentationUrl]]"
-				widget-view>
+		</d2l-my-courses-card-grid>
 
-				<d2l-alert id="imageErrorAlert" hidden$="[[!showImageError]]" type="warning">
-					[[localize('error.settingImage')]]
-				</d2l-alert>
-				<d2l-alert id="courseInfoAlert" hidden$="[[!_courseInfoAlertText]]" type="call-to-action">
-					[[_courseInfoAlertText]]
-				</d2l-alert>
-				<d2l-alert id="newEnrollmentAlert" hidden$="[[!_newEnrollmentAlertText]]" type="call-to-action">
-					[[_newEnrollmentAlertText]]
-				</d2l-alert>
-
-			</d2l-my-courses-card-grid>
-
+		<div hidden$="[[!_showContent]]">
 			<d2l-link id="viewAllCourses"
 				hidden$="[[!_numberOfEnrollments]]"
 				href="javascript:void(0);"

--- a/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
+++ b/test/d2l-my-courses-card-grid/d2l-my-courses-card-grid.js
@@ -11,6 +11,26 @@ describe('d2l-my-courses-card-grid', function() {
 		});
 	});
 
+	describe('Loading', function() {
+		it('should display loading spinner if loading is true', done => {
+			let loadingSpinner = widget.shadowRoot.querySelector('d2l-loading-spinner');
+			let cardGrid = widget.shadowRoot.querySelector('.course-card-grid');
+			expect(widget.loading).to.be.false;
+			expect(loadingSpinner).to.be.null;
+			expect(cardGrid).to.not.be.null;
+
+			widget.loading = true;
+			requestAnimationFrame(() => {
+				loadingSpinner = widget.shadowRoot.querySelector('d2l-loading-spinner');
+				cardGrid = widget.shadowRoot.querySelector('.course-card-grid');
+				expect(widget.loading).to.be.true;
+				expect(loadingSpinner).to.not.be.null;
+				expect(cardGrid).to.be.null;
+				done();
+			});
+		});
+	});
+
 	describe('Card Grid', function() {
 
 		it('should set --course-image-card-height as part of initial setup', done => {


### PR DESCRIPTION
Back when we were going to move the tabs inside the card grid, I moved the loading spinner in to prepare for that.  We've cut the tab move from scope, but this was already good to go and seems like a plus to me to help simplify and consolidate.