### PR TITLE
fix: Add IntersectionObserver to detect bottom of scroll instead of iron-scroll-threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout
       - uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: '14'
       - name: Install dependencies
         run: npm install
       - name: Lint (JavaScript)

--- a/src/d2l-all-courses.js
+++ b/src/d2l-all-courses.js
@@ -280,13 +280,13 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 		};
 	}
 
-	connectedCallback(){
+	connectedCallback() {
 		super.connectedCallback();
 		this._observer = new IntersectionObserver(this._onAllCoursesLowerThreshold.bind(this));
 		this._observer.observe(this.$['scrollThreshold']);
 	}
 
-	disconnectedCallback(){
+	disconnectedCallback() {
 		this._observer.unobserve(this.$['scrollThreshold']);
 		super.disconnectedCallback();
 	}
@@ -335,14 +335,14 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 	*/
 
 	_onAllCoursesLowerThreshold(entries) {
-		for (var i = 0; i < entries.length; i++) {
+		for (let i = 0; i < entries.length; i++) {
 			// Chrome/FF immediately call the callback when we observer.observe()
 			// so we need to also make sure the image is visible for that first run
 			// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
 			if (entries[i].intersectionRatio > 0) {
 				if (this.$['all-courses'].opened && this._lastEnrollmentCollectionResponse) {
 					const nextHref = this._lastEnrollmentCollectionResponse.getNextEnrollmentHref();
-		
+
 					if (nextHref) {
 						this.$.lazyLoadSpinner.scrollIntoView();
 						entityFactory(EnrollmentCollectionEntity, nextHref, this.token, entity => {
@@ -356,7 +356,6 @@ class AllCourses extends MyCoursesLocalizeBehavior(PolymerElement) {
 			}
 		}
 	}
-
 
 	_onOrgUnitTypeIdsChange(newValue) {
 		if (this._actionParams) {

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -209,7 +209,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 			// so we need to also make sure the image is visible for that first run
 			// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819
 			if (entries[i].intersectionRatio > 0) {
-				this.shadowRoot.querySelector('d2l-basic-image-selector').loadMore(this.$['image-selector-threshold']);
+				this.shadowRoot.querySelector('d2l-basic-image-selector').loadMore();
 				break;
 			}
 		}

--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -163,7 +163,6 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 
 		document.body.addEventListener('d2l-course-pinned-change', this._onCourseEnrollmentChange);
 
-
 		let ouTypeIds = []; // default value
 		try {
 			ouTypeIds = JSON.parse(this.orgUnitTypeIds).value;
@@ -205,7 +204,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 	* Changing Course Image Functions
 	*/
 	_onChangeImageLowerThreshold(entries) {
-		for (var i = 0; i < entries.length; i++) {
+		for (let i = 0; i < entries.length; i++) {
 			// Chrome/FF immediately call the callback when we observer.observe()
 			// so we need to also make sure the image is visible for that first run
 			// see https://bugs.chromium.org/p/chromium/issues/detail?id=713819

--- a/test/d2l-my-courses-container/d2l-my-courses-container.js
+++ b/test/d2l-my-courses-container/d2l-my-courses-container.js
@@ -606,25 +606,6 @@ describe('d2l-my-courses', () => {
 
 		});
 
-		describe('clear-image-scroll-threshold', () => {
-
-			it('should clear triggers on the image-selector-threshold', (done) => {
-				flush(() => {
-					const threshold = component.shadowRoot.querySelector('#image-selector-threshold');
-					const spy = sandbox.spy(threshold, 'clearTriggers');
-
-					const event = new CustomEvent('clear-image-scroll-threshold');
-					component.dispatchEvent(event);
-					setTimeout(() => {
-						expect(spy).to.have.been.calledOnce;
-						done();
-					}, 0);
-				});
-
-			});
-
-		});
-
 		describe('set-course-image', () => {
 
 			it('should close the image-selector overlay', done => {


### PR DESCRIPTION
The change from simple-overlay to d2l-dialog-fullscreen means that iron-scroll-threshold does not work, as the on-lower-threshold event does not get fired. We can replace it with an IntersectionObserver that detects when we scroll to the bottom of the course images, using a fake "scrollThreshold" div.