### PR TITLE
fix: DE44358: add height to scroll threshold to get it to show on screen

### DIFF
--- a/src/d2l-my-courses-container.js
+++ b/src/d2l-my-courses-container.js
@@ -144,7 +144,7 @@ class MyCoursesContainer extends MyCoursesLocalizeBehavior(PolymerElement) {
 					organization="[[_setImageOrg]]"
 					course-image-upload-cb="[[courseImageUploadCb]]">
 				</d2l-basic-image-selector>
-				<div id="scrollThreshold"></div>
+				<div id="scrollThreshold" style="height: 1px"></div>
 			</d2l-dialog-fullscreen>`;
 	}
 


### PR DESCRIPTION
https://github.com/BrightspaceUI/core/pull/1480 will change some CSS that will cause the scroll threshold to no longer get picked up by IntersectionObserver. I could solve the issue by making the height 1 pixel, allowing the images to reload. 

NOTE: The reloading works fine in the "show all courses" tab, it's just the change image dialog that needs to be fixed. I'm not sure why the one is working if they both use the IntersectionObserver, it might be something about the layouts.