### PR TITLE
Replace simple-overlay with dialog-fullscreen when showing all courses

### DIFF
--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -5,13 +5,13 @@ Polymer-based web component for the all courses overlay.
 
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import '@brightspace-ui/core/components/alert/alert.js';
+import '@brightspace-ui/core/components/dialog/dialog-fullscreen.js';
 import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import '@brightspace-ui/core/components/tabs/tabs.js';
 import '@brightspace-ui/core/components/tabs/tab-panel.js';
 import '@brightspace-ui-labs/facet-filter-sort/components/sort-by-dropdown/sort-by-dropdown.js';
 import '@brightspace-ui-labs/facet-filter-sort/components/sort-by-dropdown/sort-by-dropdown-option.js';
-import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import './d2l-my-courses-card-grid.js';
 import './search-filter/d2l-my-courses-search.js';
 import { createActionUrl, fetchSirenEntity } from './d2l-utility-helpers.js';
@@ -208,14 +208,10 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 				}
 			</style>
 
-			<d2l-simple-overlay
+			<d2l-dialog-fullscreen
 				id="all-courses"
-				on-d2l-simple-overlay-opening="_onSimpleOverlayOpening"
-				on-d2l-simple-overlay-closed="_onSimpleOverlayClosed"
-				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
 				restore-focus-on-close
-				title-name="[[localize('allCourses')]]"
-				with-backdrop>
+				title-text="[[localize('allCourses')]]">
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">
@@ -268,7 +264,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 				</div>
 				<d2l-loading-spinner hidden$="[[_showContent]]" size="100">
 				</d2l-loading-spinner>
-			</d2l-simple-overlay>`;
+			</d2l-dialog-fullscreen>`;
 	}
 
 	ready() {
@@ -282,6 +278,8 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			search: '',
 			sort: this._sortMap.Default.action
 		};
+		this.addEventListener('d2l-dialog-open', this._onSimpleOverlayOpening);
+		this.addEventListener('d2l-dialog-close', this._onSimpleOverlayClosed);
 	}
 
 	/*

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -210,8 +210,9 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 			<d2l-dialog-fullscreen
 				id="all-courses"
-				restore-focus-on-close
-				title-text="[[localize('allCourses')]]">
+				title-text="[[localize('allCourses')]]"
+				on-d2l-dialog-open="_onDialogOpening"
+     			on-d2l-dialog-close="_onDialogClosed">
 
 				<div hidden$="[[!_showContent]]">
 					<iron-scroll-threshold id="all-courses-scroll-threshold" on-lower-threshold="_onAllCoursesLowerThreshold">
@@ -278,8 +279,6 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			search: '',
 			sort: this._sortMap.Default.action
 		};
-		this.addEventListener('d2l-dialog-open', this._onSimpleOverlayOpening);
-		this.addEventListener('d2l-dialog-close', this._onSimpleOverlayClosed);
 	}
 
 	/*
@@ -438,7 +437,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		);
 	}
 
-	_onSimpleOverlayOpening() {
+	_onDialogOpening() {
 		if (this._hasEnrollmentsChanged) {
 			this._hasEnrollmentsChanged = false;
 			this._bustCacheToken = Math.random();
@@ -448,7 +447,7 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		}
 	}
 
-	_onSimpleOverlayClosed() {
+	_onDialogClosed() {
 		this._actionParams.search = '';
 		this._actionParams.sort = this._sortMap.Default.action;
 		this._actionParams.promotePins = this._sortMap.Default.promotePins;

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -138,7 +138,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			</d2l-all-courses>
 			
 			<d2l-dialog-fullscreen id="basic-image-selector-overlay"
-				title-text="[[localize('changeImage')]]change"
+				title-text="[[localize('changeImage')]]"
 				restore-focus-on-close>
 				<iron-scroll-threshold
 					id="image-selector-threshold"
@@ -187,7 +187,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	// If it's a catalog image this is handled by the enrollment card
 	courseImageUploadCompleted(success) {
 		if (success) {
-			this.$['basic-image-selector-overlay'].close();
+			this._setDialogOpen(false);
 
 			const contentComponent = this._getContentComponent();
 			if (contentComponent) {
@@ -218,12 +218,10 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			this._setImageOrg = parseEntity(e.detail.organization);
 		}
 
-		const dialog = this.shadowRoot.querySelector('d2l-dialog-fullscreen');
-		dialog.opened = true;
+		this._setDialogOpen(true);
 	}
 	_onSetCourseImage(e) {
-		const dialog = this.shadowRoot.querySelector('d2l-dialog-fullscreen');
-		dialog.opened = false;
+		this._setDialogOpen(false);
 		this._showImageError = false;
 		if (e && e.detail) {
 			if (e.detail.status === 'failure') {
@@ -232,6 +230,13 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 				}, 1000); // delay until the tile fail icon animation begins to kick in (1 sec delay)
 			}
 		}
+	}
+
+	_setDialogOpen(open) {
+		const dialog = this.shadowRoot.querySelector('d2l-dialog-fullscreen');
+		dialog.opened = open;
+		const imageSelector = this.shadowRoot.querySelector('d2l-basic-image-selector');
+		open ? imageSelector.initializeSearch() : imageSelector.clearSearch();
 	}
 
 	_getContentComponent() {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -6,12 +6,12 @@ Component for when the `d2l.Tools.MyCoursesWidget.UpdatedSortLogic` config varia
 
 */
 
+import '@brightspace-ui/core/components/dialog/dialog-fullscreen.js';
 import '@brightspace-ui/core/components/loading-spinner/loading-spinner.js';
 import '@brightspace-ui/core/components/tabs/tabs.js';
 import '@brightspace-ui/core/components/tabs/tab-panel.js';
 import '@polymer/iron-scroll-threshold/iron-scroll-threshold.js';
 import 'd2l-image-selector/d2l-basic-image-selector.js';
-import 'd2l-simple-overlay/d2l-simple-overlay.js';
 import './d2l-all-courses.js';
 import './d2l-my-courses-content.js';
 import { createActionUrl, getEntityIdentifier, getOrgUnitIdFromHref, parseEntity } from './d2l-utility-helpers.js';
@@ -137,10 +137,8 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 				token="[[token]]">
 			</d2l-all-courses>
 			
-			<d2l-simple-overlay id="basic-image-selector-overlay"
-				title-name="[[localize('changeImage')]]"
-				close-simple-overlay-alt-text="[[localize('closeSimpleOverlayAltText')]]"
-				with-backdrop
+			<d2l-dialog-fullscreen id="basic-image-selector-dialog"
+				title-text="[[localize('changeImage')]]"
 				restore-focus-on-close>
 				<iron-scroll-threshold
 					id="image-selector-threshold"
@@ -151,7 +149,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 					organization="[[_setImageOrg]]"
 					course-image-upload-cb="[[courseImageUploadCb]]">
 				</d2l-basic-image-selector>
-			</d2l-simple-overlay>`;
+			</d2l-dialog-fullscreen>`;
 	}
 
 	constructor() {
@@ -168,7 +166,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		document.body.addEventListener('d2l-course-pinned-change', this._onCourseEnrollmentChange);
 
-		this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
+		this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-dialog'].scrollRegion;
 
 		let ouTypeIds = []; // default value
 		try {
@@ -189,7 +187,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	// If it's a catalog image this is handled by the enrollment card
 	courseImageUploadCompleted(success) {
 		if (success) {
-			this.$['basic-image-selector-overlay'].close();
+			this.$['basic-image-selector-dialog'].close();
 
 			const contentComponent = this._getContentComponent();
 			if (contentComponent) {
@@ -220,10 +218,11 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			this._setImageOrg = parseEntity(e.detail.organization);
 		}
 
-		this.$['basic-image-selector-overlay'].open();
+		this.$['basic-image-selector-dialog'].open();
 	}
 	_onSetCourseImage(e) {
-		this.$['basic-image-selector-overlay'].close();
+		this.$['basic-image-selector-dialog'].close();
+
 		this._showImageError = false;
 		if (e && e.detail) {
 			if (e.detail.status === 'failure') {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -138,8 +138,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			</d2l-all-courses>
 			
 			<d2l-dialog-fullscreen id="basic-image-selector-overlay"
-				title-text="[[localize('changeImage')]]"
-				restore-focus-on-close>
+				title-text="[[localize('changeImage')]]">
 				<iron-scroll-threshold
 					id="image-selector-threshold"
 					on-lower-threshold="_onChangeImageLowerThreshold">

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -218,10 +218,12 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			this._setImageOrg = parseEntity(e.detail.organization);
 		}
 
-		this.$['basic-image-selector-overlay'].open();
+		const dialog = this.shadowRoot.querySelector('d2l-dialog-fullscreen');
+		dialog.opened = true;
 	}
 	_onSetCourseImage(e) {
-		this.$['basic-image-selector-overlay'].close();
+		const dialog = this.shadowRoot.querySelector('d2l-dialog-fullscreen');
+		dialog.opened = false;
 		this._showImageError = false;
 		if (e && e.detail) {
 			if (e.detail.status === 'failure') {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -137,8 +137,8 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 				token="[[token]]">
 			</d2l-all-courses>
 			
-			<d2l-dialog-fullscreen id="basic-image-selector-dialog"
-				title-text="[[localize('changeImage')]]"
+			<d2l-dialog-fullscreen id="basic-image-selector-overlay"
+				title-text="[[localize('changeImage')]]change"
 				restore-focus-on-close>
 				<iron-scroll-threshold
 					id="image-selector-threshold"
@@ -166,7 +166,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		document.body.addEventListener('d2l-course-pinned-change', this._onCourseEnrollmentChange);
 
-		this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-dialog'].scrollRegion;
+		this.$['image-selector-threshold'].scrollTarget = this.$['basic-image-selector-overlay'].scrollRegion;
 
 		let ouTypeIds = []; // default value
 		try {
@@ -187,7 +187,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	// If it's a catalog image this is handled by the enrollment card
 	courseImageUploadCompleted(success) {
 		if (success) {
-			this.$['basic-image-selector-dialog'].close();
+			this.$['basic-image-selector-overlay'].close();
 
 			const contentComponent = this._getContentComponent();
 			if (contentComponent) {
@@ -218,11 +218,10 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			this._setImageOrg = parseEntity(e.detail.organization);
 		}
 
-		this.$['basic-image-selector-dialog'].open();
+		this.$['basic-image-selector-overlay'].open();
 	}
 	_onSetCourseImage(e) {
-		this.$['basic-image-selector-dialog'].close();
-
+		this.$['basic-image-selector-overlay'].close();
 		this._showImageError = false;
 		if (e && e.detail) {
 			if (e.detail.status === 'failure') {

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "كل المقررات التعليمية",
 	"allTab": "الكل",
 	"changeImage": "تغيير الصورة",
-	"closeSimpleOverlayAltText": "إغلاق مربع الحوار",
 	"courseSearchInputPlaceholder": "العثور على مقرر تعليمي",
 	"error.settingImage": "عذرًا، يتعذّر علينا تغيير صورتك الآن. يُرجى إعادة المحاولة لاحقًا.",
 	"filtering.noDepartments": "ليس لديك أي عوامل تصفية لـ {department}.",

--- a/src/lang/cy-gb.js
+++ b/src/lang/cy-gb.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Pob Cwrs",
 	"allTab": "Pob un",
 	"changeImage": "Newid y Ddelwedd",
-	"closeSimpleOverlayAltText": "Cau’r Dialog",
 	"courseSearchInputPlaceholder": "Dod o hyd i gwrs",
 	"error.settingImage": "Mae’n ddrwg gennym, ni allwn newid eich delwedd ar hyn o bryd. Rhowch gynnig arall arni’n hwyrach.",
 	"filtering.noDepartments": "Nid oes gennych unrhyw hidlyddion {department}.",

--- a/src/lang/da-dk.js
+++ b/src/lang/da-dk.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Alle kurser",
 	"allTab": "Alle",
 	"changeImage": "Skift billede",
-	"closeSimpleOverlayAltText": "Luk dialogboks",
 	"courseSearchInputPlaceholder": "Find et kursus",
 	"error.settingImage": "Vi kan desværre ikke ændre dit billede lige nu. Prøv igen senere.",
 	"filtering.noDepartments": "Du har ikke nogen {department}-filtre.",

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Alle Kurse",
 	"allTab": "Alle",
 	"changeImage": "Bild ändern",
-	"closeSimpleOverlayAltText": "Dialogfeld schließen",
 	"courseSearchInputPlaceholder": "Kurs finden",
 	"error.settingImage": "Entschuldigung, wir können Ihr Bild zurzeit nicht ändern. Versuchen Sie es später erneut.",
 	"filtering.noDepartments": "Sie haben keine {department}-Filter ausgewählt.",

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "All Courses",
 	"allTab": "All",
 	"changeImage": "Change Image",
-	"closeSimpleOverlayAltText": "Close Dialog",
 	"courseSearchInputPlaceholder": "Find a course",
 	"error.settingImage": "Sorry, we're unable to change your image right now. Please try again later.",
 	"filtering.noDepartments": "You do not have any {department} filters.",

--- a/src/lang/es-es.js
+++ b/src/lang/es-es.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Todos los cursos",
 	"allTab": "Todos",
 	"changeImage": "Cambiar imagen",
-	"closeSimpleOverlayAltText": "Cerrar el cuadro de diálogo",
 	"courseSearchInputPlaceholder": "Buscar un curso",
 	"error.settingImage": "Lo sentimos, pero no es posible cambiar su imagen en este momento. Vuelva a intentarlo más tarde.",
 	"filtering.noDepartments": "No tiene ningún filtro de {department}.",

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Todos los cursos",
 	"allTab": "Todo",
 	"changeImage": "Cambiar imagen",
-	"closeSimpleOverlayAltText": "Cerrar cuadro de diálogo",
 	"courseSearchInputPlaceholder": "Buscar un curso",
 	"error.settingImage": "Lo sentimos, no es posible cambiar su imagen en este momento. Vuelva a intentarlo más tarde.",
 	"filtering.noDepartments": "No tiene ningún filtro de {department}.",

--- a/src/lang/fi.js
+++ b/src/lang/fi.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Kaikki kurssit",
 	"allTab": "All",
 	"changeImage": "Vaihda kuva",
-	"closeSimpleOverlayAltText": "Sulje valintaikkuna",
 	"courseSearchInputPlaceholder": "Etsi kurssi",
 	"error.settingImage": "Kuvaa ei voi vaihtaa juuri nyt. Yritä myöhemmin uudelleen.",
 	"filtering.noDepartments": "Sinulla ei ole suodattimia ({department}).",

--- a/src/lang/fr-fr.js
+++ b/src/lang/fr-fr.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Tous les cours",
 	"allTab": "Tous",
 	"changeImage": "Modifier l’image",
-	"closeSimpleOverlayAltText": "Fermer la boîte de dialogue",
 	"courseSearchInputPlaceholder": "Rechercher un cours",
 	"error.settingImage": "Désolé, nous ne pouvons pas modifier votre image pour le moment. Réessayez ultérieurement.",
 	"filtering.noDepartments": "Vous n’avez sélectionné aucun filtre {department}.",

--- a/src/lang/fr-on.js
+++ b/src/lang/fr-on.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Tous les cours",
 	"allTab": "Tous",
 	"changeImage": "Modifier l'image",
-	"closeSimpleOverlayAltText": "Fermer la boîte de dialogue",
 	"courseSearchInputPlaceholder": "Chercher un cours",
 	"error.settingImage": "Désolé, nous ne sommes pas en mesure de modifier votre image pour le moment. Veuillez essayer plus tard.",
 	"filtering.noDepartments": "Vous n'avez aucun filtre de {department}.",

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Tous les cours",
 	"allTab": "Tous",
 	"changeImage": "Modifier l'image",
-	"closeSimpleOverlayAltText": "Fermer la boîte de dialogue",
 	"courseSearchInputPlaceholder": "Chercher un cours",
 	"error.settingImage": "Désolé, nous ne sommes pas en mesure de modifier votre image pour le moment. Veuillez essayer plus tard.",
 	"filtering.noDepartments": "Vous n'avez aucun filtre de {department}.",

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "すべてのコース",
 	"allTab": "すべて",
 	"changeImage": "イメージの変更",
-	"closeSimpleOverlayAltText": "ダイアログを閉じる",
 	"courseSearchInputPlaceholder": "コースの検索",
 	"error.settingImage": "申し訳ありません。現在イメージを変更することはできません。後でもう一度試してください。",
 	"filtering.noDepartments": "{department} フィルタがありません。",

--- a/src/lang/ko.js
+++ b/src/lang/ko.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "모든 강의",
 	"allTab": "모두",
 	"changeImage": "이미지 변경",
-	"closeSimpleOverlayAltText": "대화 상자 닫기",
 	"courseSearchInputPlaceholder": "강의 찾기",
 	"error.settingImage": "지금은 이미지를 변경할 수 없습니다. 나중에 다시 시도하십시오.",
 	"filtering.noDepartments": "{department} 필터가 없습니다.",

--- a/src/lang/nb.js
+++ b/src/lang/nb.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Alle undervisningsenheter",
 	"allTab": "All",
 	"changeImage": "Endre bilde",
-	"closeSimpleOverlayAltText": "Lukk dialogboks",
 	"courseSearchInputPlaceholder": "Finn en undervisningsenhet",
 	"error.settingImage": "Vi kan ikke endre bildet ditt akkurat nå. Prøv igjen senere.",
 	"filtering.noDepartments": "You do not have any {department} filters.",

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Alle cursussen",
 	"allTab": "Alle",
 	"changeImage": "Afbeelding wijzigen",
-	"closeSimpleOverlayAltText": "Dialoogvenster sluiten",
 	"courseSearchInputPlaceholder": "Een cursus zoeken",
 	"error.settingImage": "Uw afbeelding kan op dit moment niet worden gewijzigd. Probeer het later opnieuw.",
 	"filtering.noDepartments": "U hebt geen {department}-filters.",

--- a/src/lang/pt.js
+++ b/src/lang/pt.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Todos os Cursos",
 	"allTab": "Todos",
 	"changeImage": "Alterar Imagem",
-	"closeSimpleOverlayAltText": "Fechar Caixa de Diálogo",
 	"courseSearchInputPlaceholder": "Encontrar um curso",
 	"error.settingImage": "Não é possível alterar sua imagem agora. Tente novamente mais tarde.",
 	"filtering.noDepartments": "Você não tem nenhum filtro de {department}.",

--- a/src/lang/sv.js
+++ b/src/lang/sv.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Alla kurser",
 	"allTab": "Alla",
 	"changeImage": "Ändra bild",
-	"closeSimpleOverlayAltText": "Stäng dialogruta",
 	"courseSearchInputPlaceholder": "Hitta en kurs",
 	"error.settingImage": "Vi kan inte ändra din bild just nu. Försök igen senare.",
 	"filtering.noDepartments": "Du har inga filter för {department}.",

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "Tüm Dersler",
 	"allTab": "Tümü",
 	"changeImage": "Görüntüyü Değiştir",
-	"closeSimpleOverlayAltText": "Diyaloğu Kapat",
 	"courseSearchInputPlaceholder": "Ders bul",
 	"error.settingImage": "Üzgünüz; şu anda görüntünüzü değiştiremiyoruz. Lütfen daha sonra tekrar deneyin.",
 	"filtering.noDepartments": "Herhangi bir {department} filtreniz yok.",

--- a/src/lang/zh-tw.js
+++ b/src/lang/zh-tw.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "所有課程",
 	"allTab": "全部",
 	"changeImage": "變更影像",
-	"closeSimpleOverlayAltText": "關閉對話方塊",
 	"courseSearchInputPlaceholder": "尋找課程",
 	"error.settingImage": "抱歉，我們現在無法變更您的影像。請稍後再試。",
 	"filtering.noDepartments": "您沒有任何 {department} 篩選器。",

--- a/src/lang/zh.js
+++ b/src/lang/zh.js
@@ -5,7 +5,6 @@ export default {
 	"allCourses": "所有课程",
 	"allTab": "全部",
 	"changeImage": "更改图像",
-	"closeSimpleOverlayAltText": "关闭对话框",
 	"courseSearchInputPlaceholder": "查找课程",
 	"error.settingImage": "抱歉，目前我们无法更改您的图像。请稍后重试。",
 	"filtering.noDepartments": "您没有设置任何 {department} 筛选条件。",

--- a/test/d2l-all-courses/d2l-all-courses.js
+++ b/test/d2l-all-courses/d2l-all-courses.js
@@ -693,7 +693,7 @@ describe('d2l-all-courses', function() {
 				roles: '456'
 			});
 
-			widget._onSimpleOverlayClosed();
+			widget._onDialogClosed();
 
 			requestAnimationFrame(() => {
 				expect(widget._actionParams.search).to.be.equal('');
@@ -710,7 +710,7 @@ describe('d2l-all-courses', function() {
 			const spy = sandbox.spy(search, 'clear');
 
 			search._getSearchInput().value = 'foo';
-			widget._onSimpleOverlayClosed();
+			widget._onDialogClosed();
 
 			requestAnimationFrame(() => {
 				expect(spy.called).to.be.true;
@@ -728,7 +728,7 @@ describe('d2l-all-courses', function() {
 				roles: 5
 			};
 
-			widget._onSimpleOverlayClosed();
+			widget._onDialogClosed();
 
 			requestAnimationFrame(() => {
 				expect(spy.called).to.be.true;
@@ -752,7 +752,7 @@ describe('d2l-all-courses', function() {
 			fireEvent(sortDropdown, 'd2l-labs-sort-by-dropdown-change', event);
 			expect(widget._searchUrl).to.contain('sort=OrgUnitCode,OrgUnitId');
 
-			widget._onSimpleOverlayClosed();
+			widget._onDialogClosed();
 			requestAnimationFrame(() => {
 				expect(widget._searchUrl).to.contain('sort=Current');
 				done();

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -571,7 +571,7 @@ describe('d2l-my-courses', () => {
 			});
 
 			it('should open the course image overlay', done => {
-				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'open');
+				const spy = sandbox.spy(component.shadowRoot.querySelector('d2l-basic-image-selector'), 'initializeSearch');
 
 				component.addEventListener('open-change-image-view', function() {
 					setTimeout(() => {
@@ -626,8 +626,7 @@ describe('d2l-my-courses', () => {
 		describe('set-course-image', () => {
 
 			it('should close the image-selector overlay', done => {
-				const spy = sandbox.spy(component.$['basic-image-selector-overlay'], 'close');
-
+				const spy = sandbox.spy(component.shadowRoot.querySelector('d2l-basic-image-selector'), 'clearSearch');
 				const event = new CustomEvent('set-course-image');
 				component.dispatchEvent(event);
 

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -571,11 +571,13 @@ describe('d2l-my-courses', () => {
 			});
 
 			it('should open the course image overlay', done => {
+				component.shadowRoot.querySelector('d2l-dialog-fullscreen').opened = false;
 				const spy = sandbox.spy(component.shadowRoot.querySelector('d2l-basic-image-selector'), 'initializeSearch');
 
 				component.addEventListener('open-change-image-view', function() {
 					setTimeout(() => {
 						expect(spy).to.have.been.called;
+						expect(component.shadowRoot.querySelector('d2l-dialog-fullscreen').opened).to.equal(true);
 						done();
 					}, 0);
 				});
@@ -626,12 +628,14 @@ describe('d2l-my-courses', () => {
 		describe('set-course-image', () => {
 
 			it('should close the image-selector overlay', done => {
+				component.shadowRoot.querySelector('d2l-dialog-fullscreen').opened = true;
 				const spy = sandbox.spy(component.shadowRoot.querySelector('d2l-basic-image-selector'), 'clearSearch');
 				const event = new CustomEvent('set-course-image');
 				component.dispatchEvent(event);
 
 				setTimeout(() => {
 					expect(spy).to.have.been.called;
+					expect(component.shadowRoot.querySelector('d2l-dialog-fullscreen').opened).to.equal(false);
 					done();
 				});
 			});


### PR DESCRIPTION
Updating the show all courses widget to use the d2l-dialog-fullscreen component rather than d2l-simple-overlay.

This is part of a set of PRs all needed to make the image-selector component work with d2l-dialog-fullscreen: 

- https://github.com/Brightspace/d2l-my-courses-ui/pull/892
- https://github.com/Brightspace/d2l-image-banner-overlay/pull/112
- https://github.com/Brightspace/image-selector/pull/48

This can only be merged after the changes in the image-selector which expose public functions.